### PR TITLE
Allow injecting clocks into time-sensitive flows

### DIFF
--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredential.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredential.kt
@@ -39,8 +39,9 @@ data class VerifiableCredential(
         credentialStatus: Status,
         credentialSubject: CredentialSubject,
         credentialType: String,
-        issuanceDate: Instant = Clock.System.now(),
-        expirationDate: Instant? = Clock.System.now() + lifetime,
+        clock: Clock = Clock.System,
+        issuanceDate: Instant = clock.now(),
+        expirationDate: Instant? = issuanceDate + lifetime,
     ) : this(
         id = id,
         type = listOf(VERIFIABLE_CREDENTIAL, credentialType),

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialTest.kt
@@ -1,0 +1,50 @@
+package at.asitplus.wallet.lib.data
+
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListInfo
+import at.asitplus.wallet.lib.data.rfc3986.UniformResourceIdentifier
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+class VerifiableCredentialTest : FunSpec({
+
+    test("convenience constructor uses provided clock for issuance and expiration") {
+        val issuanceInstant = Instant.fromEpochMilliseconds(1_726_358_400_000)
+        val lifetime: Duration = 15.minutes
+        val clock = object : Clock {
+            override fun now(): Instant = issuanceInstant
+        }
+
+        val status = Status(
+            statusList = StatusListInfo(
+                index = 0u,
+                uri = UniformResourceIdentifier("https://example.com/status-list"),
+            ),
+        )
+
+        val credential = VerifiableCredential(
+            id = "urn:uuid:test",
+            issuer = "did:example:issuer",
+            lifetime = lifetime,
+            credentialStatus = status,
+            credentialSubject = TestCredentialSubject("did:example:holder"),
+            credentialType = "ExampleCredential",
+            clock = clock,
+        )
+
+        credential.issuanceDate shouldBe issuanceInstant
+        credential.expirationDate shouldBe issuanceInstant + lifetime
+    }
+})
+
+@Serializable
+private data class TestCredentialSubject(
+    @SerialName("id")
+    override val id: String,
+) : CredentialSubject()
+

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensionsClockTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2SecurityExtensionsClockTest.kt
@@ -1,0 +1,64 @@
+package at.asitplus.wallet.lib.oidvci
+
+import at.asitplus.signum.indispensable.josef.JsonWebToken
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
+import at.asitplus.wallet.lib.jws.SignJwt
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+class OAuth2SecurityExtensionsClockTest : FunSpec({
+
+    val keyMaterial = EphemeralKeyWithoutCert()
+    val signJwt = SignJwt<JsonWebToken>(keyMaterial, JwsHeaderNone())
+    val fixedInstant = Instant.fromEpochMilliseconds(1_726_358_400_000)
+    val clock = object : Clock {
+        override fun now(): Instant = fixedInstant
+    }
+
+    test("client attestation JWT honors provided clock") {
+        val lifetime = 60.minutes
+        val clockSkew = 5.minutes
+
+        val signed = BuildClientAttestationJwt(
+            signJwt = signJwt,
+            clientId = "client-id",
+            issuer = "issuer",
+            clientKey = keyMaterial.jsonWebKey,
+            lifetime = lifetime,
+            clockSkew = clockSkew,
+            clock = clock,
+        )
+
+        val payload = signed.payload
+        payload.issuedAt shouldBe fixedInstant - clockSkew
+        payload.expiration shouldBe fixedInstant - clockSkew + lifetime
+        payload.confirmationClaim.shouldNotBeNull()
+    }
+
+    test("client attestation PoP JWT honors provided clock") {
+        val lifetime = 10.minutes
+        val clockSkew = 2.minutes
+
+        val signed = BuildClientAttestationPoPJwt(
+            signJwt = signJwt,
+            clientId = "client-id",
+            audience = "https://authorization.server",
+            lifetime = lifetime,
+            clockSkew = clockSkew,
+            randomSource = RandomSource.Secure,
+            clock = clock,
+        )
+
+        val payload = signed.payload
+        payload.issuedAt shouldBe fixedInstant - clockSkew
+        payload.expiration shouldBe fixedInstant - clockSkew + lifetime
+        payload.jwtId.shouldNotBeNull()
+    }
+})
+

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -43,6 +43,7 @@ class VerifiablePresentationFactory(
         SignJwt(keyMaterial, JwsHeaderCertOrJwk()),
     private val signKeyBinding: SignJwtFun<KeyBindingJws> =
         SignJwt(keyMaterial, JwsHeaderNone()),
+    private val clock: Clock = Clock.System,
 ) {
 
     suspend fun createVerifiablePresentationForIsoCredentials(
@@ -260,7 +261,7 @@ class VerifiablePresentationFactory(
     ): JwsSigned<KeyBindingJws> = signKeyBinding(
         JwsContentTypeConstants.KB_JWT,
         KeyBindingJws(
-            issuedAt = Clock.System.now(),
+            issuedAt = clock.now(),
             audience = request.audience,
             challenge = request.nonce,
             sdHash = issuerJwtPlusDisclosures.encodeToByteArray().sha256(),

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/X509CertificateExtension.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/X509CertificateExtension.kt
@@ -23,10 +23,11 @@ suspend fun X509Certificate.Companion.generateSelfSignedCertificate(
     algorithm: X509SignatureAlgorithm,
     lifetimeInSeconds: Long = 30,
     extensions: List<X509CertificateExtension> = listOf(),
+    clock: Clock = Clock.System,
     signer: suspend (ByteArray) -> KmmResult<CryptoSignature>,
 ): KmmResult<X509Certificate> = catching {
     Napier.d { "Generating self-signed Certificate" }
-    val notBeforeDate = Clock.System.now()
+    val notBeforeDate = clock.now()
     val notAfterDate = notBeforeDate.plus(lifetimeInSeconds, DateTimeUnit.SECOND)
     val tbsCertificate = TbsCertificate(
         version = 2,


### PR DESCRIPTION
## Summary
- add clock injection to time-sensitive factories and builders so they no longer call Clock.System.now() directly
- update VerifiableCredential defaults to derive timestamps from an injectable clock
- add unit tests covering the new clock-aware behaviour for credential creation and OAuth2 attestation helpers

## Testing
- ./gradlew :vck:check *(fails: Gradle could not provision Java 17 toolchain in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_68ed4445b4f48330819acfbc396cad8e)