### PR TITLE
Fix: actually return the extracted request object

### DIFF
--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopWallet.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopWallet.kt
@@ -124,7 +124,7 @@ class OidcSiopWallet(
 
     private fun extractRequestObject(params: AuthenticationRequestParameters): AuthenticationRequestParameters? {
         params.request?.let { requestObject ->
-            parseRequestObjectJws(requestObject)
+            return parseRequestObjectJws(requestObject)
         }
         return null
     }


### PR DESCRIPTION
There is currently a bug where the siop presentation fails in case the url contains a request object. This is, because the request object is not actually used.

An example of this is the following request url, but I'm unsure how to write a test for that: 
https://wallet.a-sit.at/mobile?client_id=https%3A%2F%2Fapps.egiz.gv.at%2Fterminal_sp%2Fsiopv2%2Fpostsuccess&request=eyJraWQiOiJkaWQ6a2V5Om1FcEJyQ21MMjRTT3VHenBZSWRraHNrLzlhZlZtU0w0cTQ2RFBqS0hVcUVBL0tSU3VubEZFK3owcUdXNGdqNXYzOWRLc1pQNndaUEZpYVppVzZsV3YwOGxwIiwiYWxnIjoiRVMyNTYiLCJqd2siOnsiY3J2IjoiUC0yNTYiLCJrdHkiOiJFQyIsImtpZCI6ImRpZDprZXk6bUVwQnJDbUwyNFNPdUd6cFlJZGtoc2svOWFmVm1TTDRxNDZEUGpLSFVxRUEvS1JTdW5sRkUrejBxR1c0Z2o1djM5ZEtzWlA2d1pQRmlhWmlXNmxXdjA4bHAiLCJ4IjoiYXdwaTl1RWpyaHM2V0NIWkliSlBfV24xWmtpLUt1T2d6NHloMUtoQVB5ayIsInkiOiJGSzZlVVVUN1BTb1piaUNQbV9mMTBxeGtfckJrOFdKcG1KYnFWYV9UeVdrIn19.eyJyZXNwb25zZV90eXBlIjoiaWRfdG9rZW4gdnBfdG9rZW4iLCJjbGllbnRfaWQiOiJodHRwczovL2FwcHMuZWdpei5ndi5hdC90ZXJtaW5hbF9zcC9zaW9wdjIvcG9zdHN1Y2Nlc3MiLCJyZWRpcmVjdF91cmkiOiJodHRwczovL2FwcHMuZWdpei5ndi5hdC90ZXJtaW5hbF9zcC9zaW9wdjIvcG9zdHN1Y2Nlc3MiLCJzY29wZSI6Im9wZW5pZCBwcm9maWxlIElkQXVzdHJpYTIwMjMiLCJzdGF0ZSI6IkVHdWVWYVp1UklwT201UjhvUUV5OFFDeXpsMFYwUHh2RnVqSHpjTm13a289Iiwibm9uY2UiOiI0NmE2ODc2MS0wMGJmLTRhZTUtOWU0Mi01YTRhZjQ2MzAzMWMiLCJjbGllbnRfbWV0YWRhdGEiOnsicmVkaXJlY3RfdXJpcyI6WyJodHRwczovL2FwcHMuZWdpei5ndi5hdC90ZXJtaW5hbF9zcC9zaW9wdjIvcG9zdHN1Y2Nlc3MiXSwiandrcyI6eyJrZXlzIjpbeyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwia2lkIjoiZGlkOmtleTptRXBCckNtTDI0U091R3pwWUlka2hzay85YWZWbVNMNHE0NkRQaktIVXFFQS9LUlN1bmxGRSt6MHFHVzRnajV2MzlkS3NaUDZ3WlBGaWFaaVc2bFd2MDhscCIsIngiOiJhd3BpOXVFanJoczZXQ0haSWJKUF9XbjFaa2ktS3VPZ3o0eWgxS2hBUHlrIiwieSI6IkZLNmVVVVQ3UFNvWmJpQ1BtX2YxMHF4a19yQms4V0pwbUpicVZhX1R5V2sifV19LCJzdWJqZWN0X3N5bnRheF90eXBlc19zdXBwb3J0ZWQiOlsidXJuOmlldGY6cGFyYW1zOm9hdXRoOmp3ay10aHVtYnByaW50IiwiZGlkOmtleSJdLCJ2cF9mb3JtYXRzIjp7Imp3dF92cCI6eyJhbGciOlsiRVMyNTYiLCJFUzM4NCIsIkVTNTEyIl19LCJqd3Rfc2QiOnsiYWxnIjpbIkVTMjU2IiwiRVMzODQiLCJFUzUxMiJdfSwibXNvX21kb2MiOnsiYWxnIjpbIkVTMjU2IiwiRVMzODQiLCJFUzUxMiJdfX19LCJpZF90b2tlbl90eXBlIjoic3ViamVjdF9zaWduZWRfaWRfdG9rZW4iLCJwcmVzZW50YXRpb25fZGVmaW5pdGlvbiI6eyJpZCI6IjUyYmQzZWI0LThmOWUtNDU4YS05NjZlLTRhYjZhZjY3MWJlNSIsImlucHV0X2Rlc2NyaXB0b3JzIjpbeyJpZCI6IjQyNzA2MjlmLTM4OTQtNDQ3Yy05YjI2LTUwZjhlOGZiYTEzYyIsInNjaGVtYSI6W3sidXJpIjoiaHR0cHM6Ly93YWxsZXQuYS1zaXQuYXQvc2NoZW1hcy8xLjAuMC9pZGF1c3RyaWEuanNvbiJ9XSwiY29uc3RyYWludHMiOnsiZmllbGRzIjpbeyJwYXRoIjpbIiQudHlwZSJdLCJmaWx0ZXIiOnsidHlwZSI6InN0cmluZyIsInBhdHRlcm4iOiJJZEF1c3RyaWEyMDIzIn19LHsicGF0aCI6WyIkLnBvcnRyYWl0Il19LHsicGF0aCI6WyIkLmZpcnN0bmFtZSJdfSx7InBhdGgiOlsiJC5sYXN0bmFtZSJdfV19fV0sImZvcm1hdCI6eyJqd3Rfc2QiOnsiYWxnIjpbIkVTMjU2IiwiRVMzODQiLCJFUzUxMiJdfX19LCJjbGllbnRfaWRfc2NoZW1lIjoicmVkaXJlY3RfdXJpIiwicmVzcG9uc2VfbW9kZSI6InBvc3QiLCJhdWQiOiJodHRwczovL2FwcHMuZWdpei5ndi5hdC90ZXJtaW5hbF9zcC9zaW9wdjIvcG9zdHN1Y2Nlc3MiLCJpc3MiOiJodHRwczovL2FwcHMuZWdpei5ndi5hdC90ZXJtaW5hbF9zcC9zaW9wdjIvcG9zdHN1Y2Nlc3MifQ.0N8Fn8SfA2cILNlbqW7cj89FoOPbAreOjOqLmeBqLgB2iiJnoAtjwjUSGtATy5OyNK9xM4ba5HUJGsL7LZS9pg