### PR TITLE
haip d05 status list token constraint verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,7 @@
 # Changelog
 
 Release 5.11.0 (unreleased):
-- StatusListToken:
-    - Remove `StatusTokenValidator`
-    - Remove `StatusTokenIntegrityValidator` class
-    - Refactor `StatusListToken.StatusListJwt` to `StatusListJwt`
-    - Refactor `StatusListToken.StatusListCwt` to `StatusListCwt`
-    - Add `VerifyStatusListTokenHAIP` and related resolver/tests to enforce HAIP d04 certificate chain rules for status list JWTs
+ - Add `VerifyStatusListTokenHAIP` and related resolver/tests to enforce HAIP d04
 
 Release 5.10.1:
  - Proximity presentations:
@@ -17,7 +12,12 @@ Release 5.10.1:
    - In `OpenId4VpVerifier` add option to provide `externalId` to methods `validateAuthnRequest()` and `submitAuthnRequest()`, useful for DCAPI flows
 
 Release 5.10.0:
-- OAuth 2.0:
+ - StatusListToken:
+   - Remove `StatusTokenValidator`
+   - Remove `StatusTokenIntegrityValidator` class
+   - Refactor `StatusListToken.StatusListJwt` to `StatusListJwt`
+   - Refactor `StatusListToken.StatusListCwt` to `StatusListCwt`
+ - OAuth 2.0:
    - Use correct path for metadata retrieval (inserting strings between host component and path component)
    - Support reading resource-server provided nonce for [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)
    - Use pushed authorization requests when AS supports it
@@ -45,8 +45,16 @@ Release 5.10.0:
    - When returning multiple ISO mDoc credentials, make sure to create one device response object per document, wrapping in separate VP tokens
  - SD-JWT:
    - Fix creation of SD JWTs containing structures that are selectively disclosable
+   - Fix creation of arrays in SD JWTs ... issuers are advised to use `ClaimToBeIssuedArrayElement` for such elements
+ - Issuance:
+   - Introduce duration to subtract for the issuance date of credentials, see `IssuerAgent.issuanceOffset`
+   - Do not issue SD-JWT credentials with a unique identifier in `jti`
+   - Truncate issuing timestamps to seconds
  - Remote Qualified Electronic Signatures:
    - Remove modules deprecated in 5.9.0: `vck-rqes`, `rqes-data-classes`
+
+Release 5.9.1
+- Remove bogus testballoon-shim dependency
 
 Release 5.9.0
  - Remove code elements deprecated in 5.8.0
@@ -728,70 +736,3 @@ Release 5.0.0:
    - In `OidcSiopVerifier` move `responseUrl` from constructor parameter to `RequestOptions`
    - Add `IdToken` as result case to `OidcSiopVerifier.AuthnResponseResult`, when only an `id_token` is requested and received
  - Disclosures for SD-JWT (in class `SelectiveDisclosureItem`) now contain a `JsonPrimitive` for the value, so that implementers can deserialize the value accordingly
