### PR TITLE
Make schemeSet readable

### DIFF
--- a/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/AttributeIndex.kt
+++ b/vclib/src/commonMain/kotlin/at/asitplus/wallet/lib/data/AttributeIndex.kt
@@ -2,7 +2,8 @@ package at.asitplus.wallet.lib.data
 
 object AttributeIndex {
 
-    private val schemeSet = mutableSetOf<ConstantIndex.CredentialScheme>()
+    var schemeSet = setOf<ConstantIndex.CredentialScheme>()
+        private set
 
     init {
         schemeSet += ConstantIndex.AtomicAttribute2023


### PR DESCRIPTION
It is very useful to be able to know which CredentialSchemes are registered. This makes the getter public but the setter remains private.