### PR TITLE
add source links to docs

### DIFF
--- a/vclib-aries/build.gradle.kts
+++ b/vclib-aries/build.gradle.kts
@@ -21,6 +21,18 @@ val dokkaOutputDir = "$buildDir/dokka"
 tasks.dokkaHtmlPartial{
     dependsOn(":vclib:transformIosMainCInteropDependenciesMetadataForIde")
     dependsOn(":vclib-openid:transformIosMainCInteropDependenciesMetadataForIde")
+    dokkaSourceSets {
+        configureEach {
+            sourceLink {
+                localDirectory.set(file("src/$name/kotlin"))
+                remoteUrl.set(
+                    uri("https://github.com/a-sit-plus/kmm-vc-library/tree/main/vclib/src/$name/kotlin").toURL()
+                )
+                // Suffix which is used to append the line number to the URL. Use #L for GitHub
+                remoteLineSuffix.set("#L")
+            }
+        }
+    }
 }
 tasks.dokkaHtml {
     dependsOn(":vclib:transformIosMainCInteropDependenciesMetadataForIde") //task dependency bug workaround

--- a/vclib-aries/build.gradle.kts
+++ b/vclib-aries/build.gradle.kts
@@ -26,7 +26,7 @@ tasks.dokkaHtmlPartial{
             sourceLink {
                 localDirectory.set(file("src/$name/kotlin"))
                 remoteUrl.set(
-                    uri("https://github.com/a-sit-plus/kmm-vc-library/tree/main/vclib/src/$name/kotlin").toURL()
+                    uri("https://github.com/a-sit-plus/kmm-vc-library/tree/main/${project.name}/src/$name/kotlin").toURL()
                 )
                 // Suffix which is used to append the line number to the URL. Use #L for GitHub
                 remoteLineSuffix.set("#L")

--- a/vclib-openid/build.gradle.kts
+++ b/vclib-openid/build.gradle.kts
@@ -21,6 +21,18 @@ val dokkaOutputDir = "$buildDir/dokka"
 tasks.dokkaHtmlPartial{
     dependsOn(":vclib-aries:transformIosMainCInteropDependenciesMetadataForIde")
     dependsOn(":vclib:transformIosMainCInteropDependenciesMetadataForIde")
+    dokkaSourceSets {
+        configureEach {
+            sourceLink {
+                localDirectory.set(file("src/$name/kotlin"))
+                remoteUrl.set(
+                    uri("https://github.com/a-sit-plus/kmm-vc-library/tree/main/vclib/src/$name/kotlin").toURL()
+                )
+                // Suffix which is used to append the line number to the URL. Use #L for GitHub
+                remoteLineSuffix.set("#L")
+            }
+        }
+    }
 }
 
 tasks.dokkaHtml {

--- a/vclib-openid/build.gradle.kts
+++ b/vclib-openid/build.gradle.kts
@@ -26,7 +26,7 @@ tasks.dokkaHtmlPartial{
             sourceLink {
                 localDirectory.set(file("src/$name/kotlin"))
                 remoteUrl.set(
-                    uri("https://github.com/a-sit-plus/kmm-vc-library/tree/main/vclib/src/$name/kotlin").toURL()
+                    uri("https://github.com/a-sit-plus/kmm-vc-library/tree/main/${project.name}/src/$name/kotlin").toURL()
                 )
                 // Suffix which is used to append the line number to the URL. Use #L for GitHub
                 remoteLineSuffix.set("#L")

--- a/vclib/build.gradle.kts
+++ b/vclib/build.gradle.kts
@@ -24,7 +24,7 @@ tasks.dokkaHtmlPartial {
             sourceLink {
                 localDirectory.set(file("src/$name/kotlin"))
                 remoteUrl.set(
-                    uri("https://github.com/a-sit-plus/kmm-vc-library/tree/main/vclib/src/$name/kotlin").toURL()
+                    uri("https://github.com/a-sit-plus/kmm-vc-library/tree/main/${project.name}/src/$name/kotlin").toURL()
                 )
                 // Suffix which is used to append the line number to the URL. Use #L for GitHub
                 remoteLineSuffix.set("#L")

--- a/vclib/build.gradle.kts
+++ b/vclib/build.gradle.kts
@@ -16,14 +16,28 @@ version = artifactVersion
 
 val dokkaOutputDir = "$buildDir/dokka"
 
-tasks.dokkaHtmlPartial{
+tasks.dokkaHtmlPartial {
+
     dependsOn(":vclib:transformIosMainCInteropDependenciesMetadataForIde")
+    dokkaSourceSets {
+        configureEach {
+            sourceLink {
+                localDirectory.set(file("src/$name/kotlin"))
+                remoteUrl.set(
+                    uri("https://github.com/a-sit-plus/kmm-vc-library/tree/main/vclib/src/$name/kotlin").toURL()
+                )
+                // Suffix which is used to append the line number to the URL. Use #L for GitHub
+                remoteLineSuffix.set("#L")
+            }
+        }
+    }
 }
 
 tasks.dokkaHtml {
     dependsOn("transformIosMainCInteropDependenciesMetadataForIde") //wor around bug
     outputDirectory.set(file(dokkaOutputDir))
 }
+
 val deleteDokkaOutputDir by tasks.register<Delete>("deleteDokkaOutputDirectory") {
     delete(dokkaOutputDir)
 }


### PR DESCRIPTION
please verify locally that it works by invoking `./gradlew clean dokkaHtmlMultiModule` and then navigating around a bit:

Html Doc:
![image](https://github.com/a-sit-plus/kmm-vc-library/assets/5648377/f366938e-d965-48cc-a05e-53354242dc34)

Result after clicking on "(source)":
![image](https://github.com/a-sit-plus/kmm-vc-library/assets/5648377/84adce5a-17e2-4100-a637-da791a52d600)