-
-Release 4.1.2:
- * In `OidcSiopVerifier` add parameter `nonceService` to externalize creation and validation of nonces, e.g. for deployments in load-balanced environments
- * In `SimpleAuthorizationService` change type of `tokenService` to `NonceService`
- * Add constructor parameters to `SimpleAuthorizationService` to externalize storage of maps, e.g. for deployments in load-balanced environments
- * Add constructor parameter to `WalletService` to externalize storage of state-to-code map, e.g. for deployments in load-balanced environments
-* Update to latest Signum for KMP signer and verifier.
-* Update dependencies:
-  * Kotlin 2.0.20
-  * Serialization 1.7.2 stable
-  * JsonPath4K 2.3.0
-* Add Android targets
-
-Release 4.1.1 (Bugfix Release):
-* correctly configure and name JSON serializer:
-  * `jsonSerializer` -> `vckJsonSerializer`
-  * revert to explicit serializer configuration
-  * Introduce `jsonSerializer` and `cborSerilaizer` with deprecation annotation for easier migration in projects consuming VC-K
-* rename kmp-crypto submodule to signum an update all references
-  * this changes the identifier in the version catalog!
-
-Release 4.1.0:
- * Rebrand
-   * Project name: _KMM VC Library_ -> VC-K
-   * Artifact names:
-     * `vclib` -> `vck`
-     * `vclib-aries` -> `vck-aries`
-     * `vclib-openid` -> `vck-openid`
- * Rename serializers to avoid ambiguities and kotlin bugs
-   * `jsonSerializer` -> `vckJsonSerializer`
-   * `cborSerializer` -> `vckCborSerializer`
- * Update Dependencies
-   * Signum (formerly KMP Crypto): 3.6.0
-   * Jsonpath4K (formerly Jsonpath): 2.2.0
-   * Kotlinx-Serialization 1.8.0-SNAPSHOT from upstream
-
-Release 4.0.0:
- - Add `SubmissionRequirement.evaluate`: Evaluates, whether a given submission requirement is satisfied.
- - Add `PresentationSubmissionValidator`: 
-   - Add `isValidSubmission`: Evaluates, whether all submission requirements is satisfied, and fails on redundantly submitted credentials.
-   - Add `findUnnecessaryInputDescriptorSubmissions`: Returns a list of redundantly submitted credentials.
- - Rename `BaseInputEvaluator` -> `InputEvaluator`
-   - Change `evaluateFieldQueryResults` -> `evaluateConstraintFieldMatches`: Returns all matching fields now, not just the first match
- - Change `Holder.matchInputDescriptorsAgainstCredentialStore`: Returns all matching credentials now, not just the first match
- - Do not use or assume DID as key identifiers and subjects in credentials
- - Replace list of attribute types in `Issuer.issueCredentials` with one concrete `CredentialScheme` to be passed
- - Remove functionality related to "attachments" to verifable credentials in JWT format
- - Replace list of credentials to be issued with a single credential that will be issued per call to implementations of `IssuerCredentialDataProvider`
- - Get rid of class `Issuer.IssuedCredentialResult`, replacing it with `KmmResult<Issuer.IssuedCredential>`
- - Add return types to function calls to `SubjectCredentialStore`
- - Change from list to single credential in parameter for `Holder.storeCredentials()`, changing name to `storeCredential()`
- - Refactor `AuthenticationRequestParametersFrom` used in `OidcSiopWallet` to be serializable
- - Add `AuthenticationResponseFactory`: Builds an authentication response from request and response parameters
- - Change `OidcSiopWallet`: 
-   - Add `startAuthorizationResponsePreparation()`: Gathers data necessary for presentation building and yields a `AuthorizationResponsePreparationState`
-   - Add `finalizeAuthorizationResponseParameters()`: Returns what `createAuthenticationParams` returned before, but also takes in `AuthorizationResponsePreparationState` and an optional non-default submission
-   - Add `finalizeAuthorizationResponse()`: Returns what `createAuthenticationResponse()` did before
- - Change `OidcSiopVerifier`:
-   - Add `createAuthnRequestUrlWithRequestObjectByReference()` to offer authentication requests by reference to the Wallet
- - Add `AuthorizationResponsePreparationState`: Holds data necessary for presentation building
- - Add `AuthenticationRequestParser`: Extracted presentation request parsing logic from `OidcSiopWallet` and put it here
- - Add `AuthorizationRequestValidator`: Extracted presentation request validation logic from `OidcSiopWallet` and put it here
- - Add `PresentationFactory`: Extracted presentation response building logic from `OidcSiopWallet` and put it here
-   - Also added some code for presentation submission validation
- - Update implementation of OpenID 4 Verifiable Credential Issuance, draft 13
- - Replace `createCredentialRequestJwt()` and `createCredentialRequestCwt()` with `createCredentialRequest()` in `WalletService` for OID4VCI
- - Refactor `createTokenRequestParameters()` in `WalletService` for OID4VCI to account for authorization code or pre-auth code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 Release 5.11.0 (unreleased):
+- StatusListToken:
+    - Remove `StatusTokenValidator`
+    - Remove `StatusTokenIntegrityValidator` class
+    - Refactor `StatusListToken.StatusListJwt` to `StatusListJwt`
+    - Refactor `StatusListToken.StatusListCwt` to `StatusListCwt`
+    - Add `VerifyStatusListTokenHAIP` and related resolver/tests to enforce HAIP d04 certificate chain rules for status list JWTs
 
 Release 5.10.1:
  - Proximity presentations:
@@ -11,12 +17,7 @@ Release 5.10.1:
    - In `OpenId4VpVerifier` add option to provide `externalId` to methods `validateAuthnRequest()` and `submitAuthnRequest()`, useful for DCAPI flows
 
 Release 5.10.0:
