### PR TITLE
Add credential scheme resolution by iso doctype

### DIFF
--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/AttributeIndex.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/AttributeIndex.kt
@@ -35,4 +35,12 @@ object AttributeIndex {
         return schemeSet.firstOrNull { it.isoNamespace.startsWith(namespace) || namespace.startsWith(it.isoNamespace) }
     }
 
+    /**
+     * Matches the passed [docType] against all known docTypes from [ConstantIndex.CredentialScheme.isoDocType]
+     */
+    fun resolveIsoDoctype(docType: String): ConstantIndex.CredentialScheme? {
+        // allow for extension to the namespace by appending ".countryname" or anything else, according to spec
+        return schemeSet.firstOrNull { it.isoDocType.startsWith(docType) || docType.startsWith(it.isoDocType) }
+    }
+
 }


### PR DESCRIPTION
This will be handy for the Wallet because the doctype is encoded into the id of input descriptors