### PR TITLE
Release 5.9.0

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -38,13 +38,38 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
       - name: Publish to Maven Local
-        run: ./gradlew -Dpublishing.excludeIncludedBuilds=true clean publishToMavenLocal
+        run: ./gradlew -Dpublishing.excludeIncludedBuilds=true clean publishAllPublicationsToLocalRepository
         env:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PUBLISH_SIGNING_KEYID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PUBLISH_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PUBLISH_SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.PUBLISH_SONATYPE_USER }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.PUBLISH_SONATYPE_PASSWORD }}
+      - name: List published Maven-local artifacts
+        if: success() || failure()        # always run so the table appears even if publish failed
+        shell: bash
+        run: |
+          ART_DIR="./repo/at/asitplus/wallet"
+          ls -la $ART_DIR
+          # Header
+          {
+            echo "### Maven-local artifacts for \`at.asitplus.wallet\`"
+            echo ""
+            echo "| Module | Version | File |"
+            echo "|--------|---------|------|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Abort early if nothing was written
+          [[ -d "$ART_DIR" ]] || { echo "| _No artifacts found_ |  |  |" >> "$GITHUB_STEP_SUMMARY"; exit 0; }
+
+          # Collect artifacts (jar / klib / aar / pom) and append table rows
+          find "$ART_DIR" -type f \( -name "*.jar" -o -name "*.klib" -o -name "*.aar" -o -name "*.pom" \) \
+            | sort \
+            | while read -r file; do
+                rel="${file#${ART_DIR}/}"        # => module/version/filename
+                IFS='/' read -r module version filename <<< "$rel"
+                echo "| \`$module\` | \`$version\` | \`$filename\` |" >> "$GITHUB_STEP_SUMMARY"
+              done
   deploy-docs:
     needs: build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Release 5.9.0 (unreleased):
+Release 5.9.0
  - Refactor `RqesWalletService` to be stateless
  - Remove code elements deprecated in 5.8.0
  - Gradle modules: 

--- a/conventions-vclib/src/main/kotlin/VcLibConventions.kt
+++ b/conventions-vclib/src/main/kotlin/VcLibConventions.kt
@@ -79,6 +79,8 @@ class VcLibConventions : K2Conventions() {
                     maxHeapSize = "4G"
                 }
 
+                target.compileVersionCatalog()
+                target.setupSignDependency()
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 5.9.0-SNAPSHOT
+artifactVersion = 5.9.0
 
 # JVM version, auto download
 jdk.version=17


### PR DESCRIPTION
 - Refactor `RqesWalletService` to be stateless
 - Remove code elements deprecated in 5.8.0
 - Gradle modules: 
   - Change dependency structure of modules
   - Remove `vck-rqes` module, relevant classes have been moved to `vck-openid` 
   - Rename `rqes-data-classes` to `csc-data-classes`
   - Move DIF-related classes to `dif-data-classes`
   - Move OpenId-related classes to `openid-data-classes`
   - Remove class `Initializer` from `vck-openid`
 - Remote Qualified Electronic Signatures:
   - Remove "UC5-flow" option in RQES flows
   - Remove `transactionData` from `KeyBindingJws`
   - Remove `QesAuthorizationDetails`
   - Refactor `AuthorizationDetails` to sealed class
   - Remove `QesInputDescriptor`
   - Refactor `InputDescriptor` to sealed class
   - Remove `RqesRequestOptions`
   - Remove `RequestOptions` interface
   - Rename `OpenIdRequestOptions` to `RequestOptions`
   - Refactor `TransactionData` to sealed class
   - In `TransactionData` make `credentialIds` mandatory
   - Refactor `RequestParameters` to sealed class
 - Validation:
   - Improve validation of JWT VC
   - Remove subclass `InvalidStructure` from `Verifier.VerifyCredentialResult`, is now mapped to `ValidationError`
 - Refactor handling of key material:
   - Introduce interface `PublishedKeyMaterial` to indicate clients can lookup that key with the `identifier` used as a `keyId` in a key set
   - Other key material gets randomly assigned identifiers to not rely on DIDs
   - For JVM add `PublishedKeyStoreMaterial` to load keys from Java key stores with a fixed identifier
   - In class `HolderAgent` require the `identifier` to be a URI, set in the constructor, as required for SD-JWT and JWT VC
   - Key material will be referenced by its `keyId` and key set URL or by its certificate or plain public key in JWS proofs
 - Remove workarounds and deprecated features:
   - OpenID4VP: Verify mDoc generated nonce correctly (not supporting broken EUDIW RI)
   - OpenID4VP: Only send the `response` parameter when using `direct_post.jwt` (not supporting broken EUDIW RI)
   - OpenID4VP: Use credential format identifier `dc+sd-jwt` everywhere
   - OpenID4VP: Discard option to use deprecated `client_id_scheme` parameter in `ClientIdScheme` subclasses
   - OpenID4VP: Do not read the explicit parameter `client_id_scheme` (it's prefixed in the `client_id`)
   - OpenID4VP: Do not send signed JWT as authentication responses, but always encrypt them when using `direct_post.jwt`
   - OpenID4VP: Remove `signDeviceAuthFallback` in `OpenId4VpHolder` which has been used for mDoc presentations, but was not part of any spec
   - OpenID4VP: Remove `BackwardsCompatibleDCQLQuerySerializer` which has been able to parse DCQL queries as strings in addition to the usual JSON object
   - OpenID4VP: Never sign responses, either send it in plain or encrypted (OpenID4VP 1.0 has dropped JARM)
   - DCAPI: Remove (already deprecated) preview data class `PreviewDCAPIRequest`, either use OpenID4VP or ISO 18013-7 Annex C
 - JWE:
   - Add `EncryptJweSymmetricFun` and `EncryptJweSymmetric` and `DecryptJweSymmetric`
 - OAuth 2.0:
   - Refactor the split between credential issuer (OpenID4VCI) and authorization server (OAuth2.0)
   - `SimpleAuthorizationService` supports token exchange acc. to [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693)
   - `SimpleAuthorizationService` supports token introspection acc. to [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)
   - Implement `RemoteOAuth2AuthorizationServerAdapter` so that credential issuers may be connected to external OAuth2.0 authorization servers
   - Implement `OAuth2KtorClient` to implement a ktor-based client for OAuth 2.0, including [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)  
   - Remove generics from methods in `OpenId4VpHolder` and work directly with `AuthorizationRequestParameters`
   - In `PresentationFactory` replace `RequestParameters` in function signatures to work directly with `AuthorizationRequestParameters`
   - Remove all parameters from `RequestParameters`, moved into their respective implementing class
   - Add data class `JarRequestParameters` implementing `RequestParameters` to handle [JWT-secured authorization requests](https://www.rfc-editor.org/rfc/rfc9101.html) explicitly
   - In `AuthorizationService` and `SimpleAuthorizationService` deprecate method `authorize` with `AuthenticationRequestParameters`, use `RequestParameters` instead
   - In `AuthorizationService` and `SimpleAuthorizationService` deprecate method `par` with `AuthenticationRequestParameters`, use `RequestParameters` instead
   - In `OAuth2Client` add method `createAuthRequestJar` to make intent more explicit
   - Allow `SimpleAuthorizationService` to toggle usage of PAR and JAR with new `requirePushedAuthorizationRequests` and `requestObjectSigningAlgorithms` parameters 
 - Cryptography:
   - Use [secure random](https://github.com/KotlinCrypto/random) for source of nonces by default, but also expose constructor parameters to override it
 - Update implementation of [OpenID for Verifiable Credential Issuance](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) to draft 17:
   - Offer `signedMetadata` in `CredentialIssuer`
   - In `OpenIdAuthorizationDetails` deprecate properties that have been dropped from the spec: `format`, `docType`, `sdJwtVcType` and `credentialDefinition`
   - In `SupportedCredentialFormat` add new property about `CredentialMetadata`, moving `display` and `claims`
   - In `TokenResponseParameters` remove `clientNonce` that has been dropped in OID4VCI draft 14
   - In `CredentialRequestParameters` deprecate `proof`, use `proofs` instead
   - Use correct error values for `unknown_credential_configuration` and `unknown_credential_identifier`
   - In `CredentialIssuer` deprecate constructor parameters `encryptCredentialRequest`, `requireEncryption`, `supportedJweAlgorithms`, `supportedJweEncryptionAlgorithms`
   - In `CredentialIssuer` introduce constructor parameter `encryptionService` which handles credential request decryption and credential response encryption
   - In `CredentialIssuer` deprecate method `nonce()`
   - In `CredentialIssuer` add method `nonceWithDpopNonce()` to provide a DPoP nonce to clients (only when the AS is internal)
   - In `CredentialIssuer` use the COSE algorithm identifiers (e.g. -7) for signing algorithm values in the metadata
   - In `WalletService` deprecate constructor parameters `requestEncryption`, `decryptionKeyMaterial`, `supportedJweAlgorithm`, `supportedJweEncryptionAlgorithm`
   - In `WalletService` introduce constructor parameter `encryptionService` which handles credential request encryption and credential response decryption
   - In `WalletService` add method `parseCredentialResponse` to transform the received credential response from the issuer into `StoreCredentialInput`
   - In `WalletService` deprecate method `createCredentialRequest` and replace it with `createCredential` to handle encryption
  - Presentation classes:
   - In `CreatePresentationResult.Signed` add property containing `JwsSigned<VerifiablePresentationJws>`
   - In `CreatePresentationResult.SdJwt` add property containing `SdJwtSigned`
   - Deprecate `SdJwtSigned.parse()`, please migrate to `SdJwtSigned.parseCatching()`
 - OpenID for Verifiable Presentations: Update implementation to [draft 29](https://openid.net/specs/openid-4-verifiable-presentations-1_0-29.html#name-document-history):
   - In `AuthenticationRequestParameters` deprecate member `client_metadata_uri`
   - In `RequestOptions` deprecate member `clientMetadataUrl`
   - In `OpenIdConstants` deprecate member `X509SanUri`
   - In `AuthenticationRequestParameters` and `AuthorizationResponsePreparationState` add `VerifierInfo` to display to user
   - In `RelyingPartyMetadata` deprecate `vp_formats`, replace with `vp_formats_supported`, using correct algorithm values
   - Change `DCQLCredentialQuery.meta` to be mandatory
   - Add `DCQLEmptyCredentialMetadataAndValidityConstraints`
   - In `OpenId4VpVerifier` add constructor parameter `decryptionKeyMaterial` to supply a key for decrypting encrypted responses from holders
   - In `OAuth2AuthorizationServerMetadata` deprecate `client_id_schemes_supported`, replace with `client_id_prefixes_supported`
   - Add `ClientIdScheme.CertificateHash` mapping to client identifier prefix `x509_hash` from OpenID4VP
   - Use session transcript for mDoc presentations as defined in OpenID4VP
   - Deprecate and refactor methods in `OpenId4VpHolder` and `OpenId4VpWallet` to fetch external resources only once, clients need to call `startAuthorizationResponsePreparation()` and then `finalizeAuthorizationResponse()`
   - `OpenId4VpHolder` does not return a `KmmResult.failure` when building the response fails, but returns `AuthenticationResponseResult` containing error parameters
   - `OpenId4VpWallet` does not send an error response to the verifier automatically
   - Extend `RequestParametersFrom` with sub-classes for `DcApiSigned` and `DcApiUnsigned`, removing the parameter `dcApiRequest` from several methods in `OpenId4VpVerifier` and `OpenId4VpWallet`
   - Extend `RequestParametersFrom.JwsSigned` with a `parent` member
   - Extend `RequestParametersFrom.Json` with a `parent` member
 - SD-JWT:
   - Honour digest defined in `_sd_alg` parameter to allow for more digests in issuance and verification of selective disclosures items
 - Make it possible to disable all apple targets by setting Gradle property `disableAppleTargets=true` (either through `gradle.properties`/`local.properties` or as env variable)
 - Dependency Updates:
   - Kotlin 2.2.21
   - Signum 3.18.2 / Supreme 0.10.2
 - Build Updates:
   - AGP 8.12.3 with new Android KMP Library Plugin
   - Migrate from Kotest to TestBalloon
   - Remove dodgy Swift-Klib workarounds