### PR TITLE
Separate authentication response building steps in SiopWallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ Release 4.0.0:
  - Add return types to function calls to `SubjectCredentialStore`
  - Change from list to single credential in parameter for `Holder.storeCredentials()`, changing name to `storeCredential()`
  - Refactor `AuthenticationRequestParametersFrom` used in `OidcSiopWallet` to be serializable
+ - Add `AuthenticationResponseFactory`: Builds an authentication response from request and response parameters
+ - Change `OidcSiopWallet`: 
+   - Add `startAuthorizationResponsePreparation`: Gathers data necessary for presentation building and yields a `AuthorizationResponsePreparationState`
+   - Add `finalizeAuthorizationResponseParameters`: Returns what `createAuthenticationParams` returned before, but also takes in `AuthorizationResponsePreparationState` and an optional non-default submission
+   - Add `finalizeAuthorizationResponse`: Returns what `createAuthenticationResponse` did before 
+ - Add `AuthorizationResponsePreparationState`: Holds data necessary for presentation building
+ - Add `AuthenticationRequestParser`: Extracted presentation request parsing logic from `OidcSiopWallet` and put it here
+ - Add `AuthorizationRequestValidator`: Extracted presentation request validation logic from `OidcSiopWallet` and put it here
+ - Add `PresentationFactory`: Extracted presentation response building logic from `OidcSiopWallet` and put it here
+   - Also added some code for presentation submission validation
 
 Release 3.8.0:
  - Kotlin 2.0.0

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopWallet.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopWallet.kt
@@ -151,19 +151,23 @@ class OidcSiopWallet(
      */
     suspend fun createAuthnResponseParams(
         params: AuthenticationRequestParametersFrom
-    ): KmmResult<AuthenticationResponse> = finalizeAuthorizationResponseParameters(
-        params = params,
-        preparationState = startAuthorizationResponsePreparation(params).getOrThrow(),
-    )
+    ): KmmResult<AuthenticationResponse> = catching {
+        finalizeAuthorizationResponseParameters(
+            params = params,
+            preparationState = startAuthorizationResponsePreparation(params).getOrThrow(),
+        ).getOrThrow()
+    }
 
     /**
      * Starts the authorization response building process from the RP's [params]
      */
     suspend fun startAuthorizationResponsePreparation(
         input: String,
-    ): KmmResult<AuthorizationResponsePreparationState> = startAuthorizationResponsePreparation(
-        params = parseAuthenticationRequestParameters(input).getOrThrow()
-    )
+    ): KmmResult<AuthorizationResponsePreparationState> = catching {
+        startAuthorizationResponsePreparation(
+            parseAuthenticationRequestParameters(input).getOrThrow()
+        ).getOrThrow()
+    }
 
     /**
      * Starts the authorization response building process from the RP's [params]

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopWallet.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopWallet.kt
@@ -5,45 +5,36 @@ import at.asitplus.catching
 import at.asitplus.crypto.datatypes.CryptoPublicKey
 import at.asitplus.crypto.datatypes.jws.JsonWebKey
 import at.asitplus.crypto.datatypes.jws.JsonWebKeySet
-import at.asitplus.crypto.datatypes.jws.JweHeader
 import at.asitplus.crypto.datatypes.jws.JwsSigned
 import at.asitplus.crypto.datatypes.jws.toJsonWebKey
-import at.asitplus.crypto.datatypes.pki.leaf
 import at.asitplus.wallet.lib.agent.DefaultCryptoService
 import at.asitplus.wallet.lib.agent.Holder
 import at.asitplus.wallet.lib.agent.HolderAgent
+import at.asitplus.wallet.lib.agent.CredentialSubmission
 import at.asitplus.wallet.lib.agent.KeyPairAdapter
 import at.asitplus.wallet.lib.agent.RandomKeyPairAdapter
-import at.asitplus.wallet.lib.data.dif.ClaimFormatEnum
-import at.asitplus.wallet.lib.data.dif.FormatHolder
 import at.asitplus.wallet.lib.data.dif.PresentationDefinition
 import at.asitplus.wallet.lib.jws.DefaultJwsService
 import at.asitplus.wallet.lib.jws.JwsService
 import at.asitplus.wallet.lib.oidc.OpenIdConstants.Errors
 import at.asitplus.wallet.lib.oidc.OpenIdConstants.ID_TOKEN
 import at.asitplus.wallet.lib.oidc.OpenIdConstants.PREFIX_DID_KEY
-import at.asitplus.wallet.lib.oidc.OpenIdConstants.ResponseMode.*
 import at.asitplus.wallet.lib.oidc.OpenIdConstants.SCOPE_OPENID
 import at.asitplus.wallet.lib.oidc.OpenIdConstants.URN_TYPE_JWK_THUMBPRINT
 import at.asitplus.wallet.lib.oidc.OpenIdConstants.VP_TOKEN
+import at.asitplus.wallet.lib.oidc.helper.AuthenticationRequestParser
+import at.asitplus.wallet.lib.oidc.helper.AuthenticationResponseFactory
+import at.asitplus.wallet.lib.oidc.helper.AuthorizationRequestValidator
+import at.asitplus.wallet.lib.oidc.helper.PresentationFactory
+import at.asitplus.wallet.lib.oidc.helpers.AuthorizationResponsePreparationState
 import at.asitplus.wallet.lib.oidvci.IssuerMetadata
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
-import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
-import at.asitplus.wallet.lib.oidvci.encodeToParameters
-import at.asitplus.wallet.lib.oidvci.formUrlEncode
 import io.github.aakira.napier.Napier
-import io.ktor.http.*
-import io.ktor.util.*
 import io.matthewnelson.encoding.base16.Base16
-import io.matthewnelson.encoding.base64.Base64
-import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
-import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
-import kotlin.random.Random
-import kotlin.time.Duration.Companion.seconds
 
 
 /**
@@ -65,38 +56,45 @@ class OidcSiopWallet(
      * Implementations need to fetch the url passed in, and return either the body, if there is one,
      * or the HTTP header `Location`, i.e. if the server sends the request object as a redirect.
      */
-    private val remoteResourceRetriever: RemoteResourceRetrieverFunction = { null },
+    private val remoteResourceRetriever: RemoteResourceRetrieverFunction,
     /**
      * Need to verify the request object serialized as a JWS,
      * which may be signed with a pre-registered key (see [OpenIdConstants.ClientIdScheme.PRE_REGISTERED]).
      */
-    private val requestObjectJwsVerifier: RequestObjectJwsVerifier = RequestObjectJwsVerifier { _, _ -> true },
+    private val requestObjectJwsVerifier: RequestObjectJwsVerifier,
     /**
      * Need to implement if the presentation definition needs to be derived from a scope value.
      * See [ScopePresentationDefinitionRetriever] for implementation instructions.
      */
-    private val scopePresentationDefinitionRetriever: ScopePresentationDefinitionRetriever? = null,
+    private val scopePresentationDefinitionRetriever: ScopePresentationDefinitionRetriever,
 ) {
     companion object {
         fun newDefaultInstance(
-            keyPairAdapter: KeyPairAdapter = RandomKeyPairAdapter(),
-            holder: Holder = HolderAgent(keyPairAdapter),
-            jwsService: JwsService = DefaultJwsService(DefaultCryptoService(keyPairAdapter)),
-            clock: Clock = Clock.System,
-            clientId: String = "https://wallet.a-sit.at/",
-            remoteResourceRetriever: RemoteResourceRetrieverFunction = { null },
-            requestObjectJwsVerifier: RequestObjectJwsVerifier = RequestObjectJwsVerifier { jws, authnRequest -> true },
-            scopePresentationDefinitionRetriever: ScopePresentationDefinitionRetriever? = { null },
-        ) = OidcSiopWallet(
-            holder = holder,
-            agentPublicKey = keyPairAdapter.publicKey,
-            jwsService = jwsService,
-            clock = clock,
-            clientId = clientId,
-            remoteResourceRetriever = remoteResourceRetriever,
-            requestObjectJwsVerifier = requestObjectJwsVerifier,
-            scopePresentationDefinitionRetriever = scopePresentationDefinitionRetriever,
-        )
+            keyPairAdapter: KeyPairAdapter? = null,
+            holder: Holder? = null,
+            jwsService: JwsService? = null,
+            clock: Clock? = null,
+            clientId: String? = null,
+            remoteResourceRetriever: RemoteResourceRetrieverFunction? = null,
+            requestObjectJwsVerifier: RequestObjectJwsVerifier? = null,
+            scopePresentationDefinitionRetriever: ScopePresentationDefinitionRetriever? = null,
+        ): OidcSiopWallet {
+            val actualKeyPairAdapter = keyPairAdapter ?: RandomKeyPairAdapter()
+            return OidcSiopWallet(
+                holder = holder ?: HolderAgent(actualKeyPairAdapter),
+                agentPublicKey = actualKeyPairAdapter.publicKey,
+                jwsService = jwsService ?: DefaultJwsService(
+                    DefaultCryptoService(actualKeyPairAdapter)
+                ),
+                clock = clock ?: Clock.System,
+                clientId = clientId ?: "https://wallet.a-sit.at/",
+                remoteResourceRetriever = remoteResourceRetriever ?: { null },
+                requestObjectJwsVerifier = requestObjectJwsVerifier
+                    ?: RequestObjectJwsVerifier { jws, authnRequest -> true },
+                scopePresentationDefinitionRetriever = scopePresentationDefinitionRetriever
+                    ?: { null },
+            )
+        }
     }
 
     val metadata: IssuerMetadata by lazy {
@@ -119,173 +117,34 @@ class OidcSiopWallet(
      * to create [AuthenticationResponseResult] that can be sent back to the Verifier, see
      * [AuthenticationResponseResult].
      */
-    suspend fun createAuthnResponse(input: String): KmmResult<AuthenticationResponseResult> = catching {
-        createAuthnResponse(parseAuthenticationRequestParameters(input).getOrThrow()).getOrThrow()
-    }
+    suspend fun createAuthnResponse(input: String): KmmResult<AuthenticationResponseResult> =
+        catching {
+            createAuthnResponse(parseAuthenticationRequestParameters(input).getOrThrow()).getOrThrow()
+        }
 
     /**
      * Pass in the URL sent by the Verifier (containing the [AuthenticationRequestParameters] as query parameters),
      * to create [AuthenticationResponseParameters] that can be sent back to the Verifier, see
      * [AuthenticationResponseResult].
      */
-    suspend fun parseAuthenticationRequestParameters(input: String)
-            : KmmResult<AuthenticationRequestParametersFrom> = catching {
-        // maybe it is a request JWS
-        val parsedParams = kotlin.run { parseRequestObjectJws(input) }
-            ?: kotlin.runCatching { // maybe it's in the URL parameters
-                Url(input).let {
-                    val params = it.parameters.flattenEntries().toMap()
-                        .decodeFromUrlQuery<AuthenticationRequestParameters>()
-                    AuthenticationRequestParametersFrom.Uri(it, params)
-                }
-            }.onFailure { it.printStackTrace() }.getOrNull()
-            ?: kotlin.runCatching {  // maybe it is already a JSON string
-                val params = AuthenticationRequestParameters.deserialize(input).getOrThrow()
-                AuthenticationRequestParametersFrom.Json(input, params)
-            }.getOrNull()
-            ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("Could not parse authentication request: $input") }
-
-        val extractedParams = parsedParams.let { extractRequestObject(it.parameters) ?: it }
-            .also { Napier.i("Parsed authentication request: $it") }
-        extractedParams
-    }
-
-    private suspend fun extractRequestObject(params: AuthenticationRequestParameters): AuthenticationRequestParametersFrom? =
-        params.request?.let { requestObject ->
-            parseRequestObjectJws(requestObject)
-        } ?: params.requestUri?.let { uri ->
-            remoteResourceRetriever.invoke(uri)
-                ?.let { parseAuthenticationRequestParameters(it).getOrNull() }
-        }
-
-    private fun parseRequestObjectJws(requestObject: String): AuthenticationRequestParametersFrom.JwsSigned? {
-        return JwsSigned.parse(requestObject).getOrNull()?.let { jws ->
-            val params = AuthenticationRequestParameters.deserialize(jws.payload.decodeToString()).getOrElse {
-                return null
-                    .apply { Napier.w("parseRequestObjectJws: Deserialization failed", it) }
-            }
-            if (requestObjectJwsVerifier.invoke(jws, params))
-                AuthenticationRequestParametersFrom.JwsSigned(jws, params)
-            else null
-                .also { Napier.w("parseRequestObjectJws: Signature not verified for $jws") }
-        }
-    }
+    suspend fun parseAuthenticationRequestParameters(input: String) =
+        AuthenticationRequestParser.createWithDefaults(
+            remoteResourceRetriever = remoteResourceRetriever,
+            requestObjectJwsVerifier = requestObjectJwsVerifier,
+        ).parseAuthenticationRequestParameters(input)
 
     /**
      * Pass in the deserialized [AuthenticationRequestParameters], which were either encoded as query params,
      * or JSON serialized as a JWT Request Object.
      */
     suspend fun createAuthnResponse(
-        request: AuthenticationRequestParametersFrom
+        request: AuthenticationRequestParametersFrom<*>,
     ): KmmResult<AuthenticationResponseResult> = catching {
         val response = createAuthnResponseParams(request).getOrThrow()
-        request.parameters.responseType?.let {
-            if (!it.contains(ID_TOKEN) && !it.contains(VP_TOKEN))
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("createAuthnResponse: Unknown response_type $it") }
-        } ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-            .also { Napier.w("createAuthnResponse: response_type null in ${request.parameters}") }
-
-        when (request.parameters.responseMode) {
-            DIRECT_POST -> authnResponseDirectPost(request, response)
-            DIRECT_POST_JWT -> authnResponseDirectPostJwt(request, response)
-            QUERY -> authnResponseQuery(request, response)
-            FRAGMENT, null -> authnResponseFragment(request, response)
-            is OTHER -> TODO()
-        }
-    }
-
-    private fun authnResponseDirectPost(
-        request: AuthenticationRequestParametersFrom,
-        response: AuthenticationResponse
-    ): AuthenticationResponseResult.Post {
-        val url = request.parameters.responseUrl
-            ?: request.parameters.redirectUrl
-            ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-        return AuthenticationResponseResult.Post(url, response.params.encodeToParameters())
-    }
-
-    /**
-     * Per OID4VP, the response may either be signed, or encrypted (never signed and encrypted!)
-     */
-    private suspend fun authnResponseDirectPostJwt(
-        request: AuthenticationRequestParametersFrom,
-        response: AuthenticationResponse
-    ): AuthenticationResponseResult.Post {
-        val url = request.parameters.responseUrl
-            ?: request.parameters.redirectUrl
-            ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-        val responseSerialized = buildJarm(request, response)
-        val jarm = AuthenticationResponseParameters(response = responseSerialized)
-        return AuthenticationResponseResult.Post(url, jarm.encodeToParameters())
-    }
-
-    private suspend fun buildJarm(request: AuthenticationRequestParametersFrom, response: AuthenticationResponse) =
-        if (response.clientMetadata != null && response.jsonWebKeys != null && response.clientMetadata.requestsEncryption()) {
-            val alg = response.clientMetadata.authorizationEncryptedResponseAlg!!
-            val enc = response.clientMetadata.authorizationEncryptedResponseEncoding!!
-            val jwk = response.jsonWebKeys.first()
-            val nonce = runCatching { request.parameters.nonce?.decodeToByteArray(Base64()) }.getOrNull()
-                ?: runCatching { request.parameters.nonce?.encodeToByteArray() }.getOrNull()
-                ?: Random.Default.nextBytes(16)
-            val payload = response.params.serialize().encodeToByteArray()
-            jwsService.encryptJweObject(
-                header = JweHeader(
-                    algorithm = alg,
-                    encryption = enc,
-                    type = null,
-                    agreementPartyVInfo = nonce.encodeToByteArray(Base64()),
-                    agreementPartyUInfo = Random.nextBytes(16),
-                    keyId = jwk.keyId,
-                ),
-                payload = payload,
-                recipientKey = jwk,
-                jweAlgorithm = alg,
-                jweEncryption = enc,
-            ).map { it.serialize() }.getOrElse {
-                Napier.w("buildJarm error", it)
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-            }
-        } else {
-            jwsService.createSignedJwsAddingParams(
-                payload = response.params.serialize().encodeToByteArray(), addX5c = false
-            ).map { it.serialize() }.getOrElse {
-                Napier.w("buildJarm error", it)
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-            }
-        }
-
-    private fun RelyingPartyMetadata.requestsEncryption() =
-        authorizationEncryptedResponseAlg != null && authorizationEncryptedResponseEncoding != null
-
-    private fun authnResponseQuery(
-        request: AuthenticationRequestParametersFrom,
-        response: AuthenticationResponse
-    ): AuthenticationResponseResult.Redirect {
-        val url = request.parameters.redirectUrl?.let { redirectUrl ->
-            URLBuilder(redirectUrl).apply {
-                response.params.encodeToParameters().forEach {
-                    this.parameters.append(it.key, it.value)
-                }
-            }.buildString()
-        } ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-        return AuthenticationResponseResult.Redirect(url, response.params)
-    }
-
-    /**
-     * That's the default for `id_token` and `vp_token`
-     */
-    private fun authnResponseFragment(
-        request: AuthenticationRequestParametersFrom,
-        response: AuthenticationResponse
-    ): AuthenticationResponseResult.Redirect {
-        val url = request.parameters.redirectUrl?.let { redirectUrl ->
-            URLBuilder(redirectUrl)
-                .apply { encodedFragment = response.params.encodeToParameters().formUrlEncode() }
-                .buildString()
-        } ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-        return AuthenticationResponseResult.Redirect(url, response.params)
+        AuthenticationResponseFactory(jwsService).createAuthenticationResponse(
+            request,
+            response,
+        )
     }
 
     /**
@@ -294,37 +153,103 @@ class OidcSiopWallet(
     suspend fun createAuthnResponseParams(
         params: AuthenticationRequestParametersFrom
     ): KmmResult<AuthenticationResponse> = catching {
-        val clientIdScheme = params.parameters.clientIdScheme
-        if (clientIdScheme == OpenIdConstants.ClientIdScheme.REDIRECT_URI) {
-            params.parameters.verifyClientMetadata()
-        }
-        if (params.parameters.responseMode.isAnyDirectPost()) {
-            params.parameters.verifyResponseModeDirectPost()
-        }
-        if (clientIdScheme.isAnyX509()) {
-            params.verifyClientIdSchemeX509()
-        }
+        val preparationState = startAuthorizationResponsePreparation(params).getOrThrow()
+        finalizeAuthorizationResponseParameters(
+            params = params,
+            preparationState = preparationState,
+        ).getOrThrow()
+    }
 
+    /**
+     * Starts the authorization response building process from the RP's [params]
+     */
+    suspend fun startAuthorizationResponsePreparation(
+        input: String,
+    ): KmmResult<AuthorizationResponsePreparationState> = catching {
+        startAuthorizationResponsePreparation(
+            parseAuthenticationRequestParameters(input).getOrThrow()
+        ).getOrThrow()
+    }
+
+    /**
+     * Starts the authorization response building process from the RP's [params]
+     */
+    suspend fun startAuthorizationResponsePreparation(
+        params: AuthenticationRequestParametersFrom<*>
+    ): KmmResult<AuthorizationResponsePreparationState> = catching {
         val clientMetadata = runCatching { params.parameters.loadClientMetadata() }.getOrNull()
-        val certKey = (params as? AuthenticationRequestParametersFrom.JwsSigned)
-            ?.jwsSigned?.header?.certificateChain?.firstOrNull()?.publicKey?.toJsonWebKey()
-        val jsonWebKeySet = clientMetadata?.loadJsonWebKeySet()?.keys?.combine(certKey)
-        val audience = params.extractAudience(clientMetadata)
-        if (!clientIdScheme.isAnyX509()) {
-            params.parameters.verifyRedirectUrl()
-        }
+        val presentationDefinition = params.parameters.loadPresentationDefinition()
 
-        val idToken = buildSignedIdToken(params)?.serialize()
-        val resultContainer = params.parameters.loadPresentationDefinition()?.let { presentationDefinition ->
-            params.parameters.verifyResponseType(presentationDefinition)
-            buildPresentation(params, audience, presentationDefinition, clientMetadata).also { container ->
-                clientMetadata?.vpFormats?.let { supportedFormats ->
-                    container.verifyFormatSupport(supportedFormats)
-                }
-            }
-        }
+        AuthorizationRequestValidator(remoteResourceRetriever).validateAuthorizationRequest(params)
 
-        val vpToken = resultContainer?.presentationResults?.map { it.toJsonPrimitive() }?.singleOrArray()
+        AuthorizationResponsePreparationState(
+            clientMetadata = clientMetadata,
+            presentationDefinition = presentationDefinition,
+        )
+    }
+
+    /**
+     * Finalize the authorization response
+     *
+     * @param request: the RP's [params]
+     * @param preparationState: The preparation state from [startAuthorizationResponsePreparation]
+     * @param inputDescriptorSubmissions: Map from input descriptor ids to [CredentialSubmission]
+     */
+    suspend fun finalizeAuthorizationResponse(
+        request: AuthenticationRequestParametersFrom<*>,
+        preparationState: AuthorizationResponsePreparationState,
+        inputDescriptorSubmissions: Map<String, CredentialSubmission>? = null,
+    ): KmmResult<AuthenticationResponseResult> = catching {
+        val responseParameters = finalizeAuthorizationResponseParameters(
+            params = request,
+            preparationState = preparationState,
+            inputDescriptorSubmissions = inputDescriptorSubmissions,
+        ).getOrThrow()
+        AuthenticationResponseFactory(jwsService).createAuthenticationResponse(
+            request,
+            responseParameters,
+        )
+    }
+
+
+    /**
+     * Finalize the authorization response parameters
+     *
+     * @param request: the RP's [params]
+     * @param preparationState: The preparation state from [startAuthorizationResponsePreparation]
+     * @param inputDescriptorSubmissions: Map from input descriptor ids to [CredentialSubmission]
+     */
+    suspend fun finalizeAuthorizationResponseParameters(
+        params: AuthenticationRequestParametersFrom<*>,
+        preparationState: AuthorizationResponsePreparationState,
+        inputDescriptorSubmissions: Map<String, CredentialSubmission>? = null,
+    ): KmmResult<AuthenticationResponse> = preparationState.catching {
+        val certKey =
+            (params as? AuthenticationRequestParametersFrom.JwsSigned)?.source?.header?.certificateChain?.firstOrNull()?.publicKey?.toJsonWebKey()
+        val clientJsonWebKeySet = clientMetadata?.loadJsonWebKeySet()
+
+        val audience = params.extractAudience(clientJsonWebKeySet)
+
+        val presentationFactory = PresentationFactory(jwsService)
+
+        val idToken = presentationFactory.createSignedIdToken(
+            clock = clock,
+            agentPublicKey = agentPublicKey,
+            parameters = params,
+        ).getOrNull()?.serialize()
+
+        val resultContainer = presentationDefinition?.let {
+            presentationFactory.createPresentationExchangePresentation(
+                holder = holder,
+                params,
+                audience,
+                presentationDefinition,
+                clientMetadata,
+                inputDescriptorSubmissions
+            ).getOrThrow()
+        }
+        val vpToken =
+            resultContainer?.presentationResults?.map { it.toJsonPrimitive() }?.singleOrArray()
         val presentationSubmission = resultContainer?.presentationSubmission
 
         val parameters = AuthenticationResponseParameters(
@@ -333,180 +258,38 @@ class OidcSiopWallet(
             vpToken = vpToken,
             presentationSubmission = presentationSubmission,
         )
-        AuthenticationResponse(parameters, clientMetadata, jsonWebKeySet)
+
+        val jsonWebKeys = clientJsonWebKeySet?.keys?.combine(certKey)
+        AuthenticationResponse(parameters, clientMetadata, jsonWebKeys)
     }
 
-    private fun Holder.PresentationResponseParameters.verifyFormatSupport(supportedFormats: FormatHolder) =
-        presentationSubmission.descriptorMap?.mapIndexed { _, descriptor ->
-            if (supportedFormats.isMissingFormatSupport(descriptor.format)) {
-                Napier.w("Incompatible JWT algorithms for claim format ${descriptor.format}: $supportedFormats")
-                throw OAuth2Exception(Errors.REGISTRATION_VALUE_NOT_SUPPORTED)
-            }
-        }
-
-    private suspend fun buildPresentation(
-        params: AuthenticationRequestParametersFrom,
-        audience: String,
-        presentationDefinition: PresentationDefinition,
-        clientMetadata: RelyingPartyMetadata?
-    ): Holder.PresentationResponseParameters {
-        val nonce = params.parameters.nonce ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-            .also { Napier.w("nonce is null in ${params.parameters}") }
-        return holder.createPresentation(
-            challenge = nonce,
-            audienceId = audience,
-            presentationDefinition = presentationDefinition,
-            fallbackFormatHolder = presentationDefinition.formats ?: clientMetadata?.vpFormats,
-        ).getOrElse {
-            Napier.w("Could not create presentation", it)
-            throw OAuth2Exception(Errors.USER_CANCELLED)
-        }
-    }
-
-    private suspend fun buildSignedIdToken(params: AuthenticationRequestParametersFrom): JwsSigned? {
-        if (params.parameters.responseType?.contains(ID_TOKEN) != true) {
-            return null
-        }
-        val nonce = params.parameters.nonce ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-            .also { Napier.w("nonce is null in ${params.parameters}") }
-        val now = clock.now()
-        // we'll assume jwk-thumbprint
-        val agentJsonWebKey = agentPublicKey.toJsonWebKey()
-        val idToken = IdToken(
-            issuer = agentJsonWebKey.jwkThumbprint,
-            subject = agentJsonWebKey.jwkThumbprint,
-            subjectJwk = agentJsonWebKey,
-            audience = params.parameters.redirectUrl ?: params.parameters.clientId ?: agentJsonWebKey.jwkThumbprint,
-            issuedAt = now,
-            expiration = now + 60.seconds,
-            nonce = nonce,
-        )
-        val jwsPayload = idToken.serialize().encodeToByteArray()
-        val signedIdToken = jwsService.createSignedJwsAddingParams(payload = jwsPayload, addX5c = false).getOrElse {
-            Napier.w("Could not sign id_token", it)
-            throw OAuth2Exception(Errors.USER_CANCELLED)
-        }
-        return signedIdToken
-    }
-
-    private fun AuthenticationRequestParameters.verifyResponseType(presentationDefinition: PresentationDefinition?) {
-        if (responseType == null)
-            throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("response_type is not specified") }
-        if (!responseType.contains(VP_TOKEN) && presentationDefinition == null)
-            throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("vp_token not requested") }
-    }
-
-    private suspend fun AuthenticationRequestParameters.loadPresentationDefinition() =
-        if (responseType?.contains(VP_TOKEN) == true) {
-            presentationDefinition
-                ?: presentationDefinitionUrl?.let {
-                    remoteResourceRetriever.invoke(it)
-                }?.let { PresentationDefinition.deserialize(it).getOrNull() }
-                ?: scope?.split(" ")?.firstNotNullOfOrNull {
-                    scopePresentationDefinitionRetriever?.invoke(it)
-                }
-        } else null
-
-    private fun AuthenticationRequestParameters.verifyRedirectUrl() {
-        if (redirectUrl != null) {
-            if (clientId != redirectUrl)
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id does not match redirect_uri") }
-        }
-    }
-
-    private suspend fun AuthenticationRequestParametersFrom.extractAudience(
-        clientMetadata: RelyingPartyMetadata?
-    ) = clientMetadata?.loadJsonWebKeySet()?.keys?.firstOrNull()?.identifier
-        ?: parameters.clientId
-        ?: parameters.audience
-        ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-            .also { Napier.w("Could not parse audience") }
+    private fun AuthenticationRequestParametersFrom<*>.extractAudience(
+        clientJsonWebKeySet: JsonWebKeySet?,
+    ) = clientJsonWebKeySet?.keys?.firstOrNull()?.identifier ?: parameters.clientId
+    ?: parameters.audience
+    ?: throw OAuth2Exception(Errors.INVALID_REQUEST).also { Napier.w("Could not parse audience") }
 
     private suspend fun RelyingPartyMetadata.loadJsonWebKeySet() =
         this.jsonWebKeySet ?: jsonWebKeySetUrl?.let { remoteResourceRetriever.invoke(it) }
             ?.let { JsonWebKeySet.deserialize(it).getOrNull() }
 
-    private suspend fun AuthenticationRequestParameters.loadClientMetadata() = clientMetadata
-        ?: clientMetadataUri?.let { uri ->
-            remoteResourceRetriever.invoke(uri)?.let { RelyingPartyMetadata.deserialize(it).getOrNull() }
-        } ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-            .also { Napier.w("client metadata is not specified in $this") }
 
-    private fun OpenIdConstants.ClientIdScheme?.isAnyX509() =
-        (this == OpenIdConstants.ClientIdScheme.X509_SAN_DNS) || (this == OpenIdConstants.ClientIdScheme.X509_SAN_URI)
+    private suspend fun AuthenticationRequestParameters.loadPresentationDefinition() =
+        if (responseType?.contains(VP_TOKEN) == true) {
+            presentationDefinition ?: presentationDefinitionUrl?.let {
+                remoteResourceRetriever.invoke(it)
+            }?.let { PresentationDefinition.deserialize(it).getOrNull() } ?: scope?.split(" ")
+                ?.firstNotNullOfOrNull {
+                    scopePresentationDefinitionRetriever.invoke(it)
+                }
+        } else null
 
-    private fun AuthenticationRequestParameters.verifyClientMetadata() {
-        if (clientMetadata == null && clientMetadataUri == null)
-            throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("client_id_scheme is redirect_uri, but metadata is not set") }
-    }
-
-    private fun AuthenticationRequestParametersFrom.verifyClientIdSchemeX509() {
-        val clientIdScheme = parameters.clientIdScheme
-        val responseModeIsDirectPost = parameters.responseMode.isAnyDirectPost()
-        if (this !is AuthenticationRequestParametersFrom.JwsSigned
-            || jwsSigned.header.certificateChain == null
-            || jwsSigned.header.certificateChain!!.isEmpty()
-        ) throw OAuth2Exception(Errors.INVALID_REQUEST)
-            .also { Napier.w("client_id_scheme is $clientIdScheme, but metadata is not set and no x5c certificate chain is present in the original authn request") }
-        //basic checks done
-        val leaf = jwsSigned.header.certificateChain!!.leaf
-        if (leaf.tbsCertificate.extensions == null || leaf.tbsCertificate.extensions!!.isEmpty()) {
-            throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("client_id_scheme is $clientIdScheme, but no extensions were found in the leaf certificate") }
+    private suspend fun AuthenticationRequestParameters.loadClientMetadata() =
+        clientMetadata ?: clientMetadataUri?.let { uri ->
+            remoteResourceRetriever.invoke(uri)
+                ?.let { RelyingPartyMetadata.deserialize(it).getOrNull() }
         }
-        if (clientIdScheme == OpenIdConstants.ClientIdScheme.X509_SAN_DNS) {
-            val dnsNames = leaf.tbsCertificate.subjectAlternativeNames?.dnsNames
-                ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id_scheme is $clientIdScheme, but no dnsNames were found in the leaf certificate") }
-
-            if (!dnsNames.contains(parameters.clientId))
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id_scheme is $clientIdScheme, but client_id does not match any dnsName in the leaf certificate") }
-
-            if (!responseModeIsDirectPost) {
-                val parsedUrl = parameters.redirectUrl?.let { Url(it) }
-                    ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-                        .also { Napier.w("client_id_scheme is $clientIdScheme, but no redirect_url was provided") }
-                //TODO  If the Wallet can establish trust in the Client Identifier authenticated through the certificate it may allow the client to freely choose the redirect_uri value
-                if (parsedUrl.host != parameters.clientId)
-                    throw OAuth2Exception(Errors.INVALID_REQUEST)
-                        .also { Napier.w("client_id_scheme is $clientIdScheme, but no redirect_url was provided") }
-            }
-        } else {
-            val uris = leaf.tbsCertificate.subjectAlternativeNames?.uris
-                ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id_scheme is $clientIdScheme, but no URIs were found in the leaf certificate") }
-            if (!uris.contains(parameters.clientId))
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id_scheme is $clientIdScheme, but client_id does not match any URIs in the leaf certificate") }
-
-            if (parameters.clientId != parameters.redirectUrl)
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id_scheme is $clientIdScheme, but client_id does not match redirect_uri") }
-        }
-    }
-
-    private fun OpenIdConstants.ResponseMode?.isAnyDirectPost() = (this == DIRECT_POST) || (this == DIRECT_POST_JWT)
-
-    private fun FormatHolder.isMissingFormatSupport(claimFormatEnum: ClaimFormatEnum) = when (claimFormatEnum) {
-        ClaimFormatEnum.JWT_VP -> jwtVp?.algorithms?.let { !it.contains(jwsService.algorithm.identifier) } ?: false
-        ClaimFormatEnum.JWT_SD -> jwtSd?.algorithms?.let { !it.contains(jwsService.algorithm.identifier) } ?: false
-        ClaimFormatEnum.MSO_MDOC -> msoMdoc?.algorithms?.let { !it.contains(jwsService.algorithm.identifier) } ?: false
-        else -> false
-    }
-
-    private fun AuthenticationRequestParameters.verifyResponseModeDirectPost() {
-        if (redirectUrl != null)
-            throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("response_mode is $responseMode, but redirect_url is set") }
-        if (responseUrl == null)
-            throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("response_mode is $responseMode, but response_url is not set") }
-    }
+        ?: throw OAuth2Exception(Errors.INVALID_REQUEST).also { Napier.w("client metadata is not specified in $this") }
 
     private fun Holder.CreatePresentationResult.toJsonPrimitive() = when (this) {
         is Holder.CreatePresentationResult.Signed -> {
@@ -530,12 +313,11 @@ class OidcSiopWallet(
         }
     }
 
-    private fun List<JsonPrimitive>.singleOrArray() =
-        if (size == 1) {
-            this[0]
-        } else buildJsonArray {
-            forEach { add(it) }
-        }
+    private fun List<JsonPrimitive>.singleOrArray() = if (size == 1) {
+        this[0]
+    } else buildJsonArray {
+        forEach { add(it) }
+    }
 }
 
 /**

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopWallet.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopWallet.kt
@@ -151,23 +151,19 @@ class OidcSiopWallet(
      */
     suspend fun createAuthnResponseParams(
         params: AuthenticationRequestParametersFrom
-    ): KmmResult<AuthenticationResponse> = catching {
-        finalizeAuthorizationResponseParameters(
-            params = params,
-            preparationState = startAuthorizationResponsePreparation(params).getOrThrow(),
-        ).getOrThrow()
-    }
+    ): KmmResult<AuthenticationResponse> = finalizeAuthorizationResponseParameters(
+        params = params,
+        preparationState = startAuthorizationResponsePreparation(params).getOrThrow(),
+    )
 
     /**
      * Starts the authorization response building process from the RP's [params]
      */
     suspend fun startAuthorizationResponsePreparation(
         input: String,
-    ): KmmResult<AuthorizationResponsePreparationState> = catching {
-        startAuthorizationResponsePreparation(
-            parseAuthenticationRequestParameters(input).getOrThrow()
-        ).getOrThrow()
-    }
+    ): KmmResult<AuthorizationResponsePreparationState> = startAuthorizationResponsePreparation(
+        params = parseAuthenticationRequestParameters(input).getOrThrow()
+    )
 
     /**
      * Starts the authorization response building process from the RP's [params]

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthenticationRequestParser.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthenticationRequestParser.kt
@@ -47,7 +47,7 @@ internal class AuthenticationRequestParser(
      * to create [AuthenticationResponseParameters] that can be sent back to the Verifier, see
      * [AuthenticationResponseResult].
      */
-    suspend fun parseAuthenticationRequestParameters(input: String): KmmResult<AuthenticationRequestParametersFrom<*>> = catching {
+    suspend fun parseAuthenticationRequestParameters(input: String): KmmResult<AuthenticationRequestParametersFrom> = catching {
         // maybe it is a request JWS
         val parsedParams = kotlin.run { parseRequestObjectJws(input) }
             ?: kotlin.runCatching { // maybe it's in the URL parameters
@@ -69,7 +69,7 @@ internal class AuthenticationRequestParser(
         extractedParams
     }
 
-    private suspend fun extractRequestObject(params: AuthenticationRequestParameters): AuthenticationRequestParametersFrom<*>? =
+    private suspend fun extractRequestObject(params: AuthenticationRequestParameters): AuthenticationRequestParametersFrom? =
         params.request?.let { requestObject ->
             parseRequestObjectJws(requestObject)
         } ?: params.requestUri?.let { uri ->

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthenticationRequestParser.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthenticationRequestParser.kt
@@ -57,7 +57,7 @@ internal class AuthenticationRequestParser(
                     AuthenticationRequestParametersFrom.Uri(it, params)
                 }
             }.onFailure { it.printStackTrace() }.getOrNull()
-            ?: kotlin.runCatching {  // maybe it is already a JSON string
+            ?: catching {  // maybe it is already a JSON string
                 val params = AuthenticationRequestParameters.deserialize(input).getOrThrow()
                 AuthenticationRequestParametersFrom.Json(input, params)
             }.getOrNull()

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthenticationRequestParser.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthenticationRequestParser.kt
@@ -1,0 +1,93 @@
+package at.asitplus.wallet.lib.oidc.helper
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import at.asitplus.crypto.datatypes.jws.JsonWebKeySet
+import at.asitplus.crypto.datatypes.jws.JwsSigned
+import at.asitplus.wallet.lib.oidc.AuthenticationRequestParameters
+import at.asitplus.wallet.lib.oidc.AuthenticationRequestParametersFrom
+import at.asitplus.wallet.lib.oidc.AuthenticationResponseParameters
+import at.asitplus.wallet.lib.oidc.AuthenticationResponseResult
+import at.asitplus.wallet.lib.oidc.OpenIdConstants
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.Errors
+import at.asitplus.wallet.lib.oidc.RemoteResourceRetrieverFunction
+import at.asitplus.wallet.lib.oidc.RequestObjectJwsVerifier
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
+import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
+import io.github.aakira.napier.Napier
+import io.ktor.http.Url
+import io.ktor.util.flattenEntries
+
+internal class AuthenticationRequestParser(
+    /**
+     * Need to implement if resources are defined by reference, i.e. the URL for a [JsonWebKeySet],
+     * or the authentication request itself as `request_uri`, or `presentation_definition_uri`.
+     * Implementations need to fetch the url passed in, and return either the body, if there is one,
+     * or the HTTP header `Location`, i.e. if the server sends the request object as a redirect.
+     */
+    private val remoteResourceRetriever: RemoteResourceRetrieverFunction,
+    /**
+     * Need to verify the request object serialized as a JWS,
+     * which may be signed with a pre-registered key (see [OpenIdConstants.ClientIdScheme.PRE_REGISTERED]).
+     */
+    private val requestObjectJwsVerifier: RequestObjectJwsVerifier,
+) {
+    companion object {
+        fun createWithDefaults(
+            remoteResourceRetriever: RemoteResourceRetrieverFunction? = null,
+            requestObjectJwsVerifier: RequestObjectJwsVerifier? = null,
+        ) = AuthenticationRequestParser(
+            remoteResourceRetriever = remoteResourceRetriever ?: { null },
+            requestObjectJwsVerifier = requestObjectJwsVerifier ?: RequestObjectJwsVerifier { _, _ -> true },
+        )
+    }
+
+    /**
+     * Pass in the URL sent by the Verifier (containing the [AuthenticationRequestParameters] as query parameters),
+     * to create [AuthenticationResponseParameters] that can be sent back to the Verifier, see
+     * [AuthenticationResponseResult].
+     */
+    suspend fun parseAuthenticationRequestParameters(input: String): KmmResult<AuthenticationRequestParametersFrom<*>> = catching {
+        // maybe it is a request JWS
+        val parsedParams = kotlin.run { parseRequestObjectJws(input) }
+            ?: kotlin.runCatching { // maybe it's in the URL parameters
+                Url(input).let {
+                    val params = it.parameters.flattenEntries().toMap()
+                        .decodeFromUrlQuery<AuthenticationRequestParameters>()
+                    AuthenticationRequestParametersFrom.Uri(it, params)
+                }
+            }.onFailure { it.printStackTrace() }.getOrNull()
+            ?: kotlin.runCatching {  // maybe it is already a JSON string
+                val params = AuthenticationRequestParameters.deserialize(input).getOrThrow()
+                AuthenticationRequestParametersFrom.Json(input, params)
+            }.getOrNull()
+            ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
+                .also { Napier.w("Could not parse authentication request: $input") }
+
+        val extractedParams = parsedParams.let { extractRequestObject(it.parameters) ?: it }
+            .also { Napier.i("Parsed authentication request: $it") }
+        extractedParams
+    }
+
+    private suspend fun extractRequestObject(params: AuthenticationRequestParameters): AuthenticationRequestParametersFrom<*>? =
+        params.request?.let { requestObject ->
+            parseRequestObjectJws(requestObject)
+        } ?: params.requestUri?.let { uri ->
+            remoteResourceRetriever.invoke(uri)
+                ?.let { parseAuthenticationRequestParameters(it).getOrNull() }
+        }
+
+    private fun parseRequestObjectJws(requestObject: String): AuthenticationRequestParametersFrom.JwsSigned? {
+        return JwsSigned.parse(requestObject).getOrNull()?.let { jws ->
+            val params = AuthenticationRequestParameters.deserialize(jws.payload.decodeToString()).getOrElse {
+                return null
+                    .apply { Napier.w("parseRequestObjectJws: Deserialization failed", it) }
+            }
+            if (requestObjectJwsVerifier.invoke(jws, params))
+                AuthenticationRequestParametersFrom.JwsSigned(jws, params)
+            else null
+                .also { Napier.w("parseRequestObjectJws: Signature not verified for $jws") }
+        }
+    }
+
+}

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthenticationResponseFactory.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthenticationResponseFactory.kt
@@ -1,0 +1,134 @@
+package at.asitplus.wallet.lib.oidc.helper
+
+import at.asitplus.crypto.datatypes.jws.JweHeader
+import at.asitplus.wallet.lib.jws.JwsService
+import at.asitplus.wallet.lib.oidc.AuthenticationRequestParametersFrom
+import at.asitplus.wallet.lib.oidc.AuthenticationResponse
+import at.asitplus.wallet.lib.oidc.AuthenticationResponseParameters
+import at.asitplus.wallet.lib.oidc.AuthenticationResponseResult
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.Errors
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.ResponseMode.DIRECT_POST
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.ResponseMode.DIRECT_POST_JWT
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.ResponseMode.FRAGMENT
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.ResponseMode.OTHER
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.ResponseMode.QUERY
+import at.asitplus.wallet.lib.oidc.RelyingPartyMetadata
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
+import at.asitplus.wallet.lib.oidvci.encodeToParameters
+import at.asitplus.wallet.lib.oidvci.formUrlEncode
+import io.github.aakira.napier.Napier
+import io.ktor.http.URLBuilder
+import io.matthewnelson.encoding.base64.Base64
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToByteArray
+import kotlin.random.Random
+
+internal class AuthenticationResponseFactory(
+    val jwsService: JwsService,
+) {
+    internal suspend fun createAuthenticationResponse(
+        request: AuthenticationRequestParametersFrom<*>,
+        response: AuthenticationResponse,
+    ) = when (request.parameters.responseMode) {
+        DIRECT_POST -> authnResponseDirectPost(request, response)
+        DIRECT_POST_JWT -> authnResponseDirectPostJwt(request, response)
+        QUERY -> authnResponseQuery(request, response)
+        FRAGMENT, null -> authnResponseFragment(request, response)
+        is OTHER -> TODO()
+    }
+
+    /**
+     * Per OID4VP, the response may either be signed, or encrypted (never signed and encrypted!)
+     */
+    internal suspend fun authnResponseDirectPostJwt(
+        request: AuthenticationRequestParametersFrom<*>,
+        response: AuthenticationResponse,
+    ): AuthenticationResponseResult.Post {
+        val url = request.parameters.responseUrl ?: request.parameters.redirectUrl
+        ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
+        val responseSerialized = buildJarm(request, response)
+        val jarm = AuthenticationResponseParameters(response = responseSerialized)
+        return AuthenticationResponseResult.Post(url, jarm.encodeToParameters())
+    }
+
+    internal fun authnResponseDirectPost(
+        request: AuthenticationRequestParametersFrom<*>,
+        response: AuthenticationResponse,
+    ): AuthenticationResponseResult.Post {
+        val url = request.parameters.responseUrl ?: request.parameters.redirectUrl
+        ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
+        return AuthenticationResponseResult.Post(url, response.params.encodeToParameters())
+    }
+
+    internal fun authnResponseQuery(
+        request: AuthenticationRequestParametersFrom<*>,
+        response: AuthenticationResponse,
+    ): AuthenticationResponseResult.Redirect {
+        if (request.parameters.redirectUrl == null) throw OAuth2Exception(Errors.INVALID_REQUEST)
+        val url = URLBuilder(request.parameters.redirectUrl).apply {
+            response.params.encodeToParameters().forEach {
+                this.parameters.append(it.key, it.value)
+            }
+        }.buildString()
+        return AuthenticationResponseResult.Redirect(url, response.params)
+    }
+
+    /**
+     * That's the default for `id_token` and `vp_token`
+     */
+    internal fun authnResponseFragment(
+        request: AuthenticationRequestParametersFrom<*>,
+        response: AuthenticationResponse,
+    ): AuthenticationResponseResult.Redirect {
+        if (request.parameters.redirectUrl == null) {
+            throw OAuth2Exception(Errors.INVALID_REQUEST)
+        }
+        val url = URLBuilder(request.parameters.redirectUrl).apply {
+            encodedFragment = response.params.encodeToParameters().formUrlEncode()
+        }.buildString()
+        return AuthenticationResponseResult.Redirect(url, response.params)
+    }
+
+
+    private suspend fun buildJarm(
+        request: AuthenticationRequestParametersFrom<*>,
+        response: AuthenticationResponse,
+    ) =
+        if (response.clientMetadata != null && response.jsonWebKeys != null && response.clientMetadata.requestsEncryption()) {
+            val alg = response.clientMetadata.authorizationEncryptedResponseAlg!!
+            val enc = response.clientMetadata.authorizationEncryptedResponseEncoding!!
+            val jwk = response.jsonWebKeys.first()
+            val nonce =
+                runCatching { request.parameters.nonce?.decodeToByteArray(Base64()) }.getOrNull()
+                    ?: runCatching { request.parameters.nonce?.encodeToByteArray() }.getOrNull()
+                    ?: Random.Default.nextBytes(16)
+            val payload = response.params.serialize().encodeToByteArray()
+            jwsService.encryptJweObject(
+                header = JweHeader(
+                    algorithm = alg,
+                    encryption = enc,
+                    type = null,
+                    agreementPartyVInfo = nonce.encodeToByteArray(Base64()),
+                    agreementPartyUInfo = Random.nextBytes(16),
+                    keyId = jwk.keyId,
+                ),
+                payload = payload,
+                recipientKey = jwk,
+                jweAlgorithm = alg,
+                jweEncryption = enc,
+            ).map { it.serialize() }.getOrElse {
+                Napier.w("buildJarm error", it)
+                throw OAuth2Exception(Errors.INVALID_REQUEST)
+            }
+        } else {
+            jwsService.createSignedJwsAddingParams(
+                payload = response.params.serialize().encodeToByteArray(), addX5c = false
+            ).map { it.serialize() }.getOrElse {
+                Napier.w("buildJarm error", it)
+                throw OAuth2Exception(Errors.INVALID_REQUEST)
+            }
+        }
+
+    private fun RelyingPartyMetadata.requestsEncryption() =
+        authorizationEncryptedResponseAlg != null && authorizationEncryptedResponseEncoding != null
+}

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthorizationRequestValidator.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthorizationRequestValidator.kt
@@ -17,37 +17,42 @@ import io.ktor.http.Url
 internal class AuthorizationRequestValidator(
     val remoteResourceRetriever: RemoteResourceRetrieverFunction
 ) {
-    fun validateAuthorizationRequest(params: AuthenticationRequestParametersFrom<*>) {
-        if (params.parameters.responseType == null
-            || (!params.parameters.responseType.contains(ID_TOKEN)
-                    && !params.parameters.responseType.contains(VP_TOKEN))
-        ) {
-            Napier.w("createAuthnResponse: Unknown response_type ${params.parameters.responseType}")
+    fun validateAuthorizationRequest(request: AuthenticationRequestParametersFrom) {
+        request.parameters.responseType?.let {
+            if (!it.contains(ID_TOKEN) && !it.contains(VP_TOKEN)) {
+                Napier.w("createAuthnResponse: Unknown response_type $it")
+                throw OAuth2Exception(Errors.INVALID_REQUEST)
+            }
+        } ?: run {
+            Napier.w("createAuthnResponse: response_type null in ${request.parameters}")
             throw OAuth2Exception(Errors.INVALID_REQUEST)
         }
 
-        val clientIdScheme = params.parameters.clientIdScheme
+
+        val clientIdScheme = request.parameters.clientIdScheme
         if (clientIdScheme == OpenIdConstants.ClientIdScheme.REDIRECT_URI) {
-            params.parameters.verifyClientMetadata()
+            request.parameters.verifyClientMetadata()
         }
-        if (params.parameters.responseMode.isAnyDirectPost()) {
-            params.parameters.verifyResponseModeDirectPost()
+        if (request.parameters.responseMode.isAnyDirectPost()) {
+            request.parameters.verifyResponseModeDirectPost()
         }
         if (clientIdScheme.isAnyX509()) {
-            params.verifyClientIdSchemeX509()
+            request.verifyClientIdSchemeX509()
         }
 
         if (!clientIdScheme.isAnyX509()) {
-            params.parameters.verifyRedirectUrl()
+            request.parameters.verifyRedirectUrl()
         }
     }
 
 
     private fun AuthenticationRequestParameters.verifyRedirectUrl() {
         if (redirectUrl != null) {
-            if (clientId != redirectUrl)
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id does not match redirect_uri") }
+            if (clientId != redirectUrl) throw OAuth2Exception(Errors.INVALID_REQUEST).also {
+                    Napier.w(
+                        "client_id does not match redirect_uri"
+                    )
+                }
         }
     }
 
@@ -55,54 +60,62 @@ internal class AuthorizationRequestValidator(
         (this == OpenIdConstants.ClientIdScheme.X509_SAN_DNS) || (this == OpenIdConstants.ClientIdScheme.X509_SAN_URI)
 
     private fun AuthenticationRequestParameters.verifyClientMetadata() {
-        if (clientMetadata == null && clientMetadataUri == null)
-            throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("client_id_scheme is redirect_uri, but metadata is not set") }
+        if (clientMetadata == null && clientMetadataUri == null) throw OAuth2Exception(Errors.INVALID_REQUEST).also {
+                Napier.w(
+                    "client_id_scheme is redirect_uri, but metadata is not set"
+                )
+            }
     }
 
-    private fun AuthenticationRequestParametersFrom<*>.verifyClientIdSchemeX509() {
+    private fun AuthenticationRequestParametersFrom.verifyClientIdSchemeX509() {
         val clientIdScheme = parameters.clientIdScheme
         val responseModeIsDirectPost = parameters.responseMode.isAnyDirectPost()
-        if (this !is AuthenticationRequestParametersFrom.JwsSigned
-            || source.header.certificateChain == null
-            || source.header.certificateChain!!.isEmpty()
-        ) throw OAuth2Exception(Errors.INVALID_REQUEST)
-            .also { Napier.w("client_id_scheme is $clientIdScheme, but metadata is not set and no x5c certificate chain is present in the original authn request") }
+        if (this !is AuthenticationRequestParametersFrom.JwsSigned || jwsSigned.header.certificateChain == null || jwsSigned.header.certificateChain!!.isEmpty()) throw OAuth2Exception(
+            Errors.INVALID_REQUEST
+        ).also { Napier.w("client_id_scheme is $clientIdScheme, but metadata is not set and no x5c certificate chain is present in the original authn request") }
         //basic checks done
-        val leaf = source.header.certificateChain!!.leaf
+        val leaf = jwsSigned.header.certificateChain!!.leaf
         if (leaf.tbsCertificate.extensions == null || leaf.tbsCertificate.extensions!!.isEmpty()) {
-            throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("client_id_scheme is $clientIdScheme, but no extensions were found in the leaf certificate") }
+            throw OAuth2Exception(Errors.INVALID_REQUEST).also { Napier.w("client_id_scheme is $clientIdScheme, but no extensions were found in the leaf certificate") }
         }
         if (clientIdScheme == OpenIdConstants.ClientIdScheme.X509_SAN_DNS) {
-            val dnsNames = leaf.tbsCertificate.subjectAlternativeNames?.dnsNames
-                ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id_scheme is $clientIdScheme, but no dnsNames were found in the leaf certificate") }
+            val dnsNames =
+                leaf.tbsCertificate.subjectAlternativeNames?.dnsNames ?: throw OAuth2Exception(
+                    Errors.INVALID_REQUEST
+                ).also { Napier.w("client_id_scheme is $clientIdScheme, but no dnsNames were found in the leaf certificate") }
 
-            if (!dnsNames.contains(parameters.clientId))
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id_scheme is $clientIdScheme, but client_id does not match any dnsName in the leaf certificate") }
+            if (!dnsNames.contains(parameters.clientId)) throw OAuth2Exception(Errors.INVALID_REQUEST).also {
+                    Napier.w(
+                        "client_id_scheme is $clientIdScheme, but client_id does not match any dnsName in the leaf certificate"
+                    )
+                }
 
             if (!responseModeIsDirectPost) {
-                val parsedUrl = parameters.redirectUrl?.let { Url(it) }
-                    ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-                        .also { Napier.w("client_id_scheme is $clientIdScheme, but no redirect_url was provided") }
+                val parsedUrl = parameters.redirectUrl?.let { Url(it) } ?: throw OAuth2Exception(
+                    Errors.INVALID_REQUEST
+                ).also { Napier.w("client_id_scheme is $clientIdScheme, but no redirect_url was provided") }
                 //TODO  If the Wallet can establish trust in the Client Identifier authenticated through the certificate it may allow the client to freely choose the redirect_uri value
-                if (parsedUrl.host != parameters.clientId)
-                    throw OAuth2Exception(Errors.INVALID_REQUEST)
-                        .also { Napier.w("client_id_scheme is $clientIdScheme, but no redirect_url was provided") }
+                if (parsedUrl.host != parameters.clientId) throw OAuth2Exception(Errors.INVALID_REQUEST).also {
+                        Napier.w(
+                            "client_id_scheme is $clientIdScheme, but no redirect_url was provided"
+                        )
+                    }
             }
         } else {
-            val uris = leaf.tbsCertificate.subjectAlternativeNames?.uris
-                ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id_scheme is $clientIdScheme, but no URIs were found in the leaf certificate") }
-            if (!uris.contains(parameters.clientId))
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id_scheme is $clientIdScheme, but client_id does not match any URIs in the leaf certificate") }
+            val uris = leaf.tbsCertificate.subjectAlternativeNames?.uris ?: throw OAuth2Exception(
+                Errors.INVALID_REQUEST
+            ).also { Napier.w("client_id_scheme is $clientIdScheme, but no URIs were found in the leaf certificate") }
+            if (!uris.contains(parameters.clientId)) throw OAuth2Exception(Errors.INVALID_REQUEST).also {
+                    Napier.w(
+                        "client_id_scheme is $clientIdScheme, but client_id does not match any URIs in the leaf certificate"
+                    )
+                }
 
-            if (parameters.clientId != parameters.redirectUrl)
-                throw OAuth2Exception(Errors.INVALID_REQUEST)
-                    .also { Napier.w("client_id_scheme is $clientIdScheme, but client_id does not match redirect_uri") }
+            if (parameters.clientId != parameters.redirectUrl) throw OAuth2Exception(Errors.INVALID_REQUEST).also {
+                    Napier.w(
+                        "client_id_scheme is $clientIdScheme, but client_id does not match redirect_uri"
+                    )
+                }
         }
     }
 
@@ -110,11 +123,7 @@ internal class AuthorizationRequestValidator(
         (this == DIRECT_POST) || (this == DIRECT_POST_JWT)
 
     private fun AuthenticationRequestParameters.verifyResponseModeDirectPost() {
-        if (redirectUrl != null)
-            throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("response_mode is $responseMode, but redirect_url is set") }
-        if (responseUrl == null)
-            throw OAuth2Exception(Errors.INVALID_REQUEST)
-                .also { Napier.w("response_mode is $responseMode, but response_url is not set") }
+        if (redirectUrl != null) throw OAuth2Exception(Errors.INVALID_REQUEST).also { Napier.w("response_mode is $responseMode, but redirect_url is set") }
+        if (responseUrl == null) throw OAuth2Exception(Errors.INVALID_REQUEST).also { Napier.w("response_mode is $responseMode, but response_url is not set") }
     }
 }

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthorizationRequestValidator.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthorizationRequestValidator.kt
@@ -1,0 +1,120 @@
+package at.asitplus.wallet.lib.oidc.helper
+
+import at.asitplus.crypto.datatypes.pki.leaf
+import at.asitplus.wallet.lib.oidc.AuthenticationRequestParameters
+import at.asitplus.wallet.lib.oidc.AuthenticationRequestParametersFrom
+import at.asitplus.wallet.lib.oidc.OpenIdConstants
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.Errors
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.ID_TOKEN
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.ResponseMode.DIRECT_POST
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.ResponseMode.DIRECT_POST_JWT
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.VP_TOKEN
+import at.asitplus.wallet.lib.oidc.RemoteResourceRetrieverFunction
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
+import io.github.aakira.napier.Napier
+import io.ktor.http.Url
+
+internal class AuthorizationRequestValidator(
+    val remoteResourceRetriever: RemoteResourceRetrieverFunction
+) {
+    fun validateAuthorizationRequest(params: AuthenticationRequestParametersFrom<*>) {
+        if (params.parameters.responseType == null
+            || (!params.parameters.responseType.contains(ID_TOKEN)
+                    && !params.parameters.responseType.contains(VP_TOKEN))
+        ) {
+            Napier.w("createAuthnResponse: Unknown response_type ${params.parameters.responseType}")
+            throw OAuth2Exception(Errors.INVALID_REQUEST)
+        }
+
+        val clientIdScheme = params.parameters.clientIdScheme
+        if (clientIdScheme == OpenIdConstants.ClientIdScheme.REDIRECT_URI) {
+            params.parameters.verifyClientMetadata()
+        }
+        if (params.parameters.responseMode.isAnyDirectPost()) {
+            params.parameters.verifyResponseModeDirectPost()
+        }
+        if (clientIdScheme.isAnyX509()) {
+            params.verifyClientIdSchemeX509()
+        }
+
+        if (!clientIdScheme.isAnyX509()) {
+            params.parameters.verifyRedirectUrl()
+        }
+    }
+
+
+    private fun AuthenticationRequestParameters.verifyRedirectUrl() {
+        if (redirectUrl != null) {
+            if (clientId != redirectUrl)
+                throw OAuth2Exception(Errors.INVALID_REQUEST)
+                    .also { Napier.w("client_id does not match redirect_uri") }
+        }
+    }
+
+    private fun OpenIdConstants.ClientIdScheme?.isAnyX509() =
+        (this == OpenIdConstants.ClientIdScheme.X509_SAN_DNS) || (this == OpenIdConstants.ClientIdScheme.X509_SAN_URI)
+
+    private fun AuthenticationRequestParameters.verifyClientMetadata() {
+        if (clientMetadata == null && clientMetadataUri == null)
+            throw OAuth2Exception(Errors.INVALID_REQUEST)
+                .also { Napier.w("client_id_scheme is redirect_uri, but metadata is not set") }
+    }
+
+    private fun AuthenticationRequestParametersFrom<*>.verifyClientIdSchemeX509() {
+        val clientIdScheme = parameters.clientIdScheme
+        val responseModeIsDirectPost = parameters.responseMode.isAnyDirectPost()
+        if (this !is AuthenticationRequestParametersFrom.JwsSigned
+            || source.header.certificateChain == null
+            || source.header.certificateChain!!.isEmpty()
+        ) throw OAuth2Exception(Errors.INVALID_REQUEST)
+            .also { Napier.w("client_id_scheme is $clientIdScheme, but metadata is not set and no x5c certificate chain is present in the original authn request") }
+        //basic checks done
+        val leaf = source.header.certificateChain!!.leaf
+        if (leaf.tbsCertificate.extensions == null || leaf.tbsCertificate.extensions!!.isEmpty()) {
+            throw OAuth2Exception(Errors.INVALID_REQUEST)
+                .also { Napier.w("client_id_scheme is $clientIdScheme, but no extensions were found in the leaf certificate") }
+        }
+        if (clientIdScheme == OpenIdConstants.ClientIdScheme.X509_SAN_DNS) {
+            val dnsNames = leaf.tbsCertificate.subjectAlternativeNames?.dnsNames
+                ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
+                    .also { Napier.w("client_id_scheme is $clientIdScheme, but no dnsNames were found in the leaf certificate") }
+
+            if (!dnsNames.contains(parameters.clientId))
+                throw OAuth2Exception(Errors.INVALID_REQUEST)
+                    .also { Napier.w("client_id_scheme is $clientIdScheme, but client_id does not match any dnsName in the leaf certificate") }
+
+            if (!responseModeIsDirectPost) {
+                val parsedUrl = parameters.redirectUrl?.let { Url(it) }
+                    ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
+                        .also { Napier.w("client_id_scheme is $clientIdScheme, but no redirect_url was provided") }
+                //TODO  If the Wallet can establish trust in the Client Identifier authenticated through the certificate it may allow the client to freely choose the redirect_uri value
+                if (parsedUrl.host != parameters.clientId)
+                    throw OAuth2Exception(Errors.INVALID_REQUEST)
+                        .also { Napier.w("client_id_scheme is $clientIdScheme, but no redirect_url was provided") }
+            }
+        } else {
+            val uris = leaf.tbsCertificate.subjectAlternativeNames?.uris
+                ?: throw OAuth2Exception(Errors.INVALID_REQUEST)
+                    .also { Napier.w("client_id_scheme is $clientIdScheme, but no URIs were found in the leaf certificate") }
+            if (!uris.contains(parameters.clientId))
+                throw OAuth2Exception(Errors.INVALID_REQUEST)
+                    .also { Napier.w("client_id_scheme is $clientIdScheme, but client_id does not match any URIs in the leaf certificate") }
+
+            if (parameters.clientId != parameters.redirectUrl)
+                throw OAuth2Exception(Errors.INVALID_REQUEST)
+                    .also { Napier.w("client_id_scheme is $clientIdScheme, but client_id does not match redirect_uri") }
+        }
+    }
+
+    private fun OpenIdConstants.ResponseMode?.isAnyDirectPost() =
+        (this == DIRECT_POST) || (this == DIRECT_POST_JWT)
+
+    private fun AuthenticationRequestParameters.verifyResponseModeDirectPost() {
+        if (redirectUrl != null)
+            throw OAuth2Exception(Errors.INVALID_REQUEST)
+                .also { Napier.w("response_mode is $responseMode, but redirect_url is set") }
+        if (responseUrl == null)
+            throw OAuth2Exception(Errors.INVALID_REQUEST)
+                .also { Napier.w("response_mode is $responseMode, but response_url is not set") }
+    }
+}

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthorizationResponsePreparationState.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/AuthorizationResponsePreparationState.kt
@@ -1,0 +1,11 @@
+package at.asitplus.wallet.lib.oidc.helpers
+
+import at.asitplus.wallet.lib.data.dif.PresentationDefinition
+import at.asitplus.wallet.lib.oidc.RelyingPartyMetadata
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AuthorizationResponsePreparationState(
+    val presentationDefinition: PresentationDefinition?,
+    val clientMetadata: RelyingPartyMetadata?,
+)

--- a/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/PresentationFactory.kt
+++ b/vclib-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidc/helper/PresentationFactory.kt
@@ -1,0 +1,194 @@
+package at.asitplus.wallet.lib.oidc.helper
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import at.asitplus.crypto.datatypes.CryptoPublicKey
+import at.asitplus.crypto.datatypes.jws.JwsSigned
+import at.asitplus.crypto.datatypes.jws.toJsonWebKey
+import at.asitplus.wallet.lib.agent.CredentialSubmission
+import at.asitplus.wallet.lib.agent.Holder
+import at.asitplus.wallet.lib.agent.toDefaultSubmission
+import at.asitplus.wallet.lib.data.dif.ClaimFormatEnum
+import at.asitplus.wallet.lib.data.dif.FormatHolder
+import at.asitplus.wallet.lib.data.dif.PresentationDefinition
+import at.asitplus.wallet.lib.data.dif.PresentationSubmissionValidator
+import at.asitplus.wallet.lib.jws.JwsService
+import at.asitplus.wallet.lib.oidc.AuthenticationRequestParameters
+import at.asitplus.wallet.lib.oidc.AuthenticationRequestParametersFrom
+import at.asitplus.wallet.lib.oidc.IdToken
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.Errors
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.ID_TOKEN
+import at.asitplus.wallet.lib.oidc.OpenIdConstants.VP_TOKEN
+import at.asitplus.wallet.lib.oidc.RelyingPartyMetadata
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception
+import io.github.aakira.napier.Napier
+import kotlinx.datetime.Clock
+import kotlin.time.Duration.Companion.seconds
+
+internal class PresentationFactory(
+    val jwsService: JwsService,
+) {
+    suspend fun createPresentationExchangePresentation(
+        holder: Holder,
+        params: AuthenticationRequestParametersFrom<*>,
+        audience: String,
+        presentationDefinition: PresentationDefinition,
+        clientMetadata: RelyingPartyMetadata?,
+        inputDescriptorSubmissions: Map<String, CredentialSubmission>? = null,
+    ): KmmResult<Holder.PresentationResponseParameters> = catching {
+        params.parameters.verifyResponseType(presentationDefinition)
+        if (params.parameters.nonce == null) {
+            Napier.w("nonce is null in ${params.parameters}")
+            throw OAuth2Exception(Errors.INVALID_REQUEST)
+        }
+        val credentialSubmissions = inputDescriptorSubmissions
+            ?: holder.matchInputDescriptorsAgainstCredentialStore(
+                inputDescriptors = presentationDefinition.inputDescriptors,
+                fallbackFormatHolder = presentationDefinition.formats ?: clientMetadata?.vpFormats,
+            ).getOrThrow().toDefaultSubmission()
+
+        presentationDefinition.validateSubmission(
+            holder = holder,
+            clientMetadata = clientMetadata,
+            credentialSubmissions = credentialSubmissions
+        )
+
+        holder.createPresentation(
+            challenge = params.parameters.nonce,
+            audienceId = audience,
+            presentationDefinitionId = presentationDefinition.id,
+            presentationSubmissionSelection = credentialSubmissions,
+        ).getOrElse {
+            Napier.w("Could not create presentation", it)
+            throw OAuth2Exception(Errors.USER_CANCELLED)
+        }.also { container ->
+            clientMetadata?.vpFormats?.let { supportedFormats ->
+                container.verifyFormatSupport(supportedFormats)
+            }
+        }
+    }
+
+
+    suspend fun createSignedIdToken(
+        clock: Clock,
+        agentPublicKey: CryptoPublicKey,
+        parameters: AuthenticationRequestParametersFrom<*>,
+    ): KmmResult<JwsSigned?> = catching {
+        if (parameters.parameters.responseType?.contains(ID_TOKEN) != true) {
+            return@catching null
+        }
+        if (parameters.parameters.nonce == null) {
+            Napier.w("nonce is null in ${parameters.parameters}")
+            throw OAuth2Exception(Errors.INVALID_REQUEST)
+        }
+        val now = clock.now()
+        // we'll assume jwk-thumbprint
+        val agentJsonWebKey = agentPublicKey.toJsonWebKey()
+        val idToken = IdToken(
+            issuer = agentJsonWebKey.jwkThumbprint,
+            subject = agentJsonWebKey.jwkThumbprint,
+            subjectJwk = agentJsonWebKey,
+            audience = parameters.parameters.redirectUrl ?: parameters.parameters.clientId
+            ?: agentJsonWebKey.jwkThumbprint,
+            issuedAt = now,
+            expiration = now + 60.seconds,
+            nonce = parameters.parameters.nonce,
+        )
+        val jwsPayload = idToken.serialize().encodeToByteArray()
+        val signedIdToken =
+            jwsService.createSignedJwsAddingParams(payload = jwsPayload, addX5c = false).getOrElse {
+                Napier.w("Could not sign id_token", it)
+                throw OAuth2Exception(Errors.USER_CANCELLED)
+            }
+        return@catching signedIdToken
+    }
+
+
+    private fun AuthenticationRequestParameters.verifyResponseType(presentationDefinition: PresentationDefinition?) {
+        if (responseType == null)
+            throw OAuth2Exception(Errors.INVALID_REQUEST)
+                .also { Napier.w("response_type is not specified") }
+        if (!responseType.contains(VP_TOKEN) && presentationDefinition == null)
+            throw OAuth2Exception(Errors.INVALID_REQUEST)
+                .also { Napier.w("vp_token not requested") }
+    }
+
+
+    private fun PresentationDefinition.validateSubmission(
+        holder: Holder,
+        clientMetadata: RelyingPartyMetadata?,
+        credentialSubmissions: Map<String, CredentialSubmission>,
+    ) {
+        val isValidSubmission =
+            PresentationSubmissionValidator.createInstance(this).getOrThrow()
+                .isValidSubmission(credentialSubmissions.keys)
+
+        if (!isValidSubmission) {
+            Napier.w("submission requirements are not satisfied")
+            throw OAuth2Exception(Errors.USER_CANCELLED)
+        }
+
+        // making sure, that all the submissions actually match the corresponding input descriptor requirements
+        credentialSubmissions.forEach { submission ->
+            val inputDescriptor = this.inputDescriptors.firstOrNull {
+                it.id == submission.key
+            } ?: run {
+                Napier.w("Invalid input descriptor id")
+                throw OAuth2Exception(Errors.USER_CANCELLED)
+            }
+
+            val constraintFieldMatches = holder.evaluateInputDescriptorAgainstCredential(
+                inputDescriptor,
+                submission.value.credential,
+                fallbackFormatHolder = this.formats ?: clientMetadata?.vpFormats,
+                pathAuthorizationValidator = { true },
+            ).getOrThrow()
+
+            val disclosedAttributes = submission.value.disclosedAttributes.map {
+                it.toString()
+            }
+
+            // find a matching path for each constraint field
+            constraintFieldMatches.filter {
+                // only need to validate non-optional constraint fields
+                it.key.optional != true
+            }.forEach { constraintField ->
+                val allowedPaths = constraintField.value.map {
+                    it.normalizedJsonPath.toString()
+                }
+                disclosedAttributes.firstOrNull {
+                    allowedPaths.contains(it)
+                } ?: run {
+                    Napier.w("Input descriptor constraints not satisfied: ${inputDescriptor.id}.${constraintField.key.id?.let { " Missing field: $it" }}")
+                    throw OAuth2Exception(Errors.USER_CANCELLED)
+                }
+            }
+
+            // TODO: maybe we also want to validate, whether there are any redundant disclosed attributes?
+            //  this would be the case if there is only one constraint field with path "$['name']", but two attributes are disclosed
+        }
+
+    }
+
+    private fun Holder.PresentationResponseParameters.verifyFormatSupport(supportedFormats: FormatHolder) =
+        presentationSubmission.descriptorMap?.mapIndexed { _, descriptor ->
+            if (supportedFormats.isMissingFormatSupport(descriptor.format)) {
+                Napier.w("Incompatible JWT algorithms for claim format ${descriptor.format}: $supportedFormats")
+                throw OAuth2Exception(Errors.REGISTRATION_VALUE_NOT_SUPPORTED)
+            }
+        }
+
+    private fun FormatHolder.isMissingFormatSupport(claimFormatEnum: ClaimFormatEnum) =
+        when (claimFormatEnum) {
+            ClaimFormatEnum.JWT_VP -> jwtVp?.algorithms?.let { !it.contains(jwsService.algorithm.identifier) }
+                ?: false
+
+            ClaimFormatEnum.JWT_SD -> jwtSd?.algorithms?.let { !it.contains(jwsService.algorithm.identifier) }
+                ?: false
+
+            ClaimFormatEnum.MSO_MDOC -> msoMdoc?.algorithms?.let { !it.contains(jwsService.algorithm.identifier) }
+                ?: false
+
+            else -> false
+        }
+}

--- a/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopCombinedProtocolTwoStepTest.kt
+++ b/vclib-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidc/OidcSiopCombinedProtocolTwoStepTest.kt
@@ -1,0 +1,372 @@
+package at.asitplus.wallet.lib.oidc
+
+import at.asitplus.wallet.lib.agent.CredentialSubmission
+import at.asitplus.wallet.lib.agent.Holder
+import at.asitplus.wallet.lib.agent.HolderAgent
+import at.asitplus.wallet.lib.agent.IssuerAgent
+import at.asitplus.wallet.lib.agent.KeyPairAdapter
+import at.asitplus.wallet.lib.agent.RandomKeyPairAdapter
+import at.asitplus.wallet.lib.agent.SubjectCredentialStore
+import at.asitplus.wallet.lib.agent.Verifier
+import at.asitplus.wallet.lib.agent.VerifierAgent
+import at.asitplus.wallet.lib.agent.toStoreCredentialInput
+import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.dif.FormatHolder
+import com.benasher44.uuid.uuid4
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.maps.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.runBlocking
+
+class OidcSiopCombinedProtocolTwoStepTest : FreeSpec({
+
+    lateinit var relyingPartyUrl: String
+
+    lateinit var holderKeyPair: KeyPairAdapter
+    lateinit var verifierKeyPair: KeyPairAdapter
+
+    lateinit var holderAgent: Holder
+    lateinit var verifierAgent: Verifier
+
+    lateinit var holderSiop: OidcSiopWallet
+    lateinit var verifierSiop: OidcSiopVerifier
+
+    beforeEach {
+        holderKeyPair = RandomKeyPairAdapter()
+        verifierKeyPair = RandomKeyPairAdapter()
+        relyingPartyUrl = "https://example.com/rp/${uuid4()}"
+        holderAgent = HolderAgent(holderKeyPair)
+        verifierAgent = VerifierAgent(verifierKeyPair)
+
+        holderSiop = OidcSiopWallet.newDefaultInstance(
+            keyPairAdapter = holderKeyPair,
+            holder = holderAgent,
+        )
+        verifierSiop = OidcSiopVerifier.newInstance(
+            verifier = verifierAgent,
+            relyingPartyUrl = relyingPartyUrl,
+        )
+    }
+
+    "test credential matching" - {
+        "only credentials of the correct format are matched" {
+            runBlocking {
+                holderAgent.storeIsoCredential(holderKeyPair, ConstantIndex.AtomicAttribute2023)
+                holderAgent.storeIsoCredential(holderKeyPair, ConstantIndex.AtomicAttribute2023)
+                holderAgent.storeSdJwtCredential(holderKeyPair, ConstantIndex.AtomicAttribute2023)
+            }
+
+            verifierSiop = OidcSiopVerifier.newInstance(
+                verifier = verifierAgent,
+                relyingPartyUrl = relyingPartyUrl,
+            )
+
+            val authnRequest = verifierSiop.createAuthnRequest(
+                requestOptions = OidcSiopVerifier.RequestOptions(
+                    credentialScheme = ConstantIndex.AtomicAttribute2023,
+                    representation = ConstantIndex.CredentialRepresentation.ISO_MDOC,
+                )
+            ).let { request ->
+                request.copy(
+                    presentationDefinition = request.presentationDefinition?.let { presentationDefinition ->
+                        presentationDefinition.copy(
+                            // only support msoMdoc here
+                            formats = FormatHolder(
+                                msoMdoc = presentationDefinition.formats?.msoMdoc
+                            ),
+                            inputDescriptors = presentationDefinition.inputDescriptors.map { inputDescriptor ->
+                                inputDescriptor.copy(
+                                    format = null
+                                )
+                            }
+                        )
+                    },
+                )
+            }
+            val preparationState = holderSiop.startAuthorizationResponsePreparation(
+                authnRequest.serialize()
+            ).getOrThrow()
+
+            val presentationDefinition = preparationState.presentationDefinition
+            presentationDefinition.shouldNotBeNull()
+
+            val inputDescriptorId = presentationDefinition.inputDescriptors.first().id
+
+            val matches = holderAgent.matchInputDescriptorsAgainstCredentialStore(
+                presentationDefinition.inputDescriptors,
+                presentationDefinition.formats,
+            ).getOrThrow()
+            val inputDescriptorMatches = matches[inputDescriptorId]!!
+            inputDescriptorMatches shouldHaveSize 2
+            inputDescriptorMatches.keys.forEach {
+                it.shouldBeInstanceOf<SubjectCredentialStore.StoreEntry.Iso>()
+            }
+        }
+    }
+
+    "test credential submission" - {
+        "submission requirements need to macth" - {
+            "all credentials matching an input descriptor should be presentable" {
+                runBlocking {
+                    holderAgent.storeIsoCredential(
+                        holderKeyPair,
+                        ConstantIndex.AtomicAttribute2023
+                    )
+                    holderAgent.storeIsoCredential(
+                        holderKeyPair,
+                        ConstantIndex.AtomicAttribute2023
+                    )
+                    holderAgent.storeSdJwtCredential(
+                        holderKeyPair,
+                        ConstantIndex.AtomicAttribute2023
+                    )
+                }
+
+                verifierSiop = OidcSiopVerifier.newInstance(
+                    verifier = verifierAgent,
+                    relyingPartyUrl = relyingPartyUrl,
+                )
+
+                val authnRequest = verifierSiop.createAuthnRequest(
+                    requestOptions = OidcSiopVerifier.RequestOptions(
+                        credentialScheme = ConstantIndex.AtomicAttribute2023,
+                        representation = ConstantIndex.CredentialRepresentation.ISO_MDOC,
+                    )
+                ).let { request ->
+                    request.copy(
+                        presentationDefinition = request.presentationDefinition?.let { presentationDefinition ->
+                            presentationDefinition.copy(
+                                // only support msoMdoc here
+                                formats = FormatHolder(
+                                    msoMdoc = presentationDefinition.formats?.msoMdoc
+                                ),
+                                inputDescriptors = presentationDefinition.inputDescriptors.map { inputDescriptor ->
+                                    inputDescriptor.copy(
+                                        format = null
+                                    )
+                                }
+                            )
+                        },
+                    )
+                }
+
+                val params = holderSiop.parseAuthenticationRequestParameters(authnRequest.serialize())
+                    .getOrThrow()
+                val preparationState = holderSiop.startAuthorizationResponsePreparation(
+                    params
+                ).getOrThrow()
+
+                val presentationDefinition = preparationState.presentationDefinition
+                presentationDefinition.shouldNotBeNull()
+
+                val inputDescriptorId = presentationDefinition.inputDescriptors.first().id
+
+                val matches = holderAgent.matchInputDescriptorsAgainstCredentialStore(
+                    presentationDefinition.inputDescriptors,
+                    presentationDefinition.formats,
+                ).getOrThrow().also {
+                    it shouldHaveSize 1
+                }
+
+                val inputDescriptorMatches = matches[inputDescriptorId]!!
+                inputDescriptorMatches shouldHaveSize 2
+
+                inputDescriptorMatches.forEach {
+                    val submission = mapOf(
+                        inputDescriptorId to CredentialSubmission(
+                            credential = it.key,
+                            disclosedAttributes = it.value.mapNotNull {
+                                it.value.firstOrNull()?.normalizedJsonPath
+                            }
+                        )
+                    )
+
+                    shouldNotThrowAny {
+                        holderSiop.finalizeAuthorizationResponseParameters(
+                            preparationState = preparationState,
+                            params = params,
+                            inputDescriptorSubmissions = submission
+                        ).getOrThrow()
+                    }
+                }
+            }
+            "credentials not matcing an input descriptor should not yield a valid submission" {
+                runBlocking {
+                    holderAgent.storeIsoCredential(
+                        holderKeyPair,
+                        ConstantIndex.AtomicAttribute2023
+                    )
+                    holderAgent.storeIsoCredential(
+                        holderKeyPair,
+                        ConstantIndex.AtomicAttribute2023
+                    )
+                    holderAgent.storeSdJwtCredential(
+                        holderKeyPair,
+                        ConstantIndex.AtomicAttribute2023
+                    )
+                }
+
+                verifierSiop = OidcSiopVerifier.newInstance(
+                    verifier = verifierAgent,
+                    relyingPartyUrl = relyingPartyUrl,
+                )
+
+                val sdJwtMatches = run {
+                    val authnRequestSdJwt = verifierSiop.createAuthnRequest(
+                        requestOptions = OidcSiopVerifier.RequestOptions(
+                            credentialScheme = ConstantIndex.AtomicAttribute2023,
+                            representation = ConstantIndex.CredentialRepresentation.SD_JWT,
+                        )
+                    ).let { request ->
+                        request.copy(
+                            presentationDefinition = request.presentationDefinition?.let { presentationDefinition ->
+                                presentationDefinition.copy(
+                                    // only support msoMdoc here
+                                    inputDescriptors = presentationDefinition.inputDescriptors.map { inputDescriptor ->
+                                        inputDescriptor.copy(
+                                            format = FormatHolder(
+                                                jwtSd = presentationDefinition.formats?.jwtSd
+                                            ),
+                                        )
+                                    }
+                                )
+                            },
+                        )
+                    }
+
+                    val preparationStateSdJwt = holderSiop.startAuthorizationResponsePreparation(
+                        holderSiop.parseAuthenticationRequestParameters(authnRequestSdJwt.serialize()).getOrThrow()
+                    ).getOrThrow()
+
+                    val presentationDefinitionSdJwt = preparationStateSdJwt.presentationDefinition
+                    presentationDefinitionSdJwt.shouldNotBeNull()
+
+                    holderAgent.matchInputDescriptorsAgainstCredentialStore(
+                        presentationDefinitionSdJwt.inputDescriptors,
+                        presentationDefinitionSdJwt.formats,
+                    ).getOrThrow().also {
+                        it.shouldHaveSize(1)
+                        it.entries.first().value.let {
+                            it.shouldHaveSize(1)
+                            it.entries.forEach {
+                                it.key.shouldBeInstanceOf<SubjectCredentialStore.StoreEntry.SdJwt>()
+                            }
+                        }
+                    }
+                }
+
+
+                val authnRequest = verifierSiop.createAuthnRequest(
+                    requestOptions = OidcSiopVerifier.RequestOptions(
+                        credentialScheme = ConstantIndex.AtomicAttribute2023,
+                        representation = ConstantIndex.CredentialRepresentation.ISO_MDOC,
+                    )
+                ).let { request ->
+                    request.copy(
+                        presentationDefinition = request.presentationDefinition?.let { presentationDefinition ->
+                            presentationDefinition.copy(
+                                // only support msoMdoc here
+                                inputDescriptors = presentationDefinition.inputDescriptors.map { inputDescriptor ->
+                                    inputDescriptor.copy(
+                                        format = FormatHolder(
+                                            msoMdoc = presentationDefinition.formats?.msoMdoc
+                                        ),
+                                    )
+                                }
+                            )
+                        },
+                    )
+                }
+
+                val params = holderSiop.parseAuthenticationRequestParameters(authnRequest.serialize())
+                    .getOrThrow()
+                val preparationState = holderSiop.startAuthorizationResponsePreparation(
+                    params
+                ).getOrThrow()
+
+                val presentationDefinition = preparationState.presentationDefinition
+                presentationDefinition.shouldNotBeNull()
+
+                val inputDescriptorId = presentationDefinition.inputDescriptors.first().id
+
+                val matches = holderAgent.matchInputDescriptorsAgainstCredentialStore(
+                    presentationDefinition.inputDescriptors,
+                    presentationDefinition.formats,
+                ).getOrThrow().also {
+                    it shouldHaveSize 1
+                }
+
+                val inputDescriptorMatches = matches[inputDescriptorId]!!
+                inputDescriptorMatches shouldHaveSize 2
+
+                val submission = mapOf(
+                    inputDescriptorId to sdJwtMatches.values.first().entries.first().let {
+                        CredentialSubmission(
+                            credential = it.key,
+                            disclosedAttributes = it.value.entries.mapNotNull {
+                                it.value.firstOrNull()?.normalizedJsonPath
+                            }
+                        )
+                    }
+                )
+
+                shouldThrowAny {
+                    holderSiop.finalizeAuthorizationResponse(
+                        request = params,
+                        preparationState = preparationState,
+                        inputDescriptorSubmissions = submission
+                    ).getOrThrow()
+                }
+            }
+        }
+    }
+})
+
+private suspend fun Holder.storeJwtCredentials(
+    holderKeyPair: KeyPairAdapter,
+    credentialScheme: ConstantIndex.CredentialScheme,
+) {
+    storeCredential(
+        IssuerAgent(
+            RandomKeyPairAdapter(),
+            DummyCredentialDataProvider(),
+        ).issueCredential(
+            holderKeyPair.publicKey,
+            credentialScheme,
+            ConstantIndex.CredentialRepresentation.PLAIN_JWT,
+        ).getOrThrow().toStoreCredentialInput()
+    )
+}
+
+private suspend fun Holder.storeSdJwtCredential(
+    holderKeyPair: KeyPairAdapter,
+    credentialScheme: ConstantIndex.CredentialScheme,
+) {
+    storeCredential(
+        IssuerAgent(
+            RandomKeyPairAdapter(),
+            DummyCredentialDataProvider(),
+        ).issueCredential(
+            holderKeyPair.publicKey,
+            credentialScheme,
+            ConstantIndex.CredentialRepresentation.SD_JWT,
+        ).getOrThrow().toStoreCredentialInput()
+    )
+}
+
+private suspend fun Holder.storeIsoCredential(
+    holderKeyPair: KeyPairAdapter,
+    credentialScheme: ConstantIndex.CredentialScheme,
+) = storeCredential(
+    IssuerAgent(
+        RandomKeyPairAdapter(),
+        DummyCredentialDataProvider(),
+    ).issueCredential(
+        holderKeyPair.publicKey,
+        credentialScheme,
+        ConstantIndex.CredentialRepresentation.ISO_MDOC,
+    ).getOrThrow().toStoreCredentialInput()
+)

--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
@@ -14,7 +14,7 @@ import at.asitplus.wallet.lib.iso.IssuerSigned
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class InputDescriptorCredentialSubmission(
+data class CredentialSubmission(
     val credential: SubjectCredentialStore.StoreEntry,
     val disclosedAttributes: Collection<NormalizedJsonPath>,
 )
@@ -139,7 +139,7 @@ interface Holder {
         challenge: String,
         audienceId: String,
         presentationDefinitionId: String?,
-        presentationSubmissionSelection: Map<String, InputDescriptorCredentialSubmission>,
+        presentationSubmissionSelection: Map<String, CredentialSubmission>,
     ): KmmResult<PresentationResponseParameters>
 
     /**
@@ -156,7 +156,23 @@ interface Holder {
         inputDescriptors: Collection<InputDescriptor>,
         fallbackFormatHolder: FormatHolder? = null,
         pathAuthorizationValidator: PathAuthorizationValidator? = null,
-    ): KmmResult<Map<InputDescriptor, Map<SubjectCredentialStore.StoreEntry, Map<ConstraintField, NodeList>>>>
+    ): KmmResult<Map<String, Map<SubjectCredentialStore.StoreEntry, Map<ConstraintField, NodeList>>>>
+
+    /**
+     * Evaluates a given input descriptor against a store enctry.
+     *
+     * @param fallbackFormatHolder: format holder to be used in case there is no format holder in the input descriptor.
+     *  This will mostly be some presentationDefinition.formats ?: clientMetadata.vpFormats
+     * @param pathAuthorizationValidator: Provides the user of this library with a way to enforce
+     *  authorization rules on attribute credentials that are to be disclosed.
+     * @return for each constraint field a set of matching nodes or null,
+     */
+    fun evaluateInputDescriptorAgainstCredential(
+        inputDescriptor: InputDescriptor,
+        credential: SubjectCredentialStore.StoreEntry,
+        fallbackFormatHolder: FormatHolder?,
+        pathAuthorizationValidator: (NormalizedJsonPath) -> Boolean,
+    ): KmmResult<Map<ConstraintField, NodeList>>
 
     sealed class CreatePresentationResult {
         /**
@@ -179,17 +195,17 @@ interface Holder {
 
 }
 
-fun Map<InputDescriptor, Map<SubjectCredentialStore.StoreEntry, Map<ConstraintField, NodeList>>>.toDefaultSubmission() =
+fun Map<String, Map<SubjectCredentialStore.StoreEntry, Map<ConstraintField, NodeList>>>.toDefaultSubmission() =
     mapNotNull { descriptorCredentialMatches ->
         descriptorCredentialMatches.value.entries.firstNotNullOfOrNull { credentialConstraintFieldMatches ->
-            InputDescriptorCredentialSubmission(
+            CredentialSubmission(
                 credential = credentialConstraintFieldMatches.key,
                 disclosedAttributes = credentialConstraintFieldMatches.value.values.mapNotNull {
                     it.firstOrNull()?.normalizedJsonPath
                 },
             )
         }?.let {
-            descriptorCredentialMatches.key.id to it
+            descriptorCredentialMatches.key to it
         }
     }.toMap()
 

--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
@@ -19,6 +19,8 @@ data class CredentialSubmission(
     val disclosedAttributes: Collection<NormalizedJsonPath>,
 )
 
+typealias InputDescriptorMatches = Map<SubjectCredentialStore.StoreEntry, Map<ConstraintField, NodeList>>
+
 /**
  * Summarizes operations for a Holder in the sense of the [W3C VC Data Model](https://w3c.github.io/vc-data-model/).
  *
@@ -156,7 +158,7 @@ interface Holder {
         inputDescriptors: Collection<InputDescriptor>,
         fallbackFormatHolder: FormatHolder? = null,
         pathAuthorizationValidator: PathAuthorizationValidator? = null,
-    ): KmmResult<Map<String, Map<SubjectCredentialStore.StoreEntry, Map<ConstraintField, NodeList>>>>
+    ): KmmResult<Map<String, InputDescriptorMatches>>
 
     /**
      * Evaluates a given input descriptor against a store enctry.

--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/PresentationSubmissionValidator.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/PresentationSubmissionValidator.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.data.dif
 
 import at.asitplus.KmmResult
 import at.asitplus.KmmResult.Companion.wrap
+import at.asitplus.catching
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -10,7 +11,7 @@ sealed class PresentationSubmissionValidator {
         fun createInstance(
             submissionRequirements: Collection<SubmissionRequirement>?,
             inputDescriptors: Collection<InputDescriptor>,
-        ): KmmResult<PresentationSubmissionValidator> = runCatching {
+        ): KmmResult<PresentationSubmissionValidator> = catching {
             val verifier = submissionRequirements?.let { _ ->
                 SubmissionRequirementsValidator(
                     submissionRequirements = submissionRequirements,
@@ -22,7 +23,14 @@ sealed class PresentationSubmissionValidator {
                 inputDescriptorIds = inputDescriptors.map { it.id }.toSet()
             )
             return KmmResult.success(verifier)
-        }.wrap()
+        }
+
+        fun createInstance(
+            presentationDefinition: PresentationDefinition,
+        ): KmmResult<PresentationSubmissionValidator> = createInstance(
+            submissionRequirements = presentationDefinition.submissionRequirements,
+            inputDescriptors = presentationDefinition.inputDescriptors,
+        )
     }
 
     /**


### PR DESCRIPTION
Separates the response building into two phases, allowing the user of the library to select credentials and attributes to be disclosed, but leaves the original logic in tact using default submissions

 - Change `OidcSiopWallet`: 
   - Add `startAuthorizationResponsePreparation`: Gathers data necessary for presentation building and yields a `AuthorizationResponsePreparationState`
   - Add `finalizeAuthorizationResponseParameters`: Returns what `createAuthenticationParams` returned before, but also takes in `AuthorizationResponsePreparationState` and an optional non-default submission
   - Add `finalizeAuthorizationResponse`: Returns what `createAuthenticationResponse` did before 
 - Add `AuthorizationResponsePreparationState`: Holds data necessary for presentation building
 - Add `AuthenticationRequestParser`: Extracted presentation request parsing logic from `OidcSiopWallet` and put it here
 - Add `AuthorizationRequestValidator`: Extracted presentation request validation logic from `OidcSiopWallet` and put it here
 - Add `PresentationFactory`: Extracted presentation response building logic from `OidcSiopWallet` and put it here
   - Also added some code for presentation submission validation