### PR TITLE
Moved credentialRepresentation from parameter to function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 Release 3.4.0:
- - Remove `OidcSiopVerifier.credentialRepresentation` parameter, now function parameter
  - Target Java 17
  - Updated dependencies from conventions: Bouncycastle 1.77, Serialization 1.6.3-snapshot (fork), Napier 2.7.1
  - Integrate `kmp-crypto` library
@@ -16,7 +15,8 @@ Release 3.4.0:
  - Support `ES384`, `ES512`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384` and `PS512` signatures in `DefaultCryptoService`
  - Change `DefaultCryptoService` constructor signature: When handing over a private/public key pair, the `CryptoAlgorithm` parameter is now mandatory
  - Change return type of methods in `JwsService` to `KmmResult<T>` to transport exceptions from native implementations
- - Support static QR code use case for OIDC SIOPv2 flows
+ - Support static QR code use case for OIDC SIOPv2 flows in `OidcSiopVerifier`
+ - Move constructor parameters `credentialRepresentation`, `requestedAttributes` from `OidcSiopVerifier` into function calls
 
 Release 3.3.0:
  - Change non-typed attribute types (i.e. Strings) to typed credential schemes (i.e. `ConstantIndex.CredentialScheme`), this includes methods `getCredentials`, `createPresentation` in interface `Holder`, and method `getCredentials` in interface `SubjectCredentialStore`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 Release 3.4.0:
+ - Remove `OidcSiopVerifier.credentialRepresentation` parameter, now function parameter
  - Target Java 17
  - Updated dependencies from conventions: Bouncycastle 1.77, Serialization 1.6.3-snapshot (fork), Napier 2.7.1
  - Integrate `kmp-crypto` library

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopVerifier.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopVerifier.kt
@@ -81,16 +81,6 @@ class OidcSiopVerifier(
     private val containerJwt =
         FormatContainerJwt(algorithms = verifierJwsService.supportedAlgorithms.map { it.identifier }.toTypedArray())
 
-    //    private val vpFormats =
-//    val metadata by lazy {
-//        RelyingPartyMetadata(
-//            redirectUris = arrayOf(relyingPartyUrl),
-//            jsonWebKeySet = JsonWebKeySet(arrayOf(agentPublicKey.toJsonWebKey())),
-//            subjectSyntaxTypesSupported = arrayOf(URN_TYPE_JWK_THUMBPRINT, PREFIX_DID_KEY),
-//            vpFormats = vpFormats,
-//        )
-//    }
-
     private fun getVpFormats(credentialRepresentation: ConstantIndex.CredentialRepresentation) =
         FormatHolder(
             msoMdoc = if (credentialRepresentation == ConstantIndex.CredentialRepresentation.ISO_MDOC) containerJwt else null,

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopVerifier.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopVerifier.kt
@@ -140,18 +140,18 @@ class OidcSiopVerifier(
      * Creates an OIDC Authentication Request, encoded as query parameters to the [walletUrl].
      *
      * @param responseMode which response mode to request, see [OpenIdConstants.ResponseModes]
-     * @param credentialRepresentation specifies the required representation, see [ConstantIndex.CredentialRepresentation]
+     * @param representation specifies the required representation, see [ConstantIndex.CredentialRepresentation]
      */
     suspend fun createAuthnRequestUrl(
         walletUrl: String,
         responseMode: String? = null,
-        credentialRepresentation: ConstantIndex.CredentialRepresentation,
+        representation: ConstantIndex.CredentialRepresentation = ConstantIndex.CredentialRepresentation.PLAIN_JWT,
         state: String? = uuid4().toString(),
     ): String {
         val urlBuilder = URLBuilder(walletUrl)
         createAuthnRequest(
             responseMode = responseMode,
-            representation = credentialRepresentation,
+            representation = representation,
             state = state,
         ).encodeToParameters()
             .forEach { urlBuilder.parameters.append(it.key, it.value) }

--- a/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopIsoProtocolTest.kt
+++ b/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopIsoProtocolTest.kt
@@ -1,6 +1,12 @@
 package at.asitplus.wallet.lib.oidc
 
-import at.asitplus.wallet.lib.agent.*
+import at.asitplus.wallet.lib.agent.CryptoService
+import at.asitplus.wallet.lib.agent.DefaultCryptoService
+import at.asitplus.wallet.lib.agent.Holder
+import at.asitplus.wallet.lib.agent.HolderAgent
+import at.asitplus.wallet.lib.agent.IssuerAgent
+import at.asitplus.wallet.lib.agent.Verifier
+import at.asitplus.wallet.lib.agent.VerifierAgent
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.IsoDocumentParsed
 import at.asitplus.wallet.lib.iso.MobileDrivingLicenceDataElements

--- a/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopIsoProtocolTest.kt
+++ b/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopIsoProtocolTest.kt
@@ -100,9 +100,14 @@ class OidcSiopIsoProtocolTest : FreeSpec({
             cryptoService = verifierCryptoService,
             relyingPartyUrl = relyingPartyUrl,
             credentialScheme = ConstantIndex.MobileDrivingLicence2023,
-            requestedAttributes = listOf(requestedClaim),
         )
-        val document = runProcess(verifierSiop, walletUrl, ConstantIndex.CredentialRepresentation.ISO_MDOC, holderSiop)
+        val document = runProcess(
+            verifierSiop,
+            walletUrl,
+            ConstantIndex.CredentialRepresentation.ISO_MDOC,
+            holderSiop,
+            listOf(requestedClaim)
+        )
 
         document.validItems.shouldNotBeEmpty()
         document.validItems.shouldBeSingleton()
@@ -117,10 +122,13 @@ private suspend fun runProcess(
     walletUrl: String,
     credentialRepresentation: ConstantIndex.CredentialRepresentation,
     holderSiop: OidcSiopWallet,
+    requestedAttributes: List<String>? = null,
 ): IsoDocumentParsed {
-    val authnRequest =
-        verifierSiop.createAuthnRequestUrl(walletUrl = walletUrl, representation = credentialRepresentation)
-            .also { println(it) }
+    val authnRequest = verifierSiop.createAuthnRequestUrl(
+        walletUrl = walletUrl,
+        representation = credentialRepresentation,
+        requestedAttributes = requestedAttributes
+    ).also { println(it) }
 
     val authnResponse = holderSiop.createAuthnResponse(authnRequest).getOrThrow()
     authnResponse.shouldBeInstanceOf<OidcSiopWallet.AuthenticationResponseResult.Redirect>().also { println(it) }

--- a/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopIsoProtocolTest.kt
+++ b/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopIsoProtocolTest.kt
@@ -5,8 +5,6 @@ import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.IsoDocumentParsed
 import at.asitplus.wallet.lib.iso.MobileDrivingLicenceDataElements
 import com.benasher44.uuid.uuid4
-import io.github.aakira.napier.DebugAntilog
-import io.github.aakira.napier.Napier
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldBeSingleton
@@ -69,9 +67,8 @@ class OidcSiopIsoProtocolTest : FreeSpec({
             cryptoService = verifierCryptoService,
             relyingPartyUrl = relyingPartyUrl,
             credentialScheme = ConstantIndex.MobileDrivingLicence2023,
-            credentialRepresentation = ConstantIndex.CredentialRepresentation.ISO_MDOC,
         )
-        val document = runProcess(verifierSiop, walletUrl, holderSiop)
+        val document = runProcess(verifierSiop, walletUrl, ConstantIndex.CredentialRepresentation.ISO_MDOC, holderSiop)
 
         document.validItems.shouldNotBeEmpty()
         document.invalidItems.shouldBeEmpty()
@@ -83,9 +80,8 @@ class OidcSiopIsoProtocolTest : FreeSpec({
             cryptoService = verifierCryptoService,
             relyingPartyUrl = relyingPartyUrl,
             credentialScheme = ConstantIndex.AtomicAttribute2023,
-            credentialRepresentation = ConstantIndex.CredentialRepresentation.ISO_MDOC,
         )
-        val document = runProcess(verifierSiop, walletUrl, holderSiop)
+        val document = runProcess(verifierSiop, walletUrl, ConstantIndex.CredentialRepresentation.ISO_MDOC, holderSiop)
 
         document.validItems.shouldNotBeEmpty()
         document.invalidItems.shouldBeEmpty()
@@ -98,10 +94,9 @@ class OidcSiopIsoProtocolTest : FreeSpec({
             cryptoService = verifierCryptoService,
             relyingPartyUrl = relyingPartyUrl,
             credentialScheme = ConstantIndex.MobileDrivingLicence2023,
-            credentialRepresentation = ConstantIndex.CredentialRepresentation.ISO_MDOC,
             requestedAttributes = listOf(requestedClaim),
         )
-        val document = runProcess(verifierSiop, walletUrl, holderSiop)
+        val document = runProcess(verifierSiop, walletUrl, ConstantIndex.CredentialRepresentation.ISO_MDOC, holderSiop)
 
         document.validItems.shouldNotBeEmpty()
         document.validItems.shouldBeSingleton()
@@ -114,9 +109,12 @@ class OidcSiopIsoProtocolTest : FreeSpec({
 private suspend fun runProcess(
     verifierSiop: OidcSiopVerifier,
     walletUrl: String,
-    holderSiop: OidcSiopWallet
+    credentialRepresentation: ConstantIndex.CredentialRepresentation,
+    holderSiop: OidcSiopWallet,
 ): IsoDocumentParsed {
-    val authnRequest = verifierSiop.createAuthnRequestUrl(walletUrl).also { println(it) }
+    val authnRequest =
+        verifierSiop.createAuthnRequestUrl(walletUrl = walletUrl, credentialRepresentation = credentialRepresentation)
+            .also { println(it) }
 
     val authnResponse = holderSiop.createAuthnResponse(authnRequest).getOrThrow()
     authnResponse.shouldBeInstanceOf<OidcSiopWallet.AuthenticationResponseResult.Redirect>().also { println(it) }

--- a/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopIsoProtocolTest.kt
+++ b/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopIsoProtocolTest.kt
@@ -119,7 +119,7 @@ private suspend fun runProcess(
     holderSiop: OidcSiopWallet,
 ): IsoDocumentParsed {
     val authnRequest =
-        verifierSiop.createAuthnRequestUrl(walletUrl = walletUrl, credentialRepresentation = credentialRepresentation)
+        verifierSiop.createAuthnRequestUrl(walletUrl = walletUrl, representation = credentialRepresentation)
             .also { println(it) }
 
     val authnResponse = holderSiop.createAuthnResponse(authnRequest).getOrThrow()

--- a/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopProtocolTest.kt
+++ b/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopProtocolTest.kt
@@ -1,7 +1,13 @@
 package at.asitplus.wallet.lib.oidc
 
 import at.asitplus.crypto.datatypes.jws.JwsSigned
-import at.asitplus.wallet.lib.agent.*
+import at.asitplus.wallet.lib.agent.CryptoService
+import at.asitplus.wallet.lib.agent.DefaultCryptoService
+import at.asitplus.wallet.lib.agent.Holder
+import at.asitplus.wallet.lib.agent.HolderAgent
+import at.asitplus.wallet.lib.agent.IssuerAgent
+import at.asitplus.wallet.lib.agent.Verifier
+import at.asitplus.wallet.lib.agent.VerifierAgent
 import at.asitplus.wallet.lib.data.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.jws.DefaultVerifierJwsService
@@ -103,11 +109,11 @@ class OidcSiopProtocolTest : FreeSpec({
         qrcode shouldContain metadataUrlNonce
         qrcode shouldContain requestUrlNonce
 
-        val metadataObject = verifierSiop.createSignedMetadata(ConstantIndex.CredentialRepresentation.PLAIN_JWT).getOrThrow()
+        val metadataObject = verifierSiop.createSignedMetadata().getOrThrow()
             .also { println(it) }
         DefaultVerifierJwsService().verifyJwsObject(metadataObject).shouldBeTrue()
 
-        val authnRequest = verifierSiop.createAuthnRequestAsRequestObject(credentialRepresentation = ConstantIndex.CredentialRepresentation.PLAIN_JWT).getOrThrow()
+        val authnRequest = verifierSiop.createAuthnRequestAsRequestObject().getOrThrow()
         authnRequest.clientId shouldBe relyingPartyUrl
         val jar = authnRequest.request
         jar.shouldNotBeNull()
@@ -159,8 +165,7 @@ class OidcSiopProtocolTest : FreeSpec({
     }
 
     "test with deserializing" {
-        val authnRequest =
-            verifierSiop.createAuthnRequest(credentialRepresentation = ConstantIndex.CredentialRepresentation.PLAIN_JWT)
+        val authnRequest = verifierSiop.createAuthnRequest()
         val authnRequestUrlParams = authnRequest.encodeToParameters().formUrlEncode().also { println(it) }
 
         val parsedAuthnRequest: AuthenticationRequestParameters = authnRequestUrlParams.decodeFromUrlQuery()

--- a/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopSdJwtProtocolTest.kt
+++ b/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopSdJwtProtocolTest.kt
@@ -52,12 +52,14 @@ class OidcSiopSdJwtProtocolTest : FreeSpec({
             verifier = verifierAgent,
             cryptoService = verifierCryptoService,
             relyingPartyUrl = relyingPartyUrl,
-            credentialRepresentation = ConstantIndex.CredentialRepresentation.SD_JWT,
         )
     }
 
     "test with Fragment" {
-        val authnRequest = verifierSiop.createAuthnRequestUrl(walletUrl).also { println(it) }
+        val authnRequest = verifierSiop.createAuthnRequestUrl(
+            walletUrl = walletUrl,
+            credentialRepresentation = ConstantIndex.CredentialRepresentation.SD_JWT
+        ).also { println(it) }
 
         val authnResponse = holderSiop.createAuthnResponse(authnRequest).getOrThrow()
         authnResponse.shouldBeInstanceOf<OidcSiopWallet.AuthenticationResponseResult.Redirect>().also { println(it) }
@@ -67,7 +69,12 @@ class OidcSiopSdJwtProtocolTest : FreeSpec({
         result.disclosures.shouldNotBeEmpty()
 
         verifierSiop.validateAuthnResponse(
-            (holderSiop.createAuthnResponse(verifierSiop.createAuthnRequestUrl(walletUrl))
+            (holderSiop.createAuthnResponse(
+                verifierSiop.createAuthnRequestUrl(
+                    walletUrl = walletUrl,
+                    credentialRepresentation = ConstantIndex.CredentialRepresentation.SD_JWT
+                )
+            )
                 .getOrThrow() as OidcSiopWallet.AuthenticationResponseResult.Redirect).url
         ).shouldBeInstanceOf<OidcSiopVerifier.AuthnResponseResult.SuccessSdJwt>()
     }
@@ -79,10 +86,12 @@ class OidcSiopSdJwtProtocolTest : FreeSpec({
             cryptoService = verifierCryptoService,
             relyingPartyUrl = relyingPartyUrl,
             credentialScheme = ConstantIndex.AtomicAttribute2023,
-            credentialRepresentation = ConstantIndex.CredentialRepresentation.SD_JWT,
             requestedAttributes = listOf(requestedClaim),
         )
-        val authnRequest = verifierSiop.createAuthnRequestUrl(walletUrl).also { println(it) }
+        val authnRequest = verifierSiop.createAuthnRequestUrl(
+            walletUrl = walletUrl,
+            credentialRepresentation = ConstantIndex.CredentialRepresentation.SD_JWT
+        ).also { println(it) }
 
         val authnResponse = holderSiop.createAuthnResponse(authnRequest).getOrThrow()
         authnResponse.shouldBeInstanceOf<OidcSiopWallet.AuthenticationResponseResult.Redirect>().also { println(it) }

--- a/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopSdJwtProtocolTest.kt
+++ b/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopSdJwtProtocolTest.kt
@@ -58,7 +58,7 @@ class OidcSiopSdJwtProtocolTest : FreeSpec({
     "test with Fragment" {
         val authnRequest = verifierSiop.createAuthnRequestUrl(
             walletUrl = walletUrl,
-            credentialRepresentation = ConstantIndex.CredentialRepresentation.SD_JWT
+            representation = ConstantIndex.CredentialRepresentation.SD_JWT
         ).also { println(it) }
 
         val authnResponse = holderSiop.createAuthnResponse(authnRequest).getOrThrow()
@@ -72,7 +72,7 @@ class OidcSiopSdJwtProtocolTest : FreeSpec({
             (holderSiop.createAuthnResponse(
                 verifierSiop.createAuthnRequestUrl(
                     walletUrl = walletUrl,
-                    credentialRepresentation = ConstantIndex.CredentialRepresentation.SD_JWT
+                    representation = ConstantIndex.CredentialRepresentation.SD_JWT
                 )
             )
                 .getOrThrow() as OidcSiopWallet.AuthenticationResponseResult.Redirect).url
@@ -90,7 +90,7 @@ class OidcSiopSdJwtProtocolTest : FreeSpec({
         )
         val authnRequest = verifierSiop.createAuthnRequestUrl(
             walletUrl = walletUrl,
-            credentialRepresentation = ConstantIndex.CredentialRepresentation.SD_JWT
+            representation = ConstantIndex.CredentialRepresentation.SD_JWT
         ).also { println(it) }
 
         val authnResponse = holderSiop.createAuthnResponse(authnRequest).getOrThrow()


### PR DESCRIPTION
In order to not having to instantitate an `OidcSiopVerifier` for every `credentialRepresentation` we can move it from a class parameter to a function parameter