### PR TITLE
apply kmp-crypto version catalog

### DIFF
--- a/conventions-vclib/build.gradle.kts
+++ b/conventions-vclib/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.FileInputStream
 import java.util.*
 
@@ -21,6 +22,12 @@ gradlePlugin {
     plugins.register("vclib-conventions") {
         id = "at.asitplus.gradle.vclib-conventions"
         implementationClass = "at.asitplus.gradle.VcLibConventions"
+    }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        freeCompilerArgs = freeCompilerArgs + "-Xcontext-receivers"
     }
 }
 

--- a/conventions-vclib/settings.gradle.kts
+++ b/conventions-vclib/settings.gradle.kts
@@ -1,3 +1,4 @@
+
 rootProject.name = "vclib-conventions"
 
 //we don't want to pollute the classpath with a shadowed conventions plugin

--- a/conventions-vclib/src/main/kotlin/VcLibConventions.kt
+++ b/conventions-vclib/src/main/kotlin/VcLibConventions.kt
@@ -5,21 +5,27 @@ package at.asitplus.gradle
 import VcLibVersions
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
 
+
+val Project.kmpCryptoVersionCatalog:VersionCatalog  get() = extensions.getByType<VersionCatalogsExtension>().named("kmpCrypto")
 
 inline fun Project.commonApiDependencies(): List<String> {
     project.AspVersions.versions["kmpcrypto"] = VcLibVersions.kmpcrypto
     project.AspVersions.versions["jsonpath"] = VcLibVersions.jsonpath
-    project.AspVersions.versions["okio"] = VcLibVersions.okio
-    project.AspVersions.versions["encoding"] = VcLibVersions.encoding
+    project.AspVersions.versions["okio"] = kmpCryptoVersionCatalog.findVersion("okio").get().toString()
+    project.AspVersions.versions["encoding"] = kmpCryptoVersionCatalog.findVersion("encoding").get().toString()
+
+
     return listOf(
         coroutines(),
         serialization("json"),
         serialization("cbor"),
         addDependency("at.asitplus.crypto:datatypes", "kmpcrypto"), //for iOS Export
         addDependency("at.asitplus.crypto:datatypes-cose", "kmpcrypto"),
-        addDependency("at.asitplus.crypto:datatypes-jws", "kmpcrypto"),
         addDependency("at.asitplus.crypto:datatypes-jws", "kmpcrypto"),
         addDependency("at.asitplus:jsonpath", "jsonpath"),
         datetime(),
@@ -42,16 +48,17 @@ inline fun KotlinDependencyHandler.commonImplementationDependencies() {
     implementation(project.addDependency("com.benasher44:uuid", "uuid"))
 }
 
+
 fun Project.commonIosExports() = arrayOf(
     datetime(),
-    "com.ionspin.kotlin:bignum:${VcLibVersions.bignum}",
+    "com.ionspin.kotlin:bignum:${kmpCryptoVersionCatalog.findVersion("bignum").get()}",
     kmmresult(),
     "at.asitplus.crypto:datatypes:${VcLibVersions.kmpcrypto}",
     "at.asitplus.crypto:datatypes-cose:${VcLibVersions.kmpcrypto}",
     "at.asitplus.crypto:datatypes-jws:${VcLibVersions.kmpcrypto}",
     "at.asitplus:jsonpath:${VcLibVersions.jsonpath}",
-    "io.matthewnelson.kotlin-components:encoding-base16:${VcLibVersions.encoding}",
-    "io.matthewnelson.kotlin-components:encoding-base64:${VcLibVersions.encoding}",
+    "io.matthewnelson.kotlin-components:encoding-base16:${kmpCryptoVersionCatalog.findVersion("encoding").get()}",
+    "io.matthewnelson.kotlin-components:encoding-base64:${kmpCryptoVersionCatalog.findVersion("encoding").get()}",
 )
 
 

--- a/conventions-vclib/src/main/kotlin/VcLibConventions.kt
+++ b/conventions-vclib/src/main/kotlin/VcLibConventions.kt
@@ -8,10 +8,14 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import org.jetbrains.kotlin.gradle.utils.named
 
 
-val Project.kmpCryptoVersionCatalog:VersionCatalog  get() = extensions.getByType<VersionCatalogsExtension>().named("kmpCrypto")
+val Project.kmpCryptoVersionCatalog: VersionCatalog
+    get() = extensions.getByType<VersionCatalogsExtension>().named("kmpCrypto")
 
 inline fun Project.commonApiDependencies(): List<String> {
     project.AspVersions.versions["kmpcrypto"] = VcLibVersions.kmpcrypto
@@ -65,6 +69,15 @@ fun Project.commonIosExports() = arrayOf(
 class VcLibConventions : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("at.asitplus.gradle.conventions")
+        target.gradle.taskGraph.whenReady {
+            target.tasks.withType<KotlinCompilationTask<*>>().configureEach {
+                compilerOptions {
+                    freeCompilerArgs.add("-Xexpect-actual-classes")
+                    optIn.add("kotlinx.cinterop.BetaInteropApi")
+                }
+            }
+        }
+
     }
 }
 

--- a/conventions-vclib/src/main/kotlin/VcLibVersions.kt
+++ b/conventions-vclib/src/main/kotlin/VcLibVersions.kt
@@ -1,4 +1,6 @@
+import org.gradle.api.Project
 import java.util.*
+
 
 object VcLibVersions {
 
@@ -8,12 +10,13 @@ object VcLibVersions {
 
     private fun versionOf(dependency: String) = versions[dependency] as String
 
-
-    const val uuid = "0.8.1"
+    val uuid get() = versionOf("uuid")
     val kmpcrypto get() = versionOf("kmpCrypto")
-    const val jsonpath = "2.0.0"
+    val jsonpath get() = versionOf("jsonpath")
+    val eupidcredential get() = versionOf("eupid")
+    val mdl get() = versionOf("mdl")
 
     object Jvm {
-        const val json = "20230618"
+        val json get() = versionOf("jvm.json")
     }
 }

--- a/conventions-vclib/src/main/kotlin/VcLibVersions.kt
+++ b/conventions-vclib/src/main/kotlin/VcLibVersions.kt
@@ -1,13 +1,19 @@
+import java.util.*
+
 object VcLibVersions {
+
+    private val versions by lazy {
+        javaClass.classLoader!!.getResourceAsStream("vcLibVersions.properties").use { Properties().apply { load(it) } }
+    }
+
+    private fun versionOf(dependency: String) = versions[dependency] as String
+
+
     const val uuid = "0.8.1"
-    const val encoding = "1.2.3"
-    const val okio = "3.5.0"
-    const val kmpcrypto = "3.2.0"
+    val kmpcrypto get() = versionOf("kmpCrypto")
     const val jsonpath = "2.0.0"
-    const val bignum = "0.3.9"
 
     object Jvm {
-        const val `jose-jwt` = "9.31"
         const val json = "20230618"
     }
 }

--- a/conventions-vclib/src/main/resources/vcLibVersions.properties
+++ b/conventions-vclib/src/main/resources/vcLibVersions.properties
@@ -1,1 +1,6 @@
 kmpCrypto=3.2.1
+uuid=0.8.1
+jsonpath=2.0.0
+jvm.json=20230618
+eupid=2.1.1
+mdl=1.0.0

--- a/conventions-vclib/src/main/resources/vcLibVersions.properties
+++ b/conventions-vclib/src/main/resources/vcLibVersions.properties
@@ -1,0 +1,1 @@
+kmpCrypto=3.2.1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.*
+
 pluginManagement {
     includeBuild("conventions-vclib")
     repositories {
@@ -23,10 +26,21 @@ include(":vclib")
 include(":vclib-aries")
 include(":vclib-openid")
 
-includeBuild("kmp-crypto") {
-    dependencySubstitution {
-        substitute(module("at.asitplus.crypto:datatypes")).using(project(":datatypes"))
-        substitute(module("at.asitplus.crypto:datatypes-jws")).using(project(":datatypes-jws"))
-        substitute(module("at.asitplus.crypto:datatypes-cose")).using(project(":datatypes-cose"))
+dependencyResolutionManagement {
+    repositories.add(repositories.mavenCentral())
+    versionCatalogs {
+        val versions = Properties().apply {
+            kotlin.runCatching {
+                FileInputStream(rootProject.projectDir.absolutePath + ("/conventions-vclib/src/main/resources/vcLibVersions.properties")).use {
+                    load(it)
+                }
+            }
+        }
+
+        fun versionOf(dependency: String) = versions[dependency] as String
+
+        create("kmpCrypto") {
+            from("at.asitplus.crypto:datatypes-versionCatalog:${versionOf("kmpCrypto")}")
+        }
     }
 }

--- a/vclib-aries/build.gradle.kts
+++ b/vclib-aries/build.gradle.kts
@@ -1,4 +1,8 @@
-import at.asitplus.gradle.*
+import at.asitplus.gradle.commonImplementationDependencies
+import at.asitplus.gradle.commonIosExports
+import at.asitplus.gradle.exportIosFramework
+import at.asitplus.gradle.setupDokka
+import org.jetbrains.kotlin.gradle.plugin.mpp.BitcodeEmbeddingMode
 
 plugins {
     kotlin("multiplatform")
@@ -22,28 +26,33 @@ kotlin {
     iosX64()
     sourceSets {
 
-         commonMain {
+        commonMain {
             dependencies {
                 api(project(":vclib"))
                 commonImplementationDependencies()
             }
         }
 
-        jvmMain  {
+        jvmMain {
             dependencies {
-                implementation(bouncycastle("bcprov"))
+                implementation(kmpCrypto.bcpkix.jdk18on)
             }
         }
-         jvmTest {
+        jvmTest {
             dependencies {
-                implementation("com.nimbusds:nimbus-jose-jwt:${VcLibVersions.Jvm.`jose-jwt`}")
+                implementation(kmpCrypto.jose)
                 implementation("org.json:json:${VcLibVersions.Jvm.json}")
             }
         }
     }
 }
 
-exportIosFramework("VcLibAriesKmm", *commonIosExports(), project(":vclib"))
+exportIosFramework(
+    "VcLibAriesKmm",
+    static = false,
+    bitcodeEmbeddingMode = BitcodeEmbeddingMode.DISABLE,
+    *commonIosExports(), project(":vclib")
+)
 
 val javadocJar = setupDokka(
     baseUrl = "https://github.com/a-sit-plus/kmm-vc-library/tree/main/",

--- a/vclib-openid/build.gradle.kts
+++ b/vclib-openid/build.gradle.kts
@@ -1,4 +1,8 @@
-import at.asitplus.gradle.*
+import at.asitplus.gradle.commonImplementationDependencies
+import at.asitplus.gradle.commonIosExports
+import at.asitplus.gradle.exportIosFramework
+import at.asitplus.gradle.setupDokka
+import org.jetbrains.kotlin.gradle.plugin.mpp.BitcodeEmbeddingMode
 
 plugins {
     kotlin("multiplatform")
@@ -31,8 +35,11 @@ kotlin {
 
         commonTest {
             dependencies {
-                implementation("at.asitplus.wallet:eupidcredential:2.1.0-SNAPSHOT"){
-                    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-json") //TODO remove me once everything's updated to conventions with new serialization
+                implementation("at.asitplus.wallet:eupidcredential:2.1.0-SNAPSHOT") {
+                    exclude(
+                        group = "org.jetbrains.kotlinx",
+                        module = "kotlinx-serialization-json"
+                    ) //TODO remove me once everything's updated to conventions with new serialization
                 }
                 implementation("at.asitplus.wallet:mobiledrivinglicence:1.0.0-SNAPSHOT")
             }
@@ -40,20 +47,25 @@ kotlin {
 
         jvmMain {
             dependencies {
-                implementation(bouncycastle("bcprov"))
+                implementation(kmpCrypto.bcpkix.jdk18on)
             }
         }
 
         jvmTest {
             dependencies {
-                implementation("com.nimbusds:nimbus-jose-jwt:${VcLibVersions.Jvm.`jose-jwt`}")
+                implementation(kmpCrypto.jose)
                 implementation("org.json:json:${VcLibVersions.Jvm.json}")
             }
         }
     }
 }
 
-exportIosFramework("VcLibOpenIdKmm", *commonIosExports(), project(":vclib"))
+exportIosFramework(
+    "VcLibOpenIdKmm",
+    static = false,
+    bitcodeEmbeddingMode = BitcodeEmbeddingMode.DISABLE,
+    *commonIosExports(), project(":vclib")
+)
 
 val javadocJar = setupDokka(
     baseUrl = "https://github.com/a-sit-plus/kmm-vc-library/tree/main/",

--- a/vclib-openid/build.gradle.kts
+++ b/vclib-openid/build.gradle.kts
@@ -35,13 +35,8 @@ kotlin {
 
         commonTest {
             dependencies {
-                implementation("at.asitplus.wallet:eupidcredential:2.1.0-SNAPSHOT") {
-                    exclude(
-                        group = "org.jetbrains.kotlinx",
-                        module = "kotlinx-serialization-json"
-                    ) //TODO remove me once everything's updated to conventions with new serialization
-                }
-                implementation("at.asitplus.wallet:mobiledrivinglicence:1.0.0-SNAPSHOT")
+                implementation("at.asitplus.wallet:eupidcredential:${VcLibVersions.eupidcredential}")
+                implementation("at.asitplus.wallet:mobiledrivinglicence:${VcLibVersions.mdl}")
             }
         }
 

--- a/vclib/build.gradle.kts
+++ b/vclib/build.gradle.kts
@@ -1,8 +1,8 @@
-import at.asitplus.gradle.bouncycastle
 import at.asitplus.gradle.commonImplementationAndApiDependencies
 import at.asitplus.gradle.commonIosExports
 import at.asitplus.gradle.exportIosFramework
 import at.asitplus.gradle.setupDokka
+import org.jetbrains.kotlin.gradle.plugin.mpp.BitcodeEmbeddingMode
 
 plugins {
     kotlin("multiplatform")
@@ -35,19 +35,24 @@ kotlin {
 
         jvmMain {
             dependencies {
-                implementation(bouncycastle("bcpkix"))
+                implementation(kmpCrypto.bcpkix.jdk18on)
             }
         }
         jvmTest {
             dependencies {
-                implementation("com.nimbusds:nimbus-jose-jwt:${VcLibVersions.Jvm.`jose-jwt`}")
+                implementation(kmpCrypto.jose)
                 implementation("org.json:json:${VcLibVersions.Jvm.json}")
             }
         }
     }
 }
 
-exportIosFramework("VcLibKmm", *commonIosExports())
+exportIosFramework(
+    name = "VcLibKmm",
+    static = false,
+    bitcodeEmbeddingMode = BitcodeEmbeddingMode.DISABLE,
+    *commonIosExports()
+)
 
 val javadocJar = setupDokka(
     baseUrl = "https://github.com/a-sit-plus/kmm-vc-library/tree/main/",


### PR DESCRIPTION
If Dr. Frankenstein was McGyver's apprentice… uses the kmp-crypto version catalog to avoid version mismatches.

directly targeting main for an xcframework release