- - StatusListToken:
-   - Remove `StatusTokenValidator`
-   - Remove `StatusTokenIntegrityValidator` class
-   - Refactor `StatusListToken.StatusListJwt` to `StatusListJwt`
-   - Refactor `StatusListToken.StatusListCwt` to `StatusListCwt`
- - OAuth 2.0:
+- OAuth 2.0:
    - Use correct path for metadata retrieval (inserting strings between host component and path component)
    - Support reading resource-server provided nonce for [OAuth 2.0 Demonstrating Proof of Possession (DPoP)](https://datatracker.ietf.org/doc/html/rfc9449)
    - Use pushed authorization requests when AS supports it
@@ -44,16 +45,8 @@ Release 5.10.0:
    - When returning multiple ISO mDoc credentials, make sure to create one device response object per document, wrapping in separate VP tokens
  - SD-JWT:
    - Fix creation of SD JWTs containing structures that are selectively disclosable
-   - Fix creation of arrays in SD JWTs ... issuers are advised to use `ClaimToBeIssuedArrayElement` for such elements
- - Issuance:
-   - Introduce duration to subtract for the issuance date of credentials, see `IssuerAgent.issuanceOffset`
-   - Do not issue SD-JWT credentials with a unique identifier in `jti`
-   - Truncate issuing timestamps to seconds
  - Remote Qualified Electronic Signatures:
    - Remove modules deprecated in 5.9.0: `vck-rqes`, `rqes-data-classes`
-
-Release 5.9.1
-- Remove bogus testballoon-shim dependency
 
 Release 5.9.0
  - Remove code elements deprecated in 5.8.0
@@ -735,3 +728,70 @@ Release 5.0.0:
    - In `OidcSiopVerifier` move `responseUrl` from constructor parameter to `RequestOptions`
    - Add `IdToken` as result case to `OidcSiopVerifier.AuthnResponseResult`, when only an `id_token` is requested and received
  - Disclosures for SD-JWT (in class `SelectiveDisclosureItem`) now contain a `JsonPrimitive` for the value, so that implementers can deserialize the value accordingly
+
+Release 4.1.2:
+ * In `OidcSiopVerifier` add parameter `nonceService` to externalize creation and validation of nonces, e.g. for deployments in load-balanced environments
+ * In `SimpleAuthorizationService` change type of `tokenService` to `NonceService`
+ * Add constructor parameters to `SimpleAuthorizationService` to externalize storage of maps, e.g. for deployments in load-balanced environments
+ * Add constructor parameter to `WalletService` to externalize storage of state-to-code map, e.g. for deployments in load-balanced environments
+* Update to latest Signum for KMP signer and verifier.
+* Update dependencies:
+  * Kotlin 2.0.20
+  * Serialization 1.7.2 stable
+  * JsonPath4K 2.3.0
+* Add Android targets
+
+Release 4.1.1 (Bugfix Release):
+* correctly configure and name JSON serializer:
+  * `jsonSerializer` -> `vckJsonSerializer`
+  * revert to explicit serializer configuration
+  * Introduce `jsonSerializer` and `cborSerilaizer` with deprecation annotation for easier migration in projects consuming VC-K
+* rename kmp-crypto submodule to signum an update all references
+  * this changes the identifier in the version catalog!
+
+Release 4.1.0:
+ * Rebrand
+   * Project name: _KMM VC Library_ -> VC-K
+   * Artifact names:
+     * `vclib` -> `vck`
+     * `vclib-aries` -> `vck-aries`
+     * `vclib-openid` -> `vck-openid`
+ * Rename serializers to avoid ambiguities and kotlin bugs
+   * `jsonSerializer` -> `vckJsonSerializer`
+   * `cborSerializer` -> `vckCborSerializer`
+ * Update Dependencies
+   * Signum (formerly KMP Crypto): 3.6.0
+   * Jsonpath4K (formerly Jsonpath): 2.2.0
+   * Kotlinx-Serialization 1.8.0-SNAPSHOT from upstream
+
+Release 4.0.0:
+ - Add `SubmissionRequirement.evaluate`: Evaluates, whether a given submission requirement is satisfied.
+ - Add `PresentationSubmissionValidator`: 
+   - Add `isValidSubmission`: Evaluates, whether all submission requirements is satisfied, and fails on redundantly submitted credentials.
+   - Add `findUnnecessaryInputDescriptorSubmissions`: Returns a list of redundantly submitted credentials.
+ - Rename `BaseInputEvaluator` -> `InputEvaluator`
+   - Change `evaluateFieldQueryResults` -> `evaluateConstraintFieldMatches`: Returns all matching fields now, not just the first match
+ - Change `Holder.matchInputDescriptorsAgainstCredentialStore`: Returns all matching credentials now, not just the first match
+ - Do not use or assume DID as key identifiers and subjects in credentials
+ - Replace list of attribute types in `Issuer.issueCredentials` with one concrete `CredentialScheme` to be passed
+ - Remove functionality related to "attachments" to verifable credentials in JWT format
+ - Replace list of credentials to be issued with a single credential that will be issued per call to implementations of `IssuerCredentialDataProvider`
+ - Get rid of class `Issuer.IssuedCredentialResult`, replacing it with `KmmResult<Issuer.IssuedCredential>`
+ - Add return types to function calls to `SubjectCredentialStore`
+ - Change from list to single credential in parameter for `Holder.storeCredentials()`, changing name to `storeCredential()`
+ - Refactor `AuthenticationRequestParametersFrom` used in `OidcSiopWallet` to be serializable
+ - Add `AuthenticationResponseFactory`: Builds an authentication response from request and response parameters
+ - Change `OidcSiopWallet`: 
+   - Add `startAuthorizationResponsePreparation()`: Gathers data necessary for presentation building and yields a `AuthorizationResponsePreparationState`
+   - Add `finalizeAuthorizationResponseParameters()`: Returns what `createAuthenticationParams` returned before, but also takes in `AuthorizationResponsePreparationState` and an optional non-default submission
+   - Add `finalizeAuthorizationResponse()`: Returns what `createAuthenticationResponse()` did before
+ - Change `OidcSiopVerifier`:
+   - Add `createAuthnRequestUrlWithRequestObjectByReference()` to offer authentication requests by reference to the Wallet
+ - Add `AuthorizationResponsePreparationState`: Holds data necessary for presentation building
+ - Add `AuthenticationRequestParser`: Extracted presentation request parsing logic from `OidcSiopWallet` and put it here
+ - Add `AuthorizationRequestValidator`: Extracted presentation request validation logic from `OidcSiopWallet` and put it here
+ - Add `PresentationFactory`: Extracted presentation response building logic from `OidcSiopWallet` and put it here
+   - Also added some code for presentation submission validation
+ - Update implementation of OpenID 4 Verifiable Credential Issuance, draft 13
+ - Replace `createCredentialRequestJwt()` and `createCredentialRequestCwt()` with `createCredentialRequest()` in `WalletService` for OID4VCI
+ - Refactor `createTokenRequestParameters()` in `WalletService` for OID4VCI to account for authorization code or pre-auth code

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
@@ -53,7 +53,7 @@ class ClientAuthenticationService(
                 throw InvalidClient("could not parse client attestation", it)
             }
             verifyJwsObject(clientAttestationJwt).getOrElse {
-                throw InvalidClient("client attestation JWT not verified. $it")
+                throw InvalidClient("client attestation JWT not verified", it)
             }
             if (clientId != null) {
                 if (clientAttestationJwt.payload.subject != clientId) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/ClientAuthenticationService.kt
@@ -52,8 +52,8 @@ class ClientAuthenticationService(
             ).getOrElse {
                 throw InvalidClient("could not parse client attestation", it)
             }
-            if (!verifyJwsObject(clientAttestationJwt)) {
-                throw InvalidClient("client attestation JWT not verified")
+            verifyJwsObject(clientAttestationJwt).getOrElse {
+                throw InvalidClient("client attestation JWT not verified. $it")
             }
             if (clientId != null) {
                 if (clientAttestationJwt.payload.subject != clientId) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
@@ -208,7 +208,7 @@ class JwtTokenVerificationService(
             throw InvalidDpopProof("could not parse DPoP JWT", it)
         }.also {
             verifyJwsObject(it).getOrElse {
-                throw InvalidDpopProof("DPoP JWT not verified. $it")
+                throw InvalidDpopProof("DPoP JWT not verified.", it)
             }
         }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
@@ -207,8 +207,8 @@ class JwtTokenVerificationService(
         JwsSigned.deserialize(JsonWebToken.serializer(), this, vckJsonSerializer).getOrElse {
             throw InvalidDpopProof("could not parse DPoP JWT", it)
         }.also {
-            if (!verifyJwsObject(it)) {
-                throw InvalidDpopProof("DPoP JWT not verified")
+            verifyJwsObject(it).getOrElse {
+                throw InvalidDpopProof("DPoP JWT not verified. $it")
             }
         }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/ProofValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/ProofValidator.kt
@@ -100,8 +100,8 @@ class ProofValidator(
         if (payload.issuedAt == null || payload.issuedAt!! > (clock.now() + timeLeeway)) {
             throw InvalidProof("issuedAt in future: ${payload.issuedAt}")
         }
-        if (!verifyJwsObject(this)) {
-            throw InvalidProof("invalid signature: $this")
+        verifyJwsObject(this).getOrElse {
+            throw InvalidProof("invalid signature: $this. Error: $it")
         }
         // OID4VCI F.1.: The Credential Issuer SHOULD issue a Credential for each cryptographic public key specified
         // in the attested_keys claim within the key_attestation parameter.

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/ProofValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/ProofValidator.kt
@@ -101,7 +101,7 @@ class ProofValidator(
             throw InvalidProof("issuedAt in future: ${payload.issuedAt}")
         }
         verifyJwsObject(this).getOrElse {
-            throw InvalidProof("invalid signature: $this. Error: $it")
+            throw InvalidProof("invalid signature: $this.", it)
         }
         // OID4VCI F.1.: The Credential Issuer SHOULD issue a Credential for each cryptographic public key specified
         // in the attested_keys claim within the key_attestation parameter.

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -509,7 +509,7 @@ class OpenId4VpVerifier(
         val jwsSigned = JwsSigned.deserialize(IdToken.serializer(), idTokenJws, vckJsonSerializer)
             .getOrElse { throw IllegalArgumentException("idToken", it) }
         verifyJwsObject(jwsSigned).getOrElse {
-            throw IllegalArgumentException("idToken. $it")
+            throw IllegalArgumentException("idToken.", it)
                 .also { Napier.w { "JWS of idToken not verified: $idTokenJws" } }
         }
         val idToken = jwsSigned.payload

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -508,9 +508,10 @@ class OpenId4VpVerifier(
             ?: throw IllegalArgumentException("idToken")
         val jwsSigned = JwsSigned.deserialize(IdToken.serializer(), idTokenJws, vckJsonSerializer)
             .getOrElse { throw IllegalArgumentException("idToken", it) }
-        if (!verifyJwsObject(jwsSigned))
-            throw IllegalArgumentException("idToken")
+        verifyJwsObject(jwsSigned).getOrElse {
+            throw IllegalArgumentException("idToken. $it")
                 .also { Napier.w { "JWS of idToken not verified: $idTokenJws" } }
+        }
         val idToken = jwsSigned.payload
         if (idToken.issuer != idToken.subject)
             throw IllegalArgumentException("idToken.iss")

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ResponseParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ResponseParser.kt
@@ -67,7 +67,9 @@ class ResponseParser(
     @Throws(IllegalArgumentException::class, CancellationException::class)
     internal suspend fun ResponseParametersFrom.extractFromJar() = parameters.response?.let { encodedResponse ->
         encodedResponse.fromJws()?.let { jws ->
-            require(verifyJwsObject(jws)) { "JWS not verified: $encodedResponse" }
+            verifyJwsObject(jws).getOrElse {
+                throw IllegalArgumentException("JWS not verified: $encodedResponse. $it")
+            }
             ResponseParametersFrom.JwsSigned(jws, this, jws.payload)
         } ?: encodedResponse.fromJwe()?.let { jwe ->
             ResponseParametersFrom.JweDecrypted(jwe, this, jwe.payload)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ResponseParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ResponseParser.kt
@@ -68,7 +68,7 @@ class ResponseParser(
     internal suspend fun ResponseParametersFrom.extractFromJar() = parameters.response?.let { encodedResponse ->
         encodedResponse.fromJws()?.let { jws ->
             verifyJwsObject(jws).getOrElse {
-                throw IllegalArgumentException("JWS not verified: $encodedResponse. $it")
+                throw IllegalArgumentException("JWS not verified: $encodedResponse", it)
             }
             ResponseParametersFrom.JwsSigned(jws, this, jws.payload)
         } ?: encodedResponse.fromJwe()?.let { jwe ->

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpInteropTest.kt
@@ -161,7 +161,7 @@ val OpenId4VpInteropTest by testSuite {
                 val verifierRequestSigningKey = it.verifierKeyMaterial.jsonWebKey.shouldNotBeNull()
                 VerifyJwsSignatureWithKey()(jar, verifierRequestSigningKey).isSuccess shouldBe true
             } else {
-                VerifyJwsObject()(jar) shouldBe true
+                VerifyJwsObject()(jar).getOrThrow()
             }
 
             val response = it.holderOid4vp.finalizeAuthorizationResponse(state, null).getOrThrow()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -198,7 +198,7 @@ val PreRegisteredClientTest by testSuite {
                 .shouldNotBeNull()
             val jwsObject = JwsSigned.deserialize(AuthenticationRequestParameters.serializer(), jar, vckJsonSerializer)
                 .getOrThrow()
-            VerifyJwsObject().invoke(jwsObject).shouldBeTrue()
+            VerifyJwsObject().invoke(jwsObject).getOrThrow()
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(jar).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwt.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwt.kt
@@ -67,8 +67,8 @@ class ValidatorSdJwt(
                 return VerifyPresentationResult.ValidationError("Key binding JWT not verified (from cnf)")
             }
         } ?: run {
-            if (!verifyJwsObject(keyBindingSigned)) {
-                return VerifyPresentationResult.ValidationError("Key binding JWT not verified")
+            verifyJwsObject(keyBindingSigned).getOrElse {
+                return VerifyPresentationResult.ValidationError("Key binding JWT not verified. $it")
             }
         }
         val keyBinding = keyBindingSigned.payload

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcJws.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcJws.kt
@@ -57,7 +57,7 @@ class ValidatorVcJws(
         clientId: String,
     ): VerifyPresentationResult {
         Napier.d("Verifying VP $input with $challenge and $clientId")
-        require (verifyJwsObject(input)) { "signature invalid" }
+        verifyJwsObject(input).getOrThrow()
         val vpJws = input.payload.validate(challenge, clientId)
         val vcValidationResults = vpJws.vp.verifiableCredential
             .map { it to verifyVcJws(it, null, input) }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/sdJwt/SdJwtInputValidator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/sdJwt/SdJwtInputValidator.kt
@@ -65,7 +65,7 @@ data class SdJwtInputValidator(
 
         return SdJwtInputValidationResult(
             input = sdJwtSigned,
-            isIntegrityGood = verifyJwsObject(sdJwtSigned.jws),
+            isIntegrityGood = verifyJwsObject(sdJwtSigned.jws).isSuccess,
             payloadCredentialValidationSummary = payloadCredentialValidationSummary,
             payloadJsonValidationSummary = payloadJsonValidationSummary,
             payload = payloadValidationSummary,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/vcJws/VcJwsInputValidator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/vcJws/VcJwsInputValidator.kt
@@ -32,7 +32,7 @@ data class VcJwsInputValidator(
         return VcJwsInputValidationResult.ContentValidationSummary(
             input = input,
             parsed = jws,
-            isIntegrityGood = verifyJwsObject(jws),
+            isIntegrityGood = verifyJwsObject(jws).isSuccess,
             subjectMatchingResult = publicKey?.let {
                 SubjectMatchingResult(
                     subject = vcJws.subject,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/StatusListJwt.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/StatusListJwt.kt
@@ -48,8 +48,8 @@ data class StatusListJwt(
     ): KmmResult<StatusListTokenPayload> =
         catching {
             val jwsSigned = statusListToken.value
-            if (!verifyJwsObject(jwsSigned)) {
-                throw IllegalStateException("Invalid Signature")
+            verifyJwsObject(jwsSigned).getOrElse {
+                throw IllegalStateException(it)
             }
             val type = jwsSigned.header.type?.lowercase()
                 ?: throw IllegalArgumentException("Invalid type header")

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/StatusListJwt.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/StatusListJwt.kt
@@ -49,7 +49,7 @@ data class StatusListJwt(
         catching {
             val jwsSigned = statusListToken.value
             verifyJwsObject(jwsSigned).getOrElse {
-                throw IllegalStateException(it)
+                throw IllegalStateException("Invalid signature", it)
             }
             val type = jwsSigned.header.type?.lowercase()
                 ?: throw IllegalArgumentException("Invalid type header")

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
@@ -569,7 +569,7 @@ class VerifyStatusListTokenHAIP(
     val trustStoreLookup: TrustStoreLookup = TrustStoreLookup { null },
 ) : VerifyJwsObjectFun {
 
-    override suspend operator fun invoke(jwsObject: JwsSigned<*>) = catchingUnwrapped {
+    override suspend operator fun invoke(jwsObject: JwsSigned<*>) = catching {
         val trustStore: Set<X509Certificate>? = trustStoreLookup(jwsObject)
         val certChain: CertificateChain? = jwsObject.header.certificateChain
         val signingCert: X509Certificate = certChain?.first() ?: throw Exception("Certificate Chain MUST not be empty")

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
@@ -557,11 +557,11 @@ class VerifyJwsSignatureWithCnf(
 class VerifyStatusListTokenHAIP(
     val verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
     /** Need to implement if valid keys for JWS are transported somehow out-of-band, e.g. provided by a trust store */
-    val trustStoreLookup: TrustStoreLookup = TrustStoreLookup { null },
+//    val trustStoreLookup: TrustStoreLookup = TrustStoreLookup { null },
 ) : VerifyJwsObjectFun {
 
-    override suspend operator fun invoke(jwsObject: JwsSigned<*>) = catching {
-        val trustStore: Set<X509Certificate>? = trustStoreLookup(jwsObject)
+    override suspend operator fun invoke(jwsObject: JwsSigned<*>) = catchingUnwrapped {
+        val trustStore: Set<X509Certificate>? = null //trustStoreLookup(jwsObject)
         val certChain: CertificateChain? = jwsObject.header.certificateChain
         val signingCert: X509Certificate = certChain?.first() ?: throw Exception("Certificate Chain MUST not be empty")
         signingCert.decodedPublicKey

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -119,7 +119,7 @@ val AgentRevocationTest by testSuite {
         "revocation credential should be valid" {
             it.statusListIssuer.issueStatusListJwt().also {
                 it.shouldNotBeNull()
-                VerifyJwsObject().invoke(it) shouldBe true
+                VerifyJwsObject().invoke(it).getOrThrow()
             }
             it.statusListIssuer.issueStatusListCwt().also {
                 it.shouldNotBeNull()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
@@ -43,9 +43,7 @@ import com.benasher44.uuid.uuid4
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.engine.runBlocking
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.matchers.types.shouldNotBeInstanceOf
 import kotlinx.serialization.json.JsonObject
@@ -329,7 +327,9 @@ val AgentSdJwtTest by testSuite {
             val certStatusKey = EphemeralKeyWithoutCert()
             val noCertStatusListIssuer = StatusListAgent(
                 keyMaterial = certStatusKey,
-                signStatusListJwt = SignJwt(certStatusKey, CertChainRemoverJwsHeaderFun())
+                signStatusListJwt = SignJwt(
+                    certStatusKey,
+                    JwsHeaderIdentifierFun { header, _ -> header.copy(certificateChain = null) }),
             )
 
             val haipTokenStatusResolver = TokenStatusResolverImpl(
@@ -370,10 +370,6 @@ val AgentSdJwtTest by testSuite {
                 .shouldBeInstanceOf<TokenStatusValidationResult.Rejected>()
         }
     }
-}
-
-private class CertChainRemoverJwsHeaderFun : JwsHeaderIdentifierFun {
-    override suspend fun invoke(jwsHeader: JwsHeader, keyMaterial: KeyMaterial): JwsHeader = jwsHeader.copy(certificateChain = null)
 }
 
 private fun buildDCQLQuery(vararg claimsQueries: DCQLJsonClaimsQuery) = DCQLQuery(

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
@@ -287,8 +287,8 @@ val AgentSdJwtTest by testSuite {
 
         "sd-jwt vc request verified with HAIP status list rules" {
             val haipTokenStatusResolver = TokenStatusResolverImpl(
-                resolveStatusListToken = StatusListTokenResolver {
-                    statusListIssuer.provideStatusListToken(
+                resolveStatusListToken = { _ ->
+                    it.statusListIssuer.provideStatusListToken(
                         listOf(StatusListTokenMediaType.Jwt),
                         Clock.System.now(),
                     ).second
@@ -297,14 +297,14 @@ val AgentSdJwtTest by testSuite {
             )
 
             val haipVerifier = VerifierAgent(
-                identifier = verifierId,
+                identifier = it.verifierId,
                 validatorSdJwt = ValidatorSdJwt(
                     validator = Validator(tokenStatusResolver = haipTokenStatusResolver),
                 ),
             )
 
-            val presentationParameters = holder.createDefaultPresentation(
-                request = PresentationRequestParameters(nonce = challenge, audience = verifierId),
+            val presentationParameters = it.holder.createDefaultPresentation(
+                request = PresentationRequestParameters(nonce = it.challenge, audience = it.verifierId),
                 credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(
                     buildDCQLQuery(
                         DCQLJsonClaimsQuery(
@@ -317,7 +317,7 @@ val AgentSdJwtTest by testSuite {
             val vp = presentationParameters.verifiablePresentations.values.first()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            haipVerifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
+            haipVerifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
                 .freshnessSummary.tokenStatusValidationResult
                 .shouldBeInstanceOf<TokenStatusValidationResult.Valid>()
@@ -343,14 +343,14 @@ val AgentSdJwtTest by testSuite {
             )
 
             val haipVerifier = VerifierAgent(
-                identifier = verifierId,
+                identifier = it.verifierId,
                 validatorSdJwt = ValidatorSdJwt(
                     validator = Validator(tokenStatusResolver = haipTokenStatusResolver),
                 ),
             )
 
-            val presentationParameters = holder.createDefaultPresentation(
-                request = PresentationRequestParameters(nonce = challenge, audience = verifierId),
+            val presentationParameters = it.holder.createDefaultPresentation(
+                request = PresentationRequestParameters(nonce = it.challenge, audience = it.verifierId),
                 credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(
                     buildDCQLQuery(
                         DCQLJsonClaimsQuery(
@@ -363,7 +363,7 @@ val AgentSdJwtTest by testSuite {
             val vp = presentationParameters.verifiablePresentations.values.first()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            val test = haipVerifier.verifyPresentationSdJwt(vp.sdJwt, challenge)
+            val test = haipVerifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
 
             test.shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
                 .freshnessSummary.tokenStatusValidationResult

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceTest.kt
@@ -14,6 +14,7 @@ import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import com.benasher44.uuid.uuid4
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.matthewnelson.encoding.base64.Base64
@@ -38,9 +39,7 @@ val JwsServiceTest by testSuite {
         "signed object with bytes can be verified" {
             val payload = it.randomPayload.encodeToByteArray()
             val signed = it.signJwt(JwsContentTypeConstants.JWT, payload, ByteArraySerializer()).getOrThrow()
-
-            val result = it.verifierJwsService(signed)
-            result shouldBe true
+            it.verifierJwsService(signed).getOrThrow()
         }
 
         "Object can be reconstructed" {
@@ -51,25 +50,19 @@ val JwsServiceTest by testSuite {
             val parsed = JwsSigned.deserialize<ByteArray>(ByteArraySerializer(), signed).getOrThrow()
             parsed.serialize() shouldBe signed
             parsed.payload shouldBe payload
-
-            val result = it.verifierJwsService(parsed)
-            result shouldBe true
+            it.verifierJwsService(parsed).getOrThrow()
         }
 
         "signed object can be verified" {
             val payload = it.randomPayload.encodeToByteArray()
             val signed = it.signJwt(JwsContentTypeConstants.JWT, payload, ByteArraySerializer()).getOrThrow()
-
-            val result = it.verifierJwsService(signed)
-            result shouldBe true
+            it.verifierJwsService(signed).getOrThrow()
         }
 
         "signed object with jsonWebKey can be verified" {
             val signer = SignJwt<String>(it.keyMaterial, JwsHeaderJwk())
             val signed = signer(null, it.randomPayload, String.serializer()).getOrThrow()
-
-            val result = it.verifierJwsService(signed)
-            result shouldBe true
+            it.verifierJwsService(signed).getOrThrow()
         }
 
         "signed object with kid from jku can be verified" {
@@ -78,7 +71,7 @@ val JwsServiceTest by testSuite {
             val signed = signer(null, it.randomPayload, String.serializer()).getOrThrow()
             val validKey = it.keyMaterial.jsonWebKey
             val jwkSetRetriever = JwkSetRetrieverFunction { JsonWebKeySet(keys = listOf(validKey)) }
-            VerifyJwsObject(jwkSetRetriever = jwkSetRetriever)(signed) shouldBe true
+            VerifyJwsObject(jwkSetRetriever = jwkSetRetriever)(signed).getOrThrow()
         }
 
         "signed object with kid from jku, returning invalid key, can not be verified" {
@@ -87,22 +80,22 @@ val JwsServiceTest by testSuite {
             val signed = signer(null, it.randomPayload, String.serializer()).getOrThrow()
             val invalidKey = EphemeralKeyWithoutCert().jsonWebKey
             val jwkSetRetriever = JwkSetRetrieverFunction { JsonWebKeySet(keys = listOf(invalidKey)) }
-            VerifyJwsObject(jwkSetRetriever = jwkSetRetriever)(signed) shouldBe false
+            shouldThrowAny { VerifyJwsObject(jwkSetRetriever = jwkSetRetriever)(signed).getOrThrow() }
         }
 
         "signed object without public key in header can not be verified" {
             val signer = SignJwt<String>(it.keyMaterial, JwsHeaderNone())
             val signed = signer(null, it.randomPayload, String.serializer()).getOrThrow()
 
-            VerifyJwsObject()(signed) shouldBe false
-        }
+        shouldThrowAny { VerifyJwsObject()(signed).getOrThrow() }
+    }
 
         "signed object without public key in header, but retrieved out-of-band can be verified" {
             val signer = SignJwt<String>(it.keyMaterial, JwsHeaderNone())
             val signed = signer(null, it.randomPayload, String.serializer()).getOrThrow()
 
             val publicKeyLookup = PublicJsonWebKeyLookup { jwsSigned -> setOf(it.keyMaterial.jsonWebKey) }
-            VerifyJwsObject(publicKeyLookup = publicKeyLookup)(signed) shouldBe true
+            VerifyJwsObject(publicKeyLookup = publicKeyLookup)(signed).getOrThrow()
         }
 
         "encrypted object can be decrypted" {

--- a/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceJvmTest.kt
+++ b/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/jws/JwsServiceJvmTest.kt
@@ -119,7 +119,7 @@ val JwsServiceJvmTest by testSuite {
                     ).getOrThrow()
                     val selfVerify = verifyJwsSignatureObject(signed)
                     withClue("$algo: Signature: ${signed.signature.encodeToTlv().toDerHexString()}") {
-                        selfVerify shouldBe true
+                        selfVerify.getOrThrow()
                     }
                 }
 
@@ -150,8 +150,7 @@ val JwsServiceJvmTest by testSuite {
                     }
 
                     withClue("$algo: Signature: ${parsedJwsSigned.signature.encodeToTlv().toDerHexString()}") {
-                        val result = verifyJwsSignatureObject(parsedJwsSigned)
-                        result shouldBe true
+                        verifyJwsSignatureObject(parsedJwsSigned).getOrThrow()
                     }
                 }
 


### PR DESCRIPTION
Adds verification functionality of HAIP contraints added to StatusList Token in d04. To allow diagnosis of verification failure change `VerifyJwsObjectFun` return type to KmmResult<Unit> for descriptive errors.
Constraints regarding trust stores need future signum functionality and so cannot be implemented atm.