### PR TITLE
Make CredentialSubject abstract

### DIFF
--- a/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/TestCredentialScheme.kt
+++ b/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/TestCredentialScheme.kt
@@ -22,23 +22,15 @@ object TestCredentialScheme : ConstantIndex.CredentialScheme {
 
 @Serializable
 @SerialName("TestCredential")
-class TestCredential : CredentialSubject {
+data class TestCredential (
+    override val id: String,
+
     @SerialName("name")
-    val name: String
+    val name: String,
 
     @SerialName("value")
     val value: String
-
-    constructor(id: String, name: String, value: String) : super(id = id) {
-        this.name = name
-        this.value = value
-    }
-
-    override fun toString(): String {
-        return "TestCredential(id='$id', name='$name', value='$value')"
-    }
-
-}
+) : CredentialSubject()
 
 class TestCredentialDataProvider(
     private val clock: Clock = Clock.System,

--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/AtomicAttribute2023.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/AtomicAttribute2023.kt
@@ -9,26 +9,19 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 @SerialName("AtomicAttribute2023")
-class AtomicAttribute2023 : CredentialSubject {
+data class AtomicAttribute2023 (
+    override val id: String,
+
     @SerialName("name")
-    val name: String
+    val name: String,
 
     @SerialName("value")
-    val value: String
+    val value: String,
 
     @SerialName("mime-type")
-    val mimeType: String
-
-    constructor(id: String, name: String, value: String, mimeType: String) : super(id = id) {
-        this.name = name
-        this.value = value
-        this.mimeType = mimeType
-    }
+    val mimeType: String,
+) : CredentialSubject() {
 
     constructor(id: String, name: String, value: String) : this(id, name, value, "application/text")
-
-    override fun toString(): String {
-        return "AtomicAttribute2023(id='$id', name='$name', value='$value', mimeType='$mimeType')"
-    }
 
 }

--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialSubject.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialSubject.kt
@@ -7,10 +7,10 @@ import kotlinx.serialization.Serializable
  * Base class for the subject of a [VerifiableCredential], see subclasses of this class, e.g. [AtomicAttribute2023].
  */
 @Serializable
-open class CredentialSubject(
+abstract class CredentialSubject {
     /**
      * This is the subjectId of the credential
      */
     @SerialName("id")
-    val id: String,
-)
+    abstract val id: String
+}

--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/RevocationListSubject.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/RevocationListSubject.kt
@@ -9,17 +9,9 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 @SerialName(VcDataModelConstants.REVOCATION_LIST_2020)
-class RevocationListSubject : CredentialSubject {
+data class RevocationListSubject (
+    override val id: String,
 
     @SerialName("encodedList")
-    val encodedList: String
-
-    constructor(id: String, encodedList: String) : super(id = id) {
-        this.encodedList = encodedList
-    }
-
-    override fun toString(): String {
-        return "RevocationListSubject(id='$id', encodedList='$encodedList')"
-    }
-
-}
+    val encodedList: String,
+) : CredentialSubject()

--- a/vclib/src/commonTest/kotlin/at/asitplus/wallet/lib/data/CredentialSubjectTest.kt
+++ b/vclib/src/commonTest/kotlin/at/asitplus/wallet/lib/data/CredentialSubjectTest.kt
@@ -14,8 +14,5 @@ class CredentialSubjectTest : FreeSpec({
         val result = Json.decodeFromString<SpecializedCredentialTest>("{\"id\":\"Test\",\"not-foo\":\"bar\"}")
         result.id shouldBe "Test"
         result.foo shouldBe "bar"
-
-        val superResult = Json.decodeFromString<CredentialSubject>(Json.encodeToString(result))
-        superResult.id shouldBe "Test"
     }
 })

--- a/vclib/src/commonTest/kotlin/at/asitplus/wallet/lib/data/CredentialSubjectTest.kt
+++ b/vclib/src/commonTest/kotlin/at/asitplus/wallet/lib/data/CredentialSubjectTest.kt
@@ -1,0 +1,21 @@
+package at.asitplus.wallet.lib.data
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class CredentialSubjectTest : FreeSpec({
+    "Subclasses are correctly deserialized" {
+        @Serializable
+        class SpecializedCredentialTest(override val id: String, @SerialName("not-foo") val foo: String): CredentialSubject()
+        val result = Json.decodeFromString<SpecializedCredentialTest>("{\"id\":\"Test\",\"not-foo\":\"bar\"}")
+        result.id shouldBe "Test"
+        result.foo shouldBe "bar"
+
+        val superResult = Json.decodeFromString<CredentialSubject>(Json.encodeToString(result))
+        superResult.id shouldBe "Test"
+    }
+})


### PR DESCRIPTION
This greatly reduces implementors' constructor boilerplate by allowing them to have a main constructor only.