### PR TITLE
SD-JWT: Digest algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 Release 5.9.0 (unreleased):
+ - Implement `_sd_alg` parameter functionality for SD-JWT to allowing more digests for issuance and verification of selective disclosures
  - Remove code elements deprecated in 5.8.0
  - Gradle modules: 
    - Change dependency structure of modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 Release 5.9.0 (unreleased):
- - Implement `_sd_alg` parameter functionality for SD-JWT to allowing more digests for issuance and verification of selective disclosures
  - Remove code elements deprecated in 5.8.0
  - Gradle modules: 
    - Change dependency structure of modules
@@ -99,6 +98,8 @@ Release 5.9.0 (unreleased):
    - Extend `RequestParametersFrom` with sub-classes for `DcApiSigned` and `DcApiUnsigned`, removing the parameter `dcApiRequest` from several methods in `OpenId4VpVerifier` and `OpenId4VpWallet`
    - Extend `RequestParametersFrom.JwsSigned` with a `parent` member
    - Extend `RequestParametersFrom.Json` with a `parent` member
+ - SD-JWT:
+   - Honour digest defined in `_sd_alg` parameter to allow for more digests in issuance and verification of selective disclosures items
 
 Release 5.8.0:
  - Refactor `AuthorizationServiceStrategy`

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SdJwtConstants.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SdJwtConstants.kt
@@ -4,6 +4,13 @@ package at.asitplus.wallet.lib.data
  * [IANA Naming convention](https://www.iana.org/assignments/named-information/named-information.xhtml)
  */
 object SdJwtConstants {
+
+    /** `_sd` */
+    const val NAME_SD = "_sd"
+
+    /** `_sd_alg` */
+    const val SD_ALG = "_sd_alg"
+
     /** `sha-256` */
     const val SHA_256 = "sha-256"
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SelectiveDisclosureItem.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SelectiveDisclosureItem.kt
@@ -1,8 +1,10 @@
 package at.asitplus.wallet.lib.data
 
 import at.asitplus.iso.sha256
+import at.asitplus.signum.indispensable.Digest
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.supreme.hash.digest
 import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.Serializable
@@ -56,7 +58,7 @@ data class SelectiveDisclosureItem(
          * Hashes a disclosure from [SelectiveDisclosureItem.toDisclosure] according to section 5.2.3 of
          * [draft-ietf-oauth-selective-disclosure-jwt-08](https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/)
          **/
-        fun String.hashDisclosure() = encodeToByteArray().sha256().encodeToString(Base64UrlStrict)
+        fun String.hashDisclosure(digest: Digest?) = (digest ?: Digest.SHA256).digest(this.encodeToByteArray()).encodeToString(Base64UrlStrict)
     }
 
 }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SelectiveDisclosureItem.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/SelectiveDisclosureItem.kt
@@ -58,7 +58,8 @@ data class SelectiveDisclosureItem(
          * Hashes a disclosure from [SelectiveDisclosureItem.toDisclosure] according to section 5.2.3 of
          * [draft-ietf-oauth-selective-disclosure-jwt-08](https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/)
          **/
-        fun String.hashDisclosure(digest: Digest?) = (digest ?: Digest.SHA256).digest(this.encodeToByteArray()).encodeToString(Base64UrlStrict)
+        fun String.hashDisclosure(digest: Digest = Digest.SHA256) =
+            digest.digest(this.encodeToByteArray()).encodeToString(Base64UrlStrict)
     }
 
 }

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
@@ -19,7 +19,6 @@ import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenIntrospectionRequest
 import at.asitplus.openid.TokenIntrospectionResponse
 import at.asitplus.openid.TokenRequestParameters
-import at.asitplus.openid.TokenResponseParameters
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
 import at.asitplus.wallet.eupid.EuPidScheme
 import at.asitplus.wallet.lib.agent.ClaimToBeIssued
@@ -37,6 +36,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
 import at.asitplus.wallet.lib.jws.JwsHeaderNone
 import at.asitplus.wallet.lib.jws.SignJwt
@@ -49,7 +49,6 @@ import at.asitplus.wallet.lib.oidvci.BuildClientAttestationJwt
 import at.asitplus.wallet.lib.oidvci.CredentialAuthorizationServiceStrategy
 import at.asitplus.wallet.lib.oidvci.CredentialDataProviderFun
 import at.asitplus.wallet.lib.oidvci.CredentialIssuer
-import at.asitplus.wallet.lib.oidvci.OAuth2Error
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.WalletService
 import at.asitplus.wallet.lib.oidvci.decodeFromPostBody
@@ -221,6 +220,7 @@ class OpenId4VciClientExternalAuthorizationServerTest : FunSpec() {
                         it.credentialScheme,
                         it.subjectPublicKey,
                         OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
+                        sdAlgorithm = supportedSdAlgorithms.random()
                     )
 
                     ISO_MDOC -> Iso(

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -33,6 +33,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
 import at.asitplus.wallet.lib.jws.JwsHeaderNone
 import at.asitplus.wallet.lib.jws.SignJwt
@@ -204,11 +205,12 @@ class OpenId4VciClientTest : FunSpec() {
                 when (representation) {
                     PLAIN_JWT -> TODO()
                     SD_JWT -> VcSd(
-                        attributes.map { ClaimToBeIssued(it.key, it.value) },
-                        Clock.System.now(),
-                        it.credentialScheme,
-                        it.subjectPublicKey,
-                        OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
+                        claims = attributes.map { ClaimToBeIssued(it.key, it.value) },
+                        expiration = Clock.System.now(),
+                        scheme = it.credentialScheme,
+                        subjectPublicKey = it.subjectPublicKey,
+                        userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
+                        sdAlgorithm = supportedSdAlgorithms.random()
                     )
 
                     ISO_MDOC -> Iso(

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
@@ -29,6 +29,7 @@ import at.asitplus.wallet.lib.data.CredentialPresentation.DCQLPresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
 import at.asitplus.wallet.lib.data.rfc3986.toUri
+import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.json
 import at.asitplus.wallet.lib.openid.*
@@ -363,6 +364,7 @@ class OpenId4VpWalletTest : FunSpec() {
             scheme = scheme,
             subjectPublicKey = keyMaterial.publicKey,
             userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
+            sdAlgorithm = supportedSdAlgorithms.random()
         )
 
         ISO_MDOC -> CredentialToBeIssued.Iso(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyCredentialDataProvider.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyCredentialDataProvider.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.iso.IssuerSignedItem
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.wallet.eupid.EuPidCredential
 import at.asitplus.wallet.eupid.EuPidScheme
@@ -9,20 +10,17 @@ import at.asitplus.wallet.lib.agent.ClaimToBeIssued
 import at.asitplus.wallet.lib.agent.CredentialToBeIssued
 import at.asitplus.wallet.lib.data.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex
-import at.asitplus.iso.IssuerSignedItem
-import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_DATE_OF_BIRTH
-import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
-import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_PORTRAIT
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
 import at.asitplus.wallet.lib.data.LocalDateOrInstant
+import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import at.asitplus.wallet.mdl.DrivingPrivilege
 import at.asitplus.wallet.mdl.DrivingPrivilegeCode
 import at.asitplus.wallet.mdl.MobileDrivingLicenceDataElements
 import at.asitplus.wallet.mdl.MobileDrivingLicenceScheme
-import kotlin.time.Clock
 import kotlinx.datetime.LocalDate
 import kotlin.random.Random
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 
 object DummyCredentialDataProvider {
@@ -51,6 +49,7 @@ object DummyCredentialDataProvider {
                     scheme = credentialScheme,
                     subjectPublicKey = subjectPublicKey,
                     userInfo = DummyUserProvider.user,
+                    sdAlgorithm = supportedSdAlgorithms.random()
                 )
 
                 PLAIN_JWT -> CredentialToBeIssued.VcJwt(
@@ -160,6 +159,7 @@ object DummyCredentialDataProvider {
                         scheme = credentialScheme,
                         subjectPublicKey = subjectPublicKey,
                         userInfo = DummyUserProvider.user,
+                        sdAlgorithm = supportedSdAlgorithms.random()
                     )
 
                 PLAIN_JWT -> CredentialToBeIssued.VcJwt(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyOAuth2IssuerCredentialDataProvider.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/DummyOAuth2IssuerCredentialDataProvider.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.iso.IssuerSignedItem
 import at.asitplus.openid.OidcUserInfo
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.signum.indispensable.CryptoPublicKey
@@ -15,12 +16,9 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_DATE_
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_PORTRAIT
-import at.asitplus.iso.IssuerSignedItem
-import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
-import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
-import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
-import at.asitplus.wallet.lib.data.ConstantIndex.CredentialScheme
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
 import at.asitplus.wallet.lib.data.LocalDateOrInstant
+import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import at.asitplus.wallet.lib.oidvci.CredentialDataProviderFun
 import at.asitplus.wallet.lib.oidvci.CredentialDataProviderInput
 import at.asitplus.wallet.mdl.MobileDrivingLicenceDataElements.DOCUMENT_NUMBER
@@ -32,9 +30,9 @@ import at.asitplus.wallet.mdl.MobileDrivingLicenceScheme
 import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlin.time.Clock
 import kotlinx.datetime.LocalDate
 import kotlin.random.Random
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 
 
@@ -86,11 +84,12 @@ object DummyOAuth2IssuerCredentialDataProvider : CredentialDataProviderFun {
         )
         return when (representation) {
             SD_JWT -> CredentialToBeIssued.VcSd(
-                claims,
-                expiration,
-                ConstantIndex.AtomicAttribute2023,
-                subjectPublicKey,
-                DummyUserProvider.user,
+                claims = claims,
+                expiration = expiration,
+                scheme = ConstantIndex.AtomicAttribute2023,
+                subjectPublicKey = subjectPublicKey,
+                userInfo = DummyUserProvider.user,
+                sdAlgorithm = supportedSdAlgorithms.random()
             )
 
             PLAIN_JWT -> CredentialToBeIssued.VcJwt(
@@ -163,11 +162,12 @@ object DummyOAuth2IssuerCredentialDataProvider : CredentialDataProviderFun {
         )
         return when (representation) {
             SD_JWT -> CredentialToBeIssued.VcSd(
-                claims,
-                expiration,
-                EuPidScheme,
-                subjectPublicKey,
-                DummyUserProvider.user,
+                claims = claims,
+                expiration = expiration,
+                scheme = EuPidScheme,
+                subjectPublicKey = subjectPublicKey,
+                userInfo = DummyUserProvider.user,
+                sdAlgorithm = supportedSdAlgorithms.random()
             )
 
             PLAIN_JWT -> CredentialToBeIssued.VcJwt(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpComplexSdJwtProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpComplexSdJwtProtocolTest.kt
@@ -7,6 +7,7 @@ import at.asitplus.wallet.lib.agent.*
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.rfc3986.toUri
+import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import com.benasher44.uuid.uuid4
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldBeIn
@@ -47,7 +48,7 @@ class OpenId4VpComplexSdJwtProtocolTest : FreeSpec({
                 randomSource = RandomSource.Default
             ).issueCredential(
                 CredentialToBeIssued.VcSd(
-                    listOf(
+                    claims = listOf(
                         ClaimToBeIssued(
                             CLAIM_ADDRESS, listOf(
                                 ClaimToBeIssued(CLAIM_ADDRESS_REGION, randomRegion),
@@ -55,10 +56,11 @@ class OpenId4VpComplexSdJwtProtocolTest : FreeSpec({
                             )
                         )
                     ),
-                    Clock.System.now().plus(5.minutes),
-                    AtomicAttribute2023,
-                    holderKeyMaterial.publicKey,
-                    DummyUserProvider.user,
+                    expiration = Clock.System.now().plus(5.minutes),
+                    scheme = AtomicAttribute2023,
+                    subjectPublicKey = holderKeyMaterial.publicKey,
+                    userInfo = DummyUserProvider.user,
+                    sdAlgorithm = supportedSdAlgorithms.random(),
                 )
             ).getOrThrow().toStoreCredentialInput()
         )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/helper/DummyCredentialDataProvider.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/helper/DummyCredentialDataProvider.kt
@@ -9,6 +9,7 @@ import at.asitplus.wallet.eupid.EuPidScheme
 import at.asitplus.wallet.lib.agent.ClaimToBeIssued
 import at.asitplus.wallet.lib.agent.CredentialToBeIssued
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import kotlinx.datetime.LocalDate
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
@@ -58,6 +59,7 @@ object DummyCredentialDataProvider {
                         scheme = credentialScheme,
                         subjectPublicKey = subjectPublicKey,
                         userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
+                        sdAlgorithm = supportedSdAlgorithms.random(),
                     )
 
                 else -> throw NotImplementedError()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.agent
 import at.asitplus.iso.IssuerSignedItem
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.signum.indispensable.Digest
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.CredentialSubject
 import at.asitplus.wallet.lib.jws.JwsHeaderModifierFun
@@ -30,6 +31,7 @@ sealed class CredentialToBeIssued {
         override val userInfo: OidcUserInfoExtended,
         /** Implement to add type metadata field */
         val modifyHeader: JwsHeaderModifierFun = JwsHeaderModifierFun { it },
+        val sdAlgorithm: Digest? = null
     ) : CredentialToBeIssued()
 
     data class Iso(

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/CredentialToBeIssued.kt
@@ -31,7 +31,7 @@ sealed class CredentialToBeIssued {
         override val userInfo: OidcUserInfoExtended,
         /** Implement to add type metadata field */
         val modifyHeader: JwsHeaderModifierFun = JwsHeaderModifierFun { it },
-        val sdAlgorithm: Digest? = null
+        val sdAlgorithm: Digest = Digest.SHA256
     ) : CredentialToBeIssued()
 
     data class Iso(

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Extensions.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Extensions.kt
@@ -25,7 +25,7 @@ internal fun getCommonHashesAlgorithms(transactionData: List<TransactionDataBase
     }
 }
 
-internal fun Digest.toIanaName(): String =
+fun Digest.toIanaName(): String =
     when (this) {
         Digest.SHA256 -> SdJwtConstants.SHA_256
         Digest.SHA384 -> SdJwtConstants.SHA_384

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -17,7 +17,6 @@ import at.asitplus.wallet.lib.cbor.CoseHeaderCertificate
 import at.asitplus.wallet.lib.cbor.CoseHeaderNone
 import at.asitplus.wallet.lib.cbor.SignCose
 import at.asitplus.wallet.lib.cbor.SignCoseFun
-import at.asitplus.wallet.lib.data.SdJwtConstants
 import at.asitplus.wallet.lib.data.Status
 import at.asitplus.wallet.lib.data.VerifiableCredential
 import at.asitplus.wallet.lib.data.VerifiableCredentialJws
@@ -186,7 +185,7 @@ class IssuerAgent(
                 uri = UniformResourceIdentifier(getRevocationListUrlFor(timePeriod)),
             )
         )
-        val (sdJwt, disclosures) = credential.claims.toSdJsonObject(randomSource)
+        val (sdJwt, disclosures) = credential.claims.toSdJsonObject(randomSource, credential.sdAlgorithm)
         val cnf = ConfirmationClaim(jsonWebKey = credential.subjectPublicKey.toJsonWebKey())
         val vcSdJwt = VerifiableCredentialSdJwt(
             subject = subjectId,
@@ -196,7 +195,7 @@ class IssuerAgent(
             issuedAt = issuanceDate,
             jwtId = vcId,
             verifiableCredentialType = credential.scheme.sdJwtType ?: credential.scheme.schemaUri,
-            selectiveDisclosureAlgorithm = SdJwtConstants.SHA_256,
+            selectiveDisclosureAlgorithm = credential.sdAlgorithm?.toIanaName(),
             confirmationClaim = cnf,
             statusElement = vckJsonSerializer.encodeToJsonElement(credentialStatus),
         )

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -195,7 +195,7 @@ class IssuerAgent(
             issuedAt = issuanceDate,
             jwtId = vcId,
             verifiableCredentialType = credential.scheme.sdJwtType ?: credential.scheme.schemaUri,
-            selectiveDisclosureAlgorithm = credential.sdAlgorithm?.toIanaName(),
+            selectiveDisclosureAlgorithm = credential.sdAlgorithm.toIanaName(),
             confirmationClaim = cnf,
             statusElement = vckJsonSerializer.encodeToJsonElement(credentialStatus),
         )

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreator.kt
@@ -40,7 +40,7 @@ object SdJwtCreator {
             with(honorNotDisclosableClaims().customPartition()) {
                 val objectClaimDigests: Collection<String> = recursiveClaims.mapNotNull { claim ->
                     claim.value as Collection<*>
-                    (claim.value.filterIsInstance<ClaimToBeIssued>()).toSdJsonObject(randomSource).let {
+                    (claim.value.filterIsInstance<ClaimToBeIssued>()).toSdJsonObject(randomSource, digest).let {
                         if (claim.selectivelyDisclosable) {
                             disclosures.addAll(it.second)
                             put(claim.name, it.first)
@@ -55,7 +55,7 @@ object SdJwtCreator {
                     }
                 }
                 val dotNotationClaims: Collection<String> = dotNotation.groupByDots().mapNotNull { (key, claims) ->
-                    claims.toSdJsonObject(randomSource).let {
+                    claims.toSdJsonObject(randomSource,digest).let {
                         disclosures.addAll(it.second)
                         put(key, it.first)
                         key.toSdItem(it.first, randomSource).toDisclosure()
@@ -65,7 +65,7 @@ object SdJwtCreator {
                 }
                 val dotNotationClaimsPlain: Collection<String> =
                     dotNotationPlain.groupByDots().mapNotNull { (key, claims) ->
-                        claims.toSdJsonObject(randomSource).let {
+                        claims.toSdJsonObject(randomSource, digest).let {
                             disclosures.addAll(it.second)
                             put(key, it.first)
                             null

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreator.kt
@@ -4,6 +4,7 @@ import at.asitplus.signum.indispensable.Digest
 import at.asitplus.wallet.lib.agent.SdJwtCreator.disallowedNames
 import at.asitplus.wallet.lib.agent.SdJwtCreator.toSdJsonObject
 import at.asitplus.wallet.lib.data.CredentialToJsonConverter.toJsonElement
+import at.asitplus.wallet.lib.data.SdJwtConstants
 import at.asitplus.wallet.lib.data.SdJwtConstants.NAME_SD
 import at.asitplus.wallet.lib.data.SdJwtConstants.SD_ALG
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
@@ -34,7 +35,7 @@ object SdJwtCreator {
      */
     fun Collection<ClaimToBeIssued>.toSdJsonObject(
         randomSource: RandomSource = RandomSource.Secure,
-        digest: Digest? = null,
+        digest: Digest = Digest.SHA256,
     ): Pair<JsonObject, Collection<String>> = mutableListOf<String>().let { disclosures ->
         buildJsonObject {
             with(honorNotDisclosableClaims().customPartition()) {
@@ -55,7 +56,7 @@ object SdJwtCreator {
                     }
                 }
                 val dotNotationClaims: Collection<String> = dotNotation.groupByDots().mapNotNull { (key, claims) ->
-                    claims.toSdJsonObject(randomSource,digest).let {
+                    claims.toSdJsonObject(randomSource, digest).let {
                         disclosures.addAll(it.second)
                         put(key, it.first)
                         key.toSdItem(it.first, randomSource).toDisclosure()
@@ -84,10 +85,7 @@ object SdJwtCreator {
                 (objectClaimDigests + dotNotationClaims + dotNotationClaimsPlain + singleClaimsDigests).let { digests ->
                     if (digests.isNotEmpty()) {
                         putJsonArray(NAME_SD) { addAll(digests) }
-
-                        if (digest != null) {
-                            put(SD_ALG, digest.toIanaName().toJsonElement())
-                        }
+                        put(SD_ALG, digest.toIanaName().toJsonElement())
                     }
                 }
             }
@@ -138,7 +136,7 @@ object SdJwtCreator {
     )
 
     private val disallowedNames = listOf(
-        "_sd_alg", "..."
+        SdJwtConstants.SD_ALG, "..."
     )
 
     /**

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -224,7 +224,8 @@ class VerifiablePresentationFactory(
             }.toSet()
         // Inner disclosures when an object has been requested by name (above), but contains more _sd entries
         val innerDisclosures = validSdJwtCredential.disclosures.entries.filter { claim ->
-            claim.asHashedDisclosure(validSdJwtCredential.sdJwt.selectiveDisclosureAlgorithm?.toDigest())?.let { hashedDisclosure ->
+            val digest = validSdJwtCredential.sdJwt.selectiveDisclosureAlgorithm?.toDigest() ?: Digest.SHA256
+            claim.asHashedDisclosure(digest)?.let { hashedDisclosure ->
                 disclosuresByName.any { it.containsHashedDisclosure(hashedDisclosure) }
             } == true
         }
@@ -240,7 +241,7 @@ class VerifiablePresentationFactory(
         return CreatePresentationResult.SdJwt(sdJwt.serialize(), sdJwt)
     }
 
-    private fun Map.Entry<String, SelectiveDisclosureItem?>.asHashedDisclosure(digest: Digest?): String? =
+    private fun Map.Entry<String, SelectiveDisclosureItem?>.asHashedDisclosure(digest: Digest): String? =
         value?.toDisclosure()?.hashDisclosure(digest)
 
     private fun Map.Entry<String, SelectiveDisclosureItem?>.containsHashedDisclosure(hashDisclosure: String): Boolean =

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -13,12 +13,11 @@ import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.openid.dcql.DCQLClaimsQueryResult
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult
-import at.asitplus.openid.digest
 import at.asitplus.signum.indispensable.Digest
 import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.josef.JwsSigned
-import at.asitplus.wallet.lib.agent.SdJwtCreator.NAME_SD
 import at.asitplus.wallet.lib.data.KeyBindingJws
+import at.asitplus.wallet.lib.data.SdJwtConstants.NAME_SD
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem.Companion.hashDisclosure
 import at.asitplus.wallet.lib.data.VerifiablePresentation
@@ -225,7 +224,7 @@ class VerifiablePresentationFactory(
             }.toSet()
         // Inner disclosures when an object has been requested by name (above), but contains more _sd entries
         val innerDisclosures = validSdJwtCredential.disclosures.entries.filter { claim ->
-            claim.asHashedDisclosure()?.let { hashedDisclosure ->
+            claim.asHashedDisclosure(null)?.let { hashedDisclosure ->
                 disclosuresByName.any { it.containsHashedDisclosure(hashedDisclosure) }
             } == true
         }
@@ -241,8 +240,8 @@ class VerifiablePresentationFactory(
         return CreatePresentationResult.SdJwt(sdJwt.serialize(), sdJwt)
     }
 
-    private fun Map.Entry<String, SelectiveDisclosureItem?>.asHashedDisclosure(): String? =
-        value?.toDisclosure()?.hashDisclosure()
+    private fun Map.Entry<String, SelectiveDisclosureItem?>.asHashedDisclosure(digest: Digest?): String? =
+        value?.toDisclosure()?.hashDisclosure(digest)
 
     private fun Map.Entry<String, SelectiveDisclosureItem?>.containsHashedDisclosure(hashDisclosure: String): Boolean =
         asJsonObject()?.sdElements()?.strings()?.any { it == hashDisclosure } == true

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -224,7 +224,7 @@ class VerifiablePresentationFactory(
             }.toSet()
         // Inner disclosures when an object has been requested by name (above), but contains more _sd entries
         val innerDisclosures = validSdJwtCredential.disclosures.entries.filter { claim ->
-            claim.asHashedDisclosure(null)?.let { hashedDisclosure ->
+            claim.asHashedDisclosure(validSdJwtCredential.sdJwt.selectiveDisclosureAlgorithm?.toDigest())?.let { hashedDisclosure ->
                 disclosuresByName.any { it.containsHashedDisclosure(hashedDisclosure) }
             } == true
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/sdJwt/SdJwtInputValidator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/sdJwt/SdJwtInputValidator.kt
@@ -1,6 +1,7 @@
 package at.asitplus.wallet.lib.agent.validation.sdJwt
 
 import at.asitplus.KmmResult
+import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.wallet.lib.agent.SdJwtDecoded
 import at.asitplus.wallet.lib.agent.Verifier
@@ -8,9 +9,8 @@ import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
 import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
-import io.github.aakira.napier.Napier
-import kotlin.time.Clock
 import kotlinx.serialization.json.buildJsonObject
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -36,7 +36,7 @@ data class SdJwtInputValidator(
             )
         }
 
-        val payloadJsonValidationSummary = sdJwtSigned.getPayloadAsJsonObject().map { jsonObject ->
+        val payloadJsonValidationSummary = catching {
             SdJwtDecoded(sdJwtSigned)
         }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/extensions/SdJwtSigned.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/extensions/SdJwtSigned.kt
@@ -1,7 +1,10 @@
 package at.asitplus.wallet.lib.extensions
 
+import at.asitplus.signum.indispensable.Digest
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import at.asitplus.wallet.lib.jws.SdJwtSigned
+
+val supportedSdAlgorithms = listOf(null, Digest.SHA256, Digest.SHA384, Digest.SHA512)
 
 fun SdJwtSigned.Companion.sdHashInput(
     validSdJwtCredential: SubjectCredentialStore.StoreEntry.SdJwt,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/extensions/SdJwtSigned.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/extensions/SdJwtSigned.kt
@@ -4,7 +4,7 @@ import at.asitplus.signum.indispensable.Digest
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 
-val supportedSdAlgorithms = listOf(null, Digest.SHA256, Digest.SHA384, Digest.SHA512)
+val supportedSdAlgorithms = listOf(Digest.SHA256, Digest.SHA384, Digest.SHA512)
 
 fun SdJwtSigned.Companion.sdHashInput(
     validSdJwtCredential: SubjectCredentialStore.StoreEntry.SdJwt,

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentComplexSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentComplexSdJwtTest.kt
@@ -4,20 +4,28 @@ import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.openid.OidcUserInfo
 import at.asitplus.openid.OidcUserInfoExtended
-import at.asitplus.openid.dcql.*
+import at.asitplus.openid.dcql.DCQLClaimsPathPointer
+import at.asitplus.openid.dcql.DCQLClaimsQueryList
+import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
+import at.asitplus.openid.dcql.DCQLCredentialQueryList
+import at.asitplus.openid.dcql.DCQLJsonClaimsQuery
+import at.asitplus.openid.dcql.DCQLQuery
+import at.asitplus.openid.dcql.DCQLSdJwtCredentialMetadataAndValidityConstraints
+import at.asitplus.openid.dcql.DCQLSdJwtCredentialQuery
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
-import at.asitplus.wallet.lib.data.CredentialPresentationRequest.PresentationExchangeRequest
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest.PresentationExchangeRequest
 import at.asitplus.wallet.lib.data.rfc3986.toUri
+import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import com.benasher44.uuid.uuid4
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import kotlin.time.Clock
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 
 
@@ -71,7 +79,7 @@ class AgentComplexSdJwtTest : FreeSpec({
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 1 // for address only
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -104,7 +112,7 @@ class AgentComplexSdJwtTest : FreeSpec({
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 2 // for region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -138,7 +146,7 @@ class AgentComplexSdJwtTest : FreeSpec({
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -169,7 +177,7 @@ class AgentComplexSdJwtTest : FreeSpec({
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -198,7 +206,7 @@ class AgentComplexSdJwtTest : FreeSpec({
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -229,7 +237,7 @@ class AgentComplexSdJwtTest : FreeSpec({
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 2 // claim_given_name, claim_family_name
                     reconstructedJsonObject[CLAIM_GIVEN_NAME]
@@ -266,7 +274,7 @@ class AgentComplexSdJwtTest : FreeSpec({
             val vp = createPresentation(holder, challenge, dcqlQuery, verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 1 // for address only
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -299,7 +307,7 @@ class AgentComplexSdJwtTest : FreeSpec({
             val vp = createPresentation(holder, challenge, dcqlQuery, verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 2 // for region, country
 
@@ -334,7 +342,7 @@ class AgentComplexSdJwtTest : FreeSpec({
             val vp = createPresentation(holder, challenge, dcqlQuery, verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -361,7 +369,7 @@ class AgentComplexSdJwtTest : FreeSpec({
             val vp = createPresentation(holder, challenge, dcqlQuery, verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -390,7 +398,7 @@ class AgentComplexSdJwtTest : FreeSpec({
             val vp = createPresentation(holder, challenge, dcqlQuery, verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -423,7 +431,7 @@ class AgentComplexSdJwtTest : FreeSpec({
             val vp = createPresentation(holder, challenge, dcqlQuery, verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            verifier.verifyPresentationSdJwt(vp.sdJwt!!, challenge)
+            verifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 2 // claim_given_name, claim_family_name
                     reconstructedJsonObject[CLAIM_GIVEN_NAME]
@@ -453,6 +461,7 @@ private suspend fun issueAndStoreCredential(
                 scheme = AtomicAttribute2023,
                 subjectPublicKey = holderKeyMaterial.publicKey,
                 userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
+                sdAlgorithm = supportedSdAlgorithms.random(),
             )
         ).getOrThrow().toStoreCredentialInput()
     )
@@ -464,7 +473,7 @@ private fun buildDCQLQuery(vararg claimsQueries: DCQLJsonClaimsQuery) = DCQLQuer
             id = DCQLCredentialQueryIdentifier(uuid4().toString()),
             format = CredentialFormatEnum.DC_SD_JWT,
             claims = DCQLClaimsQueryList(claimsQueries.toList().toNonEmptyList()),
-            meta = DCQLSdJwtCredentialMetadataAndValidityConstraints( listOf(AtomicAttribute2023.sdJwtType))
+            meta = DCQLSdJwtCredentialMetadataAndValidityConstraints(listOf(AtomicAttribute2023.sdJwtType))
         )
     )
 )

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/DummyCredentialDataProvider.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/DummyCredentialDataProvider.kt
@@ -2,6 +2,9 @@ package at.asitplus.wallet.lib.agent
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.iso.IssuerSignedItem
+import at.asitplus.openid.OidcUserInfo
+import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.wallet.lib.data.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex
@@ -9,12 +12,10 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_DATE_
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_PORTRAIT
-import at.asitplus.iso.IssuerSignedItem
-import at.asitplus.openid.OidcUserInfo
-import at.asitplus.openid.OidcUserInfoExtended
-import kotlin.time.Clock
+import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import kotlinx.datetime.LocalDate
 import kotlin.random.Random
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 
 object DummyCredentialDataProvider {
@@ -41,6 +42,7 @@ object DummyCredentialDataProvider {
                 scheme = credentialScheme,
                 subjectPublicKey = subjectPublicKey,
                 userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
+                sdAlgorithm = supportedSdAlgorithms.random()
             )
 
             ConstantIndex.CredentialRepresentation.PLAIN_JWT -> CredentialToBeIssued.VcJwt(

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreatorTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreatorTest.kt
@@ -1,6 +1,8 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.signum.indispensable.Digest
 import at.asitplus.wallet.lib.agent.SdJwtCreator.toSdJsonObject
+import at.asitplus.wallet.lib.data.SdJwtConstants
 import com.benasher44.uuid.uuid4
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldHaveSize
@@ -14,6 +16,16 @@ class SdJwtCreatorTest : FreeSpec({
         listOfClaims("name").toSdJsonObject(RandomSource.Default).apply {
             second.shouldHaveSize(1)
             first["_sd"]!!.jsonArray shouldHaveSize 1
+            first["_sd_alg"] shouldBe null
+            first["name"] shouldBe null
+        }
+    }
+
+    "digest can be specified" {
+        listOfClaims("name").toSdJsonObject(RandomSource.Default, Digest.SHA384).apply {
+            second.shouldHaveSize(1)
+            first["_sd"]!!.jsonArray shouldHaveSize 1
+            first["_sd_alg"] shouldBe SdJwtConstants.SHA_384
             first["name"] shouldBe null
         }
     }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreatorTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreatorTest.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.json.jsonArray
 class SdJwtCreatorTest : FreeSpec({
 
     "name can be selectively disclosed" {
-        listOfClaims("name").toSdJsonObject(RandomSource.Default).apply {
+        listOfClaims("name").toSdJsonObject(RandomSource.Default, null).apply {
             second.shouldHaveSize(1)
             first["_sd"]!!.jsonArray shouldHaveSize 1
             first["_sd_alg"] shouldBe null
@@ -32,7 +32,7 @@ class SdJwtCreatorTest : FreeSpec({
     }
 
     "issuer MUST be included in SD-JWT, i.e. can not be selectively disclosed" {
-        listOfClaims("name", "iss").toSdJsonObject(RandomSource.Default).apply {
+        listOfClaims("name", "iss").toSdJsonObject(RandomSource.Default, null).apply {
             second.shouldHaveSize(1)
             first["_sd"]!!.jsonArray shouldHaveSize 1
             first["name"] shouldBe null
@@ -41,7 +41,7 @@ class SdJwtCreatorTest : FreeSpec({
     }
 
     "nbf, cnf, vct, status MUST be included in SD-JWT, i.e. can not be selectively disclosed" {
-        listOfClaims("nbf", "cnf", "vct", "status").toSdJsonObject(RandomSource.Default).apply {
+        listOfClaims("nbf", "cnf", "vct", "status").toSdJsonObject(RandomSource.Default, null).apply {
             second.shouldHaveSize(0)
             first["_sd"] shouldBe null
             first["nbf"] shouldNotBe null
@@ -52,7 +52,7 @@ class SdJwtCreatorTest : FreeSpec({
     }
 
     "several names are disallowed" {
-        listOfClaims("_sd_alg", "...").toSdJsonObject(RandomSource.Default).apply {
+        listOfClaims("_sd_alg", "...").toSdJsonObject(RandomSource.Default, null).apply {
             second.shouldHaveSize(0)
             first["_sd"] shouldBe null
             first["_sd_alg"] shouldBe null

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreatorTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreatorTest.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.agent
 
 import at.asitplus.signum.indispensable.Digest
 import at.asitplus.wallet.lib.agent.SdJwtCreator.toSdJsonObject
+import at.asitplus.wallet.lib.data.CredentialToJsonConverter.toJsonElement
 import at.asitplus.wallet.lib.data.SdJwtConstants
 import com.benasher44.uuid.uuid4
 import io.kotest.core.spec.style.FreeSpec
@@ -25,7 +26,7 @@ class SdJwtCreatorTest : FreeSpec({
         listOfClaims("name").toSdJsonObject(RandomSource.Default, Digest.SHA384).apply {
             second.shouldHaveSize(1)
             first["_sd"]!!.jsonArray shouldHaveSize 1
-            first["_sd_alg"] shouldBe SdJwtConstants.SHA_384
+            first["_sd_alg"] shouldBe SdJwtConstants.SHA_384.toJsonElement()
             first["name"] shouldBe null
         }
     }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreatorTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/SdJwtCreatorTest.kt
@@ -14,10 +14,10 @@ import kotlinx.serialization.json.jsonArray
 class SdJwtCreatorTest : FreeSpec({
 
     "name can be selectively disclosed" {
-        listOfClaims("name").toSdJsonObject(RandomSource.Default, null).apply {
+        listOfClaims("name").toSdJsonObject(RandomSource.Default).apply {
             second.shouldHaveSize(1)
             first["_sd"]!!.jsonArray shouldHaveSize 1
-            first["_sd_alg"] shouldBe null
+            first["_sd_alg"] shouldBe SdJwtConstants.SHA_256.toJsonElement()
             first["name"] shouldBe null
         }
     }
@@ -32,7 +32,7 @@ class SdJwtCreatorTest : FreeSpec({
     }
 
     "issuer MUST be included in SD-JWT, i.e. can not be selectively disclosed" {
-        listOfClaims("name", "iss").toSdJsonObject(RandomSource.Default, null).apply {
+        listOfClaims("name", "iss").toSdJsonObject(RandomSource.Default).apply {
             second.shouldHaveSize(1)
             first["_sd"]!!.jsonArray shouldHaveSize 1
             first["name"] shouldBe null
@@ -41,7 +41,7 @@ class SdJwtCreatorTest : FreeSpec({
     }
 
     "nbf, cnf, vct, status MUST be included in SD-JWT, i.e. can not be selectively disclosed" {
-        listOfClaims("nbf", "cnf", "vct", "status").toSdJsonObject(RandomSource.Default, null).apply {
+        listOfClaims("nbf", "cnf", "vct", "status").toSdJsonObject(RandomSource.Default).apply {
             second.shouldHaveSize(0)
             first["_sd"] shouldBe null
             first["nbf"] shouldNotBe null
@@ -52,10 +52,9 @@ class SdJwtCreatorTest : FreeSpec({
     }
 
     "several names are disallowed" {
-        listOfClaims("_sd_alg", "...").toSdJsonObject(RandomSource.Default, null).apply {
+        listOfClaims("_sd_alg", "...").toSdJsonObject(RandomSource.Default).apply {
             second.shouldHaveSize(0)
             first["_sd"] shouldBe null
-            first["_sd_alg"] shouldBe null
             first["..."] shouldBe null
         }
     }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
@@ -147,7 +147,7 @@ private suspend fun issueVcSd(
         issuedAt = issuanceDate,
         jwtId = vcId,
         verifiableCredentialType = credential.scheme.sdJwtType ?: credential.scheme.schemaUri,
-        selectiveDisclosureAlgorithm = credential.sdAlgorithm?.toIanaName(),
+        selectiveDisclosureAlgorithm = credential.sdAlgorithm.toIanaName(),
         confirmationClaim = if (!buildCnf) null else
             ConfirmationClaim(jsonWebKey = credential.subjectPublicKey.toJsonWebKey())
     )

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
@@ -7,7 +7,6 @@ import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.wallet.lib.agent.SdJwtCreator.toSdJsonObject
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
-import at.asitplus.wallet.lib.data.SdJwtConstants
 import at.asitplus.wallet.lib.data.SdJwtTypeMetadata
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.rfc3986.toUri
@@ -19,7 +18,6 @@ import at.asitplus.wallet.lib.jws.SdJwtSigned
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.jws.SignJwtFun
 import com.benasher44.uuid.uuid4
-import io.github.aakira.napier.Napier
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -140,7 +138,7 @@ private suspend fun issueVcSd(
     val vcId = "urn:uuid:${uuid4()}"
     val expirationDate = credential.expiration
     val subjectId = credential.subjectPublicKey.didEncoded
-    val (sdJwt, disclosures) = credential.claims.toSdJsonObject(RandomSource.Default)
+    val (sdJwt, disclosures) = credential.claims.toSdJsonObject(RandomSource.Default, credential.sdAlgorithm)
     val vcSdJwt = VerifiableCredentialSdJwt(
         subject = if (scrambleSubject) subjectId.reversed() else subjectId,
         notBefore = issuanceDate,
@@ -149,7 +147,7 @@ private suspend fun issueVcSd(
         issuedAt = issuanceDate,
         jwtId = vcId,
         verifiableCredentialType = credential.scheme.sdJwtType ?: credential.scheme.schemaUri,
-        selectiveDisclosureAlgorithm = SdJwtConstants.SHA_256,
+        selectiveDisclosureAlgorithm = credential.sdAlgorithm?.toIanaName(),
         confirmationClaim = if (!buildCnf) null else
             ConfirmationClaim(jsonWebKey = credential.subjectPublicKey.toJsonWebKey())
     )

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/SdJwtSerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/SdJwtSerializationTest.kt
@@ -121,7 +121,7 @@ class SdJwtSerializationTest : FreeSpec({
         // different whitespaces may lead to a different string, obviously!
         disclosure shouldBe "WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsImZhbWlseV9uYW1lIiwiTcO2Yml1cyJd"
 
-        "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIkZSIl0".hashDisclosure() shouldBe "w0I8EKcdCtUPkGCNUrfwVp2xEgNjtoIDlOxc9-PlOhs"
+        "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIkZSIl0".hashDisclosure(null) shouldBe "w0I8EKcdCtUPkGCNUrfwVp2xEgNjtoIDlOxc9-PlOhs"
     }
 
     "Serialize nested Byte Array" {

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/SdJwtSerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/SdJwtSerializationTest.kt
@@ -121,7 +121,7 @@ class SdJwtSerializationTest : FreeSpec({
         // different whitespaces may lead to a different string, obviously!
         disclosure shouldBe "WyJfMjZiYzRMVC1hYzZxMktJNmNCVzVlcyIsImZhbWlseV9uYW1lIiwiTcO2Yml1cyJd"
 
-        "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIkZSIl0".hashDisclosure(null) shouldBe "w0I8EKcdCtUPkGCNUrfwVp2xEgNjtoIDlOxc9-PlOhs"
+        "WyJsa2x4RjVqTVlsR1RQVW92TU5JdkNBIiwgIkZSIl0".hashDisclosure() shouldBe "w0I8EKcdCtUPkGCNUrfwVp2xEgNjtoIDlOxc9-PlOhs"
     }
 
     "Serialize nested Byte Array" {


### PR DESCRIPTION
Implements `_sd_alg` parameter as defined in https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/  Ch 4.1.1 which allows issuer to specify which digest they want to use for selective disclosure and verification thereof. 
Currently we only support SHA256 and ignore this parameter.