### PR TITLE
Add: Improved presentation flexibility in holder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 Release 4.0.0:
+ - Add `SubmissionRequirement.evaluate`: Evaluates, whether a given submission requirement is satisfied.
+ - Add `PresentationSubmissionValidator`: 
+   - Add `isValidSubmission`: Evaluates, whether all submission requirements is satisfied, and fails on redundantly submitted credentials.
+   - Add `findUnnecessaryInputDescriptorSubmissions`: Returns a list of redundantly submitted credentials.
+ - Rename `BaseInputEvaluator` -> `InputEvaluator`
+   - Change `evaluateFieldQueryResults` -> `evaluateConstraintFieldMatches`: Returns all matching fields now, not just the first match
+ - Change `Holder.matchInputDescriptorsAgainstCredentialStore`: Returns all matching credentials now, not just the first match
  - Do not use or assume DID as key identifiers and subjects in credentials
  - Replace list of attribute types in `Issuer.issueCredentials` with one concrete `CredentialScheme` to be passed
  - Remove functionality related to "attachments" to verifable credentials in JWT format

--- a/conventions-vclib/src/main/kotlin/VcLibVersions.kt
+++ b/conventions-vclib/src/main/kotlin/VcLibVersions.kt
@@ -3,7 +3,7 @@ object VcLibVersions {
     const val encoding = "1.2.3"
     const val okio = "3.5.0"
     const val kmpcrypto = "3.2.0"
-    const val jsonpath = "2.0.0"
+    const val jsonpath = "2.1.0"
     const val bignum = "0.3.9"
 
     object Jvm {

--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -11,13 +11,14 @@ import at.asitplus.wallet.lib.cbor.CoseService
 import at.asitplus.wallet.lib.cbor.DefaultCoseService
 import at.asitplus.wallet.lib.data.CredentialToJsonConverter
 import at.asitplus.wallet.lib.data.dif.ClaimFormatEnum
-import at.asitplus.wallet.lib.data.dif.FieldQueryResults
 import at.asitplus.wallet.lib.data.dif.FormatHolder
 import at.asitplus.wallet.lib.data.dif.InputDescriptor
 import at.asitplus.wallet.lib.data.dif.InputEvaluator
 import at.asitplus.wallet.lib.data.dif.PresentationDefinition
 import at.asitplus.wallet.lib.data.dif.PresentationSubmission
 import at.asitplus.wallet.lib.data.dif.PresentationSubmissionDescriptor
+import at.asitplus.wallet.lib.data.dif.PresentationSubmissionValidator
+import at.asitplus.wallet.lib.iso.IssuerSigned
 import at.asitplus.wallet.lib.jws.DefaultJwsService
 import at.asitplus.wallet.lib.jws.JwsService
 import com.benasher44.uuid.uuid4
@@ -40,7 +41,6 @@ class HolderAgent(
         identifier = keyPair.identifier,
     ),
     private val difInputEvaluator: InputEvaluator = InputEvaluator(),
-    override val defaultPathAuthorizationValidator: (SubjectCredentialStore.StoreEntry, NormalizedJsonPath) -> Boolean = { _, _ -> true }
 ) : Holder {
 
     constructor(
@@ -90,7 +90,7 @@ class HolderAgent(
                     sdJwt.sdJwt,
                     credential.vcSdJwt,
                     sdJwt.disclosures,
-                    credential.scheme
+                    credential.scheme,
                 ).toStoredCredential()
             }
 
@@ -150,61 +150,64 @@ class HolderAgent(
         }
     }
 
-    data class CandidateInputMatchContainer(
-        val credential: SubjectCredentialStore.StoreEntry,
-        val fieldQueryResults: FieldQueryResults,
-    )
 
     override suspend fun createPresentation(
         challenge: String,
         audienceId: String,
         presentationDefinition: PresentationDefinition,
         fallbackFormatHolder: FormatHolder?,
-        pathAuthorizationValidator: (SubjectCredentialStore.StoreEntry, NormalizedJsonPath) -> Boolean,
+        pathAuthorizationValidator: PathAuthorizationValidator?,
     ): KmmResult<Holder.PresentationResponseParameters> = runCatching {
-        val matches = matchInputDescriptorsAgainstCredentialStore(
-            presentationDefinition = presentationDefinition,
+        val submittedCredentials = matchInputDescriptorsAgainstCredentialStore(
+            inputDescriptors = presentationDefinition.inputDescriptors,
             fallbackFormatHolder = fallbackFormatHolder,
             pathAuthorizationValidator = pathAuthorizationValidator,
-        ).getOrThrow().mapNotNull { (key, value) ->
-            // TODO: support submission requirements, where not all input descriptors may have a match
-            //  -> no need to throw at this point
-            value?.let { key to it }
-                ?: throw MissingInputDescriptorMatchException(key)
+        ).getOrThrow().toDefaultSubmission()
+
+        val validator = PresentationSubmissionValidator.createInstance(
+            submissionRequirements = presentationDefinition.submissionRequirements,
+            inputDescriptors = presentationDefinition.inputDescriptors,
+        ).getOrThrow()
+
+        if (!validator.isValidSubmission(submittedCredentials.keys)) {
+            val missingInputDescriptors = presentationDefinition.inputDescriptors.map {
+                it.id
+            }.toSet() - submittedCredentials.keys
+
+            throw PresentationException(
+                "Submission requirements are unsatisfied: No credentials were submitted for input descriptors: $missingInputDescriptors"
+            )
         }
 
         createPresentation(
             challenge = challenge,
             audienceId = audienceId,
             presentationDefinitionId = presentationDefinition.id,
-            inputDescriptorMatches = matches,
+            presentationSubmissionSelection = submittedCredentials,
         ).getOrThrow()
     }.wrap()
 
-    suspend fun createPresentation(
+    override suspend fun createPresentation(
         challenge: String,
         audienceId: String,
         presentationDefinitionId: String?,
-        inputDescriptorMatches: List<Pair<InputDescriptor, CandidateInputMatchContainer>>,
+        presentationSubmissionSelection: Map<String, InputDescriptorCredentialSubmission>,
     ): KmmResult<Holder.PresentationResponseParameters> = runCatching {
+        val submissionList = presentationSubmissionSelection.toList()
         val presentationSubmission = PresentationSubmission.fromMatches(
             presentationId = presentationDefinitionId,
-            matches = inputDescriptorMatches,
+            matches = submissionList,
         )
 
-        val verifiablePresentations = inputDescriptorMatches.map { match ->
+        val verifiablePresentations = submissionList.map { match ->
             val credential = match.second.credential
-            val fieldQueryResults = match.second.fieldQueryResults
+            val disclosedAttributes = match.second.disclosedAttributes
             verifiablePresentationFactory.createVerifiablePresentation(
                 challenge = challenge,
                 audienceId = audienceId,
                 credential = credential,
-                fieldQueryResults = fieldQueryResults,
-            ) ?: throw CredentialPresentationException(
-                credential = credential,
-                inputDescriptor = match.first,
-                fieldQueryResults = fieldQueryResults,
-            )
+                disclosedAttributes = disclosedAttributes,
+            ).getOrThrow()
         }
 
         Holder.PresentationResponseParameters(
@@ -216,22 +219,27 @@ class HolderAgent(
     suspend fun createVcPresentation(
         validCredentials: List<String>,
         challenge: String,
-        audienceId: String
-    ) = verifiablePresentationFactory.createVcPresentation(
-        validCredentials = validCredentials,
-        challenge = challenge,
-        audienceId = audienceId,
-    )
+        audienceId: String,
+    ): KmmResult<Holder.CreatePresentationResult> = runCatching {
+        verifiablePresentationFactory.createVcPresentation(
+            validCredentials = validCredentials,
+            challenge = challenge,
+            audienceId = audienceId,
+        )
+    }.wrap()
+
 
     override suspend fun matchInputDescriptorsAgainstCredentialStore(
-        presentationDefinition: PresentationDefinition,
+        inputDescriptors: Collection<InputDescriptor>,
         fallbackFormatHolder: FormatHolder?,
-        pathAuthorizationValidator: (SubjectCredentialStore.StoreEntry, NormalizedJsonPath) -> Boolean,
-    ): KmmResult<Map<InputDescriptor, CandidateInputMatchContainer?>> = runCatching {
+        pathAuthorizationValidator: PathAuthorizationValidator?,
+    ) = runCatching {
         findInputDescriptorMatches(
-            inputDescriptors = presentationDefinition.inputDescriptors,
-            credentials = getValidCredentialsByPriority() ?: throw CredentialRetrievalException(),
-            fallbackFormatHolder = presentationDefinition.formats ?: fallbackFormatHolder,
+            inputDescriptors = inputDescriptors,
+            credentials = getValidCredentialsByPriority() ?: throw PresentationException(
+                "Credentials could not be retrieved from the store"
+            ),
+            fallbackFormatHolder = fallbackFormatHolder,
             pathAuthorizationValidator = pathAuthorizationValidator,
         )
     }.wrap()
@@ -240,23 +248,20 @@ class HolderAgent(
         inputDescriptors: Collection<InputDescriptor>,
         credentials: Collection<SubjectCredentialStore.StoreEntry>,
         fallbackFormatHolder: FormatHolder?,
-        pathAuthorizationValidator: (SubjectCredentialStore.StoreEntry, NormalizedJsonPath) -> Boolean,
+        pathAuthorizationValidator: PathAuthorizationValidator?,
     ) = inputDescriptors.associateWith { inputDescriptor ->
-        credentials.firstNotNullOfOrNull { credential ->
+        credentials.mapNotNull { credential ->
             evaluateInputDescriptorAgainstCredential(
                 inputDescriptor = inputDescriptor,
                 credential = credential,
                 presentationDefinitionFormatHolder = fallbackFormatHolder,
                 pathAuthorizationValidator = {
-                    pathAuthorizationValidator(credential, it)
+                    pathAuthorizationValidator?.invoke(credential, it) ?: true
                 },
             )?.let {
-                CandidateInputMatchContainer(
-                    credential = credential,
-                    fieldQueryResults = it,
-                )
+                credential to it
             }
-        }
+        }.toMap()
     }
 
     private fun evaluateInputDescriptorAgainstCredential(
@@ -273,7 +278,7 @@ class HolderAgent(
             else -> true
         }
     }.firstNotNullOfOrNull {
-        difInputEvaluator.evaluateFieldQueryResults(
+        difInputEvaluator.evaluateConstraintFieldMatches(
             inputDescriptor = inputDescriptor,
             credential = CredentialToJsonConverter.toJsonElement(it),
             pathAuthorizationValidator = pathAuthorizationValidator,
@@ -292,25 +297,25 @@ class HolderAgent(
 
     private fun PresentationSubmission.Companion.fromMatches(
         presentationId: String?,
-        matches: List<Pair<InputDescriptor, CandidateInputMatchContainer>>,
+        matches: List<Pair<String, InputDescriptorCredentialSubmission>>,
     ) = PresentationSubmission(
         id = uuid4().toString(),
         definitionId = presentationId,
         descriptorMap = matches.mapIndexed { index, match ->
             PresentationSubmissionDescriptor.fromMatch(
-                inputDescriptor = match.first,
+                inputDescriptorId = match.first,
                 credential = match.second.credential,
-                index = if (matches.size == 1) null else index
+                index = if (matches.size == 1) null else index,
             )
-        }
+        },
     )
 
     private fun PresentationSubmissionDescriptor.Companion.fromMatch(
-        inputDescriptor: InputDescriptor,
         credential: SubjectCredentialStore.StoreEntry,
-        index: Int?
+        inputDescriptorId: String,
+        index: Int?,
     ) = PresentationSubmissionDescriptor(
-        id = inputDescriptor.id,
+        id = inputDescriptorId,
         format = when (credential) {
             is SubjectCredentialStore.StoreEntry.Vc -> ClaimFormatEnum.JWT_VP
             is SubjectCredentialStore.StoreEntry.SdJwt -> ClaimFormatEnum.JWT_SD
@@ -321,27 +326,6 @@ class HolderAgent(
         // MUST have the value $ (top level root path) when only one Verifiable Presentation is contained in the VP Token,
         // and MUST have the value $[n] (indexed path from root) when there are multiple Verifiable Presentations,
         // where n is the index to select.
-        path = index?.let { "\$[$it]" } ?: "\$"
+        path = index?.let { "\$[$it]" } ?: "\$",
     )
 }
-
-open class PresentationException(message: String) : Exception(message)
-
-class CredentialRetrievalException :
-    PresentationException("Credentials could not be retrieved from the store")
-
-class MissingInputDescriptorMatchException(
-    val inputDescriptor: InputDescriptor,
-) : PresentationException("No match was found for input descriptor $inputDescriptor")
-
-class AttributeNotAvailableException(
-    val credential: SubjectCredentialStore.StoreEntry.Iso,
-    val namespace: String,
-    val attributeName: String,
-) : PresentationException("Attribute not available in credential: $['$namespace']['$attributeName']: $credential")
-
-class CredentialPresentationException(
-    val inputDescriptor: InputDescriptor,
-    val credential: SubjectCredentialStore.StoreEntry,
-    val fieldQueryResults: FieldQueryResults,
-) : PresentationException("Presentation of $inputDescriptor failed with credential $credential and field query results: $fieldQueryResults")

--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -61,7 +61,9 @@ interface SubjectCredentialStore {
             : KmmResult<List<StoreEntry>>
 
     @Serializable
-    sealed class StoreEntry {
+    sealed interface StoreEntry {
+        val scheme: ConstantIndex.CredentialScheme
+
         @Serializable
         data class Vc(
             @SerialName("vc-serialized")
@@ -69,8 +71,8 @@ interface SubjectCredentialStore {
             @SerialName("vc")
             val vc: VerifiableCredentialJws,
             @SerialName("scheme")
-            val scheme: ConstantIndex.CredentialScheme
-        ) : StoreEntry()
+            override val scheme: ConstantIndex.CredentialScheme
+        ) : StoreEntry
 
         @Serializable
         data class SdJwt(
@@ -84,16 +86,16 @@ interface SubjectCredentialStore {
             @SerialName("disclosures")
             val disclosures: Map<String, SelectiveDisclosureItem?>,
             @SerialName("scheme")
-            val scheme: ConstantIndex.CredentialScheme
-        ) : StoreEntry()
+            override val scheme: ConstantIndex.CredentialScheme
+        ) : StoreEntry
 
         @Serializable
         data class Iso(
             @SerialName("issuer-signed")
             val issuerSigned: IssuerSigned,
             @SerialName("scheme")
-            val scheme: ConstantIndex.CredentialScheme
-        ) : StoreEntry()
+            override val scheme: ConstantIndex.CredentialScheme
+        ) : StoreEntry
     }
 
 }

--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/PresentationSubmissionValidator.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/PresentationSubmissionValidator.kt
@@ -1,0 +1,81 @@
+package at.asitplus.wallet.lib.data.dif
+
+import at.asitplus.KmmResult
+import at.asitplus.KmmResult.Companion.wrap
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class PresentationSubmissionValidator {
+    companion object {
+        fun createInstance(
+            submissionRequirements: Collection<SubmissionRequirement>?,
+            inputDescriptors: Collection<InputDescriptor>,
+        ): KmmResult<PresentationSubmissionValidator> = runCatching {
+            val verifier = submissionRequirements?.let { _ ->
+                SubmissionRequirementsValidator(
+                    submissionRequirements = submissionRequirements,
+                    inputDescriptorGroups = inputDescriptors.associate {
+                        it.id to (it.group ?: throw MissingInputDescriptorGroupException(it))
+                    },
+                )
+            } ?: InputDescriptorSubmissionsValidator(
+                inputDescriptorIds = inputDescriptors.map { it.id }.toSet()
+            )
+            return KmmResult.success(verifier)
+        }.wrap()
+    }
+
+    /**
+     * Primitive to check, whether all submission requirements are satisfied
+     */
+    protected abstract fun isSubmissionRequirementsSatisfied(
+        submittedInputDescriptorIds: Set<String>,
+    ): Boolean
+
+    /**
+     * Checks, whether submission requirements are satisfied, and also fails if there are unnecessary submissions
+     */
+    fun isValidSubmission(
+        submittedInputDescriptorIds: Set<String>,
+    ): Boolean =
+        isSubmissionRequirementsSatisfied(submittedInputDescriptorIds) && findUnnecessaryInputDescriptorSubmissions(
+            submittedInputDescriptorIds
+        ).isEmpty()
+
+
+    fun findUnnecessaryInputDescriptorSubmissions(submittedInputDescriptorIds: Set<String>): Set<String> =
+        submittedInputDescriptorIds.filter {
+            isSubmissionRequirementsSatisfied(
+                submittedInputDescriptorIds - it
+            )
+        }.toSet()
+
+
+    @Serializable
+    data class InputDescriptorSubmissionsValidator(
+        val inputDescriptorIds: Set<String>,
+    ) : PresentationSubmissionValidator() {
+        override fun isSubmissionRequirementsSatisfied(
+            submittedInputDescriptorIds: Set<String>,
+        ): Boolean = submittedInputDescriptorIds.containsAll(inputDescriptorIds)
+    }
+
+    @Serializable
+    data class SubmissionRequirementsValidator(
+        val submissionRequirements: Collection<SubmissionRequirement>,
+        val inputDescriptorGroups: Map<String, String>,
+    ) : PresentationSubmissionValidator() {
+        override fun isSubmissionRequirementsSatisfied(
+            submittedInputDescriptorIds: Set<String>,
+        ): Boolean = submissionRequirements.all {
+            it.evaluate(
+                inputDescriptorGroups = inputDescriptorGroups,
+                selectedInputDescriptorIds = submittedInputDescriptorIds,
+            )
+        }
+    }
+
+    class MissingInputDescriptorGroupException(inputDescriptor: InputDescriptor) : Exception(
+        "Input descriptor is missing field `group` and is therefore not eligible for use with submission requirements: $inputDescriptor"
+    )
+}

--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/SubmissionRequirement.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/SubmissionRequirement.kt
@@ -25,4 +25,70 @@ data class SubmissionRequirement(
     val from: String? = null,
     @SerialName("from_nested")
     val fromNested: Collection<SubmissionRequirement>? = null,
-)
+) {
+    /**
+     * Evaluating submission requirements as per [Presentation Exchange 2.0.0 - Submission Requirement Rules](https://identity.foundation/presentation-exchange/spec/v2.0.0/#submission-requirement-rules).
+     *
+     * @param inputDescriptorGroups: a mapping from input descriptor id to the group of the input descriptor
+     * @param selectedInputDescriptorIds: a set of input descriptor ids for which a credential is submitted
+     */
+    fun evaluate(
+        inputDescriptorGroups: Map<String, String>,
+        selectedInputDescriptorIds: Collection<String>,
+    ): Boolean = when (rule) {
+        SubmissionRequirementRuleEnum.ALL -> when {
+            from != null -> inputDescriptorGroups.filter {
+                it.value == from
+            }.all {
+                selectedInputDescriptorIds.contains(it.key)
+            }
+
+            fromNested != null -> fromNested.all {
+                it.evaluate(
+                    inputDescriptorGroups = inputDescriptorGroups,
+                    selectedInputDescriptorIds = selectedInputDescriptorIds,
+                )
+            }
+
+            else -> throw SubmissionRequirementsStructureException(
+                "neither `from` nor `fromNested` have been provided"
+            )
+        }
+
+        SubmissionRequirementRuleEnum.PICK -> when {
+            from != null -> inputDescriptorGroups.filter {
+                it.value == from
+            }.count {
+                selectedInputDescriptorIds.contains(it.key)
+            }
+
+            fromNested != null -> fromNested.map {
+                it.evaluate(
+                    inputDescriptorGroups = inputDescriptorGroups,
+                    selectedInputDescriptorIds = selectedInputDescriptorIds,
+                )
+            }.count {
+                it
+            }
+
+            else -> throw SubmissionRequirementsStructureException(
+                "neither `from` nor `fromNested` have been provided"
+            )
+        }.let { numSelected ->
+            listOfNotNull(
+                this.count?.let { numSelected == it },
+                this.min?.let { numSelected >= it },
+                this.max?.let { numSelected <= it },
+            ).all {
+                it
+            }
+        }
+
+        else -> throw SubmissionRequirementsStructureException(
+            "invalid rule: ${rule?.text}"
+        )
+    }
+
+
+    class SubmissionRequirementsStructureException(message: String) : Exception(message)
+}

--- a/vclib/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVpTest.kt
+++ b/vclib/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVpTest.kt
@@ -79,7 +79,7 @@ class ValidatorVpTest : FreeSpec({
             .filterIsInstance<Holder.StoredCredential.Vc>()
             .map { it.storeEntry.vcSerialized }
             .map { it.reversed() }
-        val vp = holder.createVcPresentation(holderVcSerialized, challenge, verifier.keyPair.identifier)
+        val vp = holder.createVcPresentation(holderVcSerialized, challenge, verifier.keyPair.identifier).getOrNull()
         vp.shouldNotBeNull()
 
         vp.shouldBeInstanceOf<Holder.CreatePresentationResult.Signed>()

--- a/vclib/src/commonTest/kotlin/at/asitplus/wallet/lib/data/SubmissionRequirementsTest.kt
+++ b/vclib/src/commonTest/kotlin/at/asitplus/wallet/lib/data/SubmissionRequirementsTest.kt
@@ -1,0 +1,1697 @@
+package at.asitplus.wallet.lib.data
+
+import at.asitplus.wallet.lib.data.dif.SubmissionRequirement
+import at.asitplus.wallet.lib.data.dif.SubmissionRequirementRuleEnum
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+@Suppress("unused")
+class SubmissionRequirementsTest : FreeSpec({
+    "all" - {
+        "from" - {
+            val group = "A"
+            val submissionRequirement = SubmissionRequirement(
+                rule = SubmissionRequirementRuleEnum.ALL,
+                from = group,
+            )
+
+            "1" - {
+                val inputDescriptorId = "0"
+
+                "inGroup" - {
+                    val inputDescriptorGroups = mapOf(inputDescriptorId to group)
+
+                    "selected" - {
+                        val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+                    "notSelected" - {
+                        val selectedInputDescriptorIds = listOf<String>()
+
+                        "shouldBeFalse" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe false
+                        }
+                    }
+                }
+
+                "notInGroup" - {
+                    val inputDescriptorGroups = mapOf(inputDescriptorId to group + "2")
+
+                    "selected" - {
+                        val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+                    "notSelected" - {
+                        val selectedInputDescriptorIds = listOf<String>()
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+                }
+            }
+
+            "2" - {
+                val inputDescriptor0Id = "0"
+                val inputDescriptor1Id = "1"
+
+                "bothInGroup" - {
+                    val inputDescriptorGroups = mapOf(
+                        inputDescriptor0Id to group,
+                        inputDescriptor1Id to group,
+                    )
+
+                    "bothSelected" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor0Id,
+                            inputDescriptor1Id,
+                        )
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+
+                    "secondSelected" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor1Id,
+                        )
+
+                        "shouldBeFalse" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe false
+                        }
+                    }
+
+                    "firstSelected" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor0Id,
+                        )
+
+                        "shouldBeFalse" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe false
+                        }
+                    }
+
+                    "neither selected" - {
+                        val selectedInputDescriptorIds = listOf<String>()
+
+                        "shouldBeFalse" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe false
+                        }
+                    }
+                }
+
+                "first in group" - {
+                    val inputDescriptorGroups = mapOf(
+                        inputDescriptor0Id to group,
+                        inputDescriptor1Id to (group + "2"),
+                    )
+
+                    "both selected" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor0Id,
+                            inputDescriptor1Id,
+                        )
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+
+                    "firstSelected" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor0Id,
+                        )
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+
+                    "secondSelected" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor1Id,
+                        )
+
+                        "shouldBeFalse" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe false
+                        }
+                    }
+
+                    "neitherSelected" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor1Id,
+                        )
+
+                        "shouldBeFalse" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe false
+                        }
+                    }
+                }
+
+                "groups00" - {
+                    val actualGroup = group + "2"
+                    val inputDescriptorGroups = mapOf(
+                        inputDescriptor0Id to actualGroup,
+                        inputDescriptor1Id to actualGroup,
+                    )
+
+                    "bothSelected" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor0Id,
+                            inputDescriptor1Id,
+                        )
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+
+                    "oneSelected" - {
+                        val selectionPossibilities = listOf(
+                            listOf(inputDescriptor0Id),
+                            listOf(inputDescriptor1Id),
+                        )
+
+                        "shouldBeTrue" {
+                            selectionPossibilities.forEach {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = it
+                                ) shouldBe true
+                            }
+                        }
+                    }
+
+                    "neitherSelected" - {
+                        val selectedInputDescriptorIds = listOf<String>()
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+                }
+
+                "groups01" - {
+                    val inputDescriptorGroups = mapOf(
+                        inputDescriptor0Id to group + "2",
+                        inputDescriptor1Id to group + "3",
+                    )
+
+                    "bothSelected" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor0Id,
+                            inputDescriptor1Id,
+                        )
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+
+                    "oneSelected" - {
+                        val selectionPossibilities = listOf(
+                            listOf(inputDescriptor0Id),
+                            listOf(inputDescriptor1Id),
+                        )
+
+                        "shouldBeTrue" {
+                            selectionPossibilities.forEach {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = it
+                                ) shouldBe true
+                            }
+                        }
+                    }
+
+                    "neitherSelected" - {
+                        val selectedInputDescriptorIds = listOf<String>()
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+                }
+            }
+        }
+
+        "nested" - {
+            "1" - {
+                val nestedGroup = "A"
+                val inputDescriptorId = "0"
+                val inputDescriptorGroups = mapOf(inputDescriptorId to nestedGroup)
+                val submissionRequirement = SubmissionRequirement(
+                    rule = SubmissionRequirementRuleEnum.ALL,
+                    fromNested = listOf(
+                        SubmissionRequirement(
+                            rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup
+                        )
+                    ),
+                )
+
+                "satisfied" - {
+                    val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                    "shouldBeTrue" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds
+                        ) shouldBe true
+                    }
+                }
+
+                "unsatisfied" - {
+                    val selectedInputDescriptorIds = listOf<String>()
+
+                    "shouldBeFalse" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds
+                        ) shouldBe false
+                    }
+                }
+            }
+
+            "2" - {
+                val nestedGroup0 = "A"
+                val nestedGroup1 = "B"
+                val inputDescriptor0Id = "0"
+                val inputDescriptor1Id = "1"
+                val inputDescriptorGroups = mapOf(
+                    inputDescriptor0Id to nestedGroup0,
+                    inputDescriptor1Id to nestedGroup1,
+                )
+
+                val nestedRequirements = listOf(
+                    SubmissionRequirement(
+                        rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup0
+                    ),
+                    SubmissionRequirement(
+                        rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup1
+                    ),
+                )
+                val submissionRequirement = SubmissionRequirement(
+                    rule = SubmissionRequirementRuleEnum.ALL,
+                    fromNested = nestedRequirements,
+                )
+
+                "bothSatisfied" - {
+                    val selectedInputDescriptorIds = listOf(
+                        inputDescriptor0Id,
+                        inputDescriptor1Id,
+                    )
+
+                    nestedRequirements.forEach {
+                        it.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe true
+                    }
+                    "shouldBeTrue" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds
+                        ) shouldBe true
+                    }
+                }
+
+                "firstSatisfied" - {
+                    val selectedInputDescriptorIds = listOf(
+                        inputDescriptor0Id,
+                    )
+                    nestedRequirements[0].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe true
+                    nestedRequirements[1].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    "shouldBeFalse" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe false
+                    }
+                }
+
+                "secondSatisfied" - {
+                    val selectedInputDescriptorIds = listOf(
+                        inputDescriptor1Id,
+                    )
+                    nestedRequirements[0].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    nestedRequirements[1].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe true
+                    "shouldBeFalse" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe false
+                    }
+                }
+
+                "neitherSatisfied" - {
+                    val selectedInputDescriptorIds = listOf<String>()
+                    nestedRequirements[0].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    nestedRequirements[1].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    "shouldBeFalse" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe false
+                    }
+                }
+            }
+        }
+    }
+
+    "pick" - {
+        "from" - {
+            val group = "A"
+
+            "count" - {
+                val submissionRequirement = SubmissionRequirement(
+                    rule = SubmissionRequirementRuleEnum.PICK, from = group, count = 1
+                )
+
+                "1" - {
+                    val inputDescriptorId = "0"
+
+                    "inGroup" - {
+                        val inputDescriptorGroups = mapOf(inputDescriptorId to group)
+
+                        "selected" - {
+                            val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+                        "notSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+
+                    "notInGroup" - {
+                        val inputDescriptorGroups = mapOf(inputDescriptorId to group + "2")
+
+                        "selected" - {
+                            val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                        "notSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+                }
+
+                "2" - {
+                    val inputDescriptor0Id = "0"
+                    val inputDescriptor1Id = "1"
+
+                    "bothInGroup" - {
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to group,
+                            inputDescriptor1Id to group,
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+
+                        "secondSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "firstSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+
+                    "groupsT0" - {
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to group,
+                            inputDescriptor1Id to (group + "2"),
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "firstSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "secondSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+
+                    "groups00" - {
+                        val actualGroup = group + "2"
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to actualGroup,
+                            inputDescriptor1Id to actualGroup,
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+
+                        "oneSelected" - {
+                            val selectionPossibilities = listOf(
+                                listOf(inputDescriptor0Id),
+                                listOf(inputDescriptor1Id),
+                            )
+
+                            "shouldBeFalse" {
+                                selectionPossibilities.forEach {
+                                    submissionRequirement.evaluate(
+                                        inputDescriptorGroups = inputDescriptorGroups,
+                                        selectedInputDescriptorIds = it
+                                    ) shouldBe false
+                                }
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+
+                    "groups01" - {
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to group + "2",
+                            inputDescriptor1Id to group + "3",
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+
+                        "oneSelected" - {
+                            val selectionPossibilities = listOf(
+                                listOf(inputDescriptor0Id),
+                                listOf(inputDescriptor1Id),
+                            )
+
+                            "shouldBeFalse" {
+                                selectionPossibilities.forEach {
+                                    submissionRequirement.evaluate(
+                                        inputDescriptorGroups = inputDescriptorGroups,
+                                        selectedInputDescriptorIds = it
+                                    ) shouldBe false
+                                }
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+                }
+            }
+            "min" - {
+                val submissionRequirement = SubmissionRequirement(
+                    rule = SubmissionRequirementRuleEnum.PICK, from = group, min = 1
+                )
+
+                "1" - {
+                    val inputDescriptorId = "0"
+
+                    "inGroup" - {
+                        val inputDescriptorGroups = mapOf(inputDescriptorId to group)
+
+                        "selected" - {
+                            val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+                        "notSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+
+                    "notInGroup" - {
+                        val inputDescriptorGroups = mapOf(inputDescriptorId to group + "2")
+
+                        "selected" - {
+                            val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                        "notSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+                }
+
+                "2" - {
+                    val inputDescriptor0Id = "0"
+                    val inputDescriptor1Id = "1"
+
+                    "bothInGroup" - {
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to group,
+                            inputDescriptor1Id to group,
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "secondSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "firstSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+
+                    "when descriptors are in different groups, but descriptor 0 is in the selected group" - {
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to group,
+                            inputDescriptor1Id to (group + "2"),
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "when only the descriptor in the intended group is selected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "when only the descriptor not in the intended group is selected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+
+                    "when descriptors are in same groups, but the group is not the intended one" - {
+                        val actualGroup = group + "2"
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to actualGroup,
+                            inputDescriptor1Id to actualGroup,
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+
+                        "oneSelected" - {
+                            val selectionPossibilities = listOf(
+                                listOf(inputDescriptor0Id),
+                                listOf(inputDescriptor1Id),
+                            )
+
+                            "shouldBeFalse" {
+                                selectionPossibilities.forEach {
+                                    submissionRequirement.evaluate(
+                                        inputDescriptorGroups = inputDescriptorGroups,
+                                        selectedInputDescriptorIds = it
+                                    ) shouldBe false
+                                }
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+
+                    "groups01" - {
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to group + "2",
+                            inputDescriptor1Id to group + "3",
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+
+                        "oneSelected" - {
+                            val selectionPossibilities = listOf(
+                                listOf(inputDescriptor0Id),
+                                listOf(inputDescriptor1Id),
+                            )
+
+                            "shouldBeFalse" {
+                                selectionPossibilities.forEach {
+                                    submissionRequirement.evaluate(
+                                        inputDescriptorGroups = inputDescriptorGroups,
+                                        selectedInputDescriptorIds = it
+                                    ) shouldBe false
+                                }
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+                    }
+                }
+            }
+            "max" - {
+                val submissionRequirement = SubmissionRequirement(
+                    rule = SubmissionRequirementRuleEnum.PICK, from = group, max = 1
+                )
+
+                "1" - {
+                    val inputDescriptorId = "0"
+
+                    "inGroup" - {
+                        val inputDescriptorGroups = mapOf(inputDescriptorId to group)
+
+                        "selected" - {
+                            val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+                        "notSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+                    }
+
+                    "notInGroup" - {
+                        val inputDescriptorGroups = mapOf(inputDescriptorId to group + "2")
+
+                        "selected" - {
+                            val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+                        "notSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+                    }
+                }
+
+                "2" - {
+                    val inputDescriptor0Id = "0"
+                    val inputDescriptor1Id = "1"
+
+                    "bothInGroup" - {
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to group,
+                            inputDescriptor1Id to group,
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeFalse" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe false
+                            }
+                        }
+
+                        "secondSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "firstSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+                    }
+
+                    "when descriptors are in different groups, but descriptor 0 is in the selected group" - {
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to group,
+                            inputDescriptor1Id to (group + "2"),
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "when only the descriptor in the intended group is selected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "when only the descriptor not in the intended group is selected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+                    }
+
+                    "when descriptors are in same groups, but the group is not the intended one" - {
+                        val actualGroup = group + "2"
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to actualGroup,
+                            inputDescriptor1Id to actualGroup,
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "oneSelected" - {
+                            val selectionPossibilities = listOf(
+                                listOf(inputDescriptor0Id),
+                                listOf(inputDescriptor1Id),
+                            )
+
+                            "shouldBeTrue" {
+                                selectionPossibilities.forEach {
+                                    submissionRequirement.evaluate(
+                                        inputDescriptorGroups = inputDescriptorGroups,
+                                        selectedInputDescriptorIds = it
+                                    ) shouldBe true
+                                }
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+                    }
+
+                    "groups01" - {
+                        val inputDescriptorGroups = mapOf(
+                            inputDescriptor0Id to group + "2",
+                            inputDescriptor1Id to group + "3",
+                        )
+
+                        "bothSelected" - {
+                            val selectedInputDescriptorIds = listOf(
+                                inputDescriptor0Id,
+                                inputDescriptor1Id,
+                            )
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+
+                        "oneSelected" - {
+                            val selectionPossibilities = listOf(
+                                listOf(inputDescriptor0Id),
+                                listOf(inputDescriptor1Id),
+                            )
+
+                            "shouldBeTrue" {
+                                selectionPossibilities.forEach {
+                                    submissionRequirement.evaluate(
+                                        inputDescriptorGroups = inputDescriptorGroups,
+                                        selectedInputDescriptorIds = it
+                                    ) shouldBe true
+                                }
+                            }
+                        }
+
+                        "neitherSelected" - {
+                            val selectedInputDescriptorIds = listOf<String>()
+
+                            "shouldBeTrue" {
+                                submissionRequirement.evaluate(
+                                    inputDescriptorGroups = inputDescriptorGroups,
+                                    selectedInputDescriptorIds = selectedInputDescriptorIds
+                                ) shouldBe true
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        "nested" - {
+            "count" - {
+                "1" - {
+                    val nestedGroup = "A"
+                    val inputDescriptorId = "0"
+                    val inputDescriptorGroups = mapOf(inputDescriptorId to nestedGroup)
+                    val submissionRequirement = SubmissionRequirement(
+                        rule = SubmissionRequirementRuleEnum.PICK, fromNested = listOf(
+                            SubmissionRequirement(
+                                rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup
+                            )
+                        ), count = 1
+                    )
+
+                    "isSatisfied" - {
+                        val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe true
+                        }
+                    }
+
+                    "isNotSatisfied" - {
+                        val selectedInputDescriptorIds = listOf<String>()
+
+                        "shouldBeFalse" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe false
+                        }
+                    }
+                }
+
+                "2" - {
+                    val nestedGroup0 = "A"
+                    val nestedGroup1 = "B"
+                    val inputDescriptor0Id = "0"
+                    val inputDescriptor1Id = "1"
+                    val inputDescriptorGroups = mapOf(
+                        inputDescriptor0Id to nestedGroup0,
+                        inputDescriptor1Id to nestedGroup1,
+                    )
+
+                    val nestedRequirements = listOf(
+                        SubmissionRequirement(
+                            rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup0
+                        ),
+                        SubmissionRequirement(
+                            rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup1
+                        ),
+                    )
+                    val submissionRequirement = SubmissionRequirement(
+                        rule = SubmissionRequirementRuleEnum.PICK,
+                        fromNested = nestedRequirements,
+                        count = 1
+                    )
+
+                    "bothSatisfied" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor0Id,
+                            inputDescriptor1Id,
+                        )
+
+                        nestedRequirements.forEach {
+                            it.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds,
+                            ) shouldBe true
+                        }
+                        "shouldBeFalse" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds
+                            ) shouldBe false
+                        }
+                    }
+
+                    "firstSatisfied" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor0Id,
+                        )
+                        nestedRequirements[0].evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe true
+                        nestedRequirements[1].evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe false
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds,
+                            ) shouldBe true
+                        }
+                    }
+
+                    "secondSatisfied" - {
+                        val selectedInputDescriptorIds = listOf(
+                            inputDescriptor1Id,
+                        )
+                        nestedRequirements[0].evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe false
+                        nestedRequirements[1].evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe true
+                        "shouldBeTrue" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds,
+                            ) shouldBe true
+                        }
+                    }
+
+                    "neitherSatisfied" - {
+                        val selectedInputDescriptorIds = listOf<String>()
+                        nestedRequirements[0].evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe false
+                        nestedRequirements[1].evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe false
+                        "shouldBeFalse" {
+                            submissionRequirement.evaluate(
+                                inputDescriptorGroups = inputDescriptorGroups,
+                                selectedInputDescriptorIds = selectedInputDescriptorIds,
+                            ) shouldBe false
+                        }
+                    }
+                }
+            }
+        }
+        "min" - {
+            "1" - {
+                val nestedGroup = "A"
+                val inputDescriptorId = "0"
+                val inputDescriptorGroups = mapOf(inputDescriptorId to nestedGroup)
+                val submissionRequirement = SubmissionRequirement(
+                    rule = SubmissionRequirementRuleEnum.PICK, fromNested = listOf(
+                        SubmissionRequirement(
+                            rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup
+                        )
+                    ), min = 1
+                )
+
+                "satisfied" - {
+                    val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                    "shouldBeTrue" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds
+                        ) shouldBe true
+                    }
+                }
+
+                "isNotSatisfied" - {
+                    val selectedInputDescriptorIds = listOf<String>()
+
+                    "shouldBeFalse" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds
+                        ) shouldBe false
+                    }
+                }
+            }
+
+            "2" - {
+                val nestedGroup0 = "A"
+                val nestedGroup1 = "B"
+                val inputDescriptor0Id = "0"
+                val inputDescriptor1Id = "1"
+                val inputDescriptorGroups = mapOf(
+                    inputDescriptor0Id to nestedGroup0,
+                    inputDescriptor1Id to nestedGroup1,
+                )
+
+                val nestedRequirements = listOf(
+                    SubmissionRequirement(
+                        rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup0
+                    ),
+                    SubmissionRequirement(
+                        rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup1
+                    ),
+                )
+                val submissionRequirement = SubmissionRequirement(
+                    rule = SubmissionRequirementRuleEnum.PICK,
+                    fromNested = nestedRequirements,
+                    min = 1
+                )
+
+                "both satisfied" - {
+                    val selectedInputDescriptorIds = listOf(
+                        inputDescriptor0Id,
+                        inputDescriptor1Id,
+                    )
+
+                    nestedRequirements.forEach {
+                        it.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe true
+                    }
+                    "shouldBeTrue" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds
+                        ) shouldBe true
+                    }
+                }
+
+                "0 is satisfied" - {
+                    val selectedInputDescriptorIds = listOf(
+                        inputDescriptor0Id,
+                    )
+                    nestedRequirements[0].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe true
+                    nestedRequirements[1].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    "shouldBeTrue" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe true
+                    }
+                }
+
+                "1 is satisfied" - {
+                    val selectedInputDescriptorIds = listOf(
+                        inputDescriptor1Id,
+                    )
+                    nestedRequirements[0].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    nestedRequirements[1].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe true
+                    "shouldBeFalse" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe true
+                    }
+                }
+
+                "neitherSatisfied" - {
+                    val selectedInputDescriptorIds = listOf<String>()
+                    nestedRequirements[0].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    nestedRequirements[1].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    "shouldBeFalse" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe false
+                    }
+                }
+            }
+        }
+        "max" - {
+            "1" - {
+                val nestedGroup = "A"
+                val inputDescriptorId = "0"
+                val inputDescriptorGroups = mapOf(inputDescriptorId to nestedGroup)
+                val submissionRequirement = SubmissionRequirement(
+                    rule = SubmissionRequirementRuleEnum.PICK, fromNested = listOf(
+                        SubmissionRequirement(
+                            rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup
+                        )
+                    ), max = 1
+                )
+
+                "satisfied" - {
+                    val selectedInputDescriptorIds = listOf(inputDescriptorId)
+
+                    "shouldBeTrue" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds
+                        ) shouldBe true
+                    }
+                }
+
+                "unsatisfied" - {
+                    val selectedInputDescriptorIds = listOf<String>()
+
+                    "shouldBeFalse" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds
+                        ) shouldBe true
+                    }
+                }
+            }
+
+            "2" - {
+                val nestedGroup0 = "A"
+                val nestedGroup1 = "B"
+                val inputDescriptor0Id = "0"
+                val inputDescriptor1Id = "1"
+                val inputDescriptorGroups = mapOf(
+                    inputDescriptor0Id to nestedGroup0,
+                    inputDescriptor1Id to nestedGroup1,
+                )
+
+                val nestedRequirements = listOf(
+                    SubmissionRequirement(
+                        rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup0
+                    ),
+                    SubmissionRequirement(
+                        rule = SubmissionRequirementRuleEnum.ALL, from = nestedGroup1
+                    ),
+                )
+                val submissionRequirement = SubmissionRequirement(
+                    rule = SubmissionRequirementRuleEnum.PICK,
+                    fromNested = nestedRequirements,
+                    max = 1
+                )
+
+                "both satisfied" - {
+                    val selectedInputDescriptorIds = listOf(
+                        inputDescriptor0Id,
+                        inputDescriptor1Id,
+                    )
+
+                    nestedRequirements.forEach {
+                        it.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe true
+                    }
+                    "shouldBeFalse" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds
+                        ) shouldBe false
+                    }
+                }
+
+                "first satisfied" - {
+                    val selectedInputDescriptorIds = listOf(
+                        inputDescriptor0Id,
+                    )
+                    nestedRequirements[0].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe true
+                    nestedRequirements[1].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    "shouldBeTrue" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe true
+                    }
+                }
+
+                "second satisfied" - {
+                    val selectedInputDescriptorIds = listOf(
+                        inputDescriptor1Id,
+                    )
+                    nestedRequirements[0].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    nestedRequirements[1].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe true
+                    "shouldBeTrue" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe true
+                    }
+                }
+
+                "neither satisfied" - {
+                    val selectedInputDescriptorIds = listOf<String>()
+                    nestedRequirements[0].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    nestedRequirements[1].evaluate(
+                        inputDescriptorGroups = inputDescriptorGroups,
+                        selectedInputDescriptorIds = selectedInputDescriptorIds,
+                    ) shouldBe false
+                    "shouldBeTrue" {
+                        submissionRequirement.evaluate(
+                            inputDescriptorGroups = inputDescriptorGroups,
+                            selectedInputDescriptorIds = selectedInputDescriptorIds,
+                        ) shouldBe true
+                    }
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
- `Holder.matchInputDescriptorsAgainstCredentialStore` now yields much richer details on credential matches.
  - list of credentials that match an input descriptor, and for each constraint field also a list of fields matching that constraint field 
- Added `SubmissionRequirement.evaluate` to allow for verification of submission requirements
- Added second method for creating a presentation, where the user may present manually selected credentials and where the submission requirements are not checked. 