### PR TITLE
OID4VP: Encryption of authorization responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release 5.10.0 (Unreleased):
    - Drop session transcript implementation from ISO/IEC 18013-7:2024 Annex B, which was pre-OpenID4VP 1.0
    - Remove deprecated format identifier `vc+sd-jwt` (now `dc+sd-jwt`)
    - Remove deprecated client identifier prefix scheme `x509_san_uri`
+   - Use correct response encryption acc. to values stated in `encrypted_response_enc_values_supported` inside `client_metadata`
  - SD-JWT:
    - Fix creation of SD JWTs containing structures that are selectivey disclosable
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RelyingPartyMetadata.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RelyingPartyMetadata.kt
@@ -57,29 +57,27 @@ data class RelyingPartyMetadata(
     val idTokenSignedResponseAlgString: String? = null,
 
     /**
-     * OID JARM: JWS (RFC7515) `alg` algorithm JWA (RFC7518). REQUIRED for signing authorization responses.
-     * If this is specified, the response will be signed using JWS and the configured algorithm.
-     * The algorithm `none` is not allowed. The default, if omitted, is `RS256`.
-     */
-    @SerialName("authorization_signed_response_alg")
-    val authorizationSignedResponseAlgString: String? = null,
-
-    /**
      * OID JARM: JWE (RFC7516) `alg` algorithm JWA (RFC7518). REQUIRED for encrypting authorization responses.
      * If both signing and encryption are requested, the response will be signed then encrypted, with the result being
      * a Nested JWT, as defined in JWT (RFC7519). The default, if omitted, is that no encryption is performed.
      */
+    @Deprecated("Not used in OpenID4VP 1.0, use [encryptedResponseEncValuesSupported] instead")
     @SerialName("authorization_encrypted_response_alg")
     val authorizationEncryptedResponseAlgString: String? = null,
 
-    /**
-     * OID JARM: JWE (RFC7516) `enc` algorithm JWA (RFC7518). REQUIRED for encrypting authorization responses.
-     * If [authorizationEncryptedResponseAlg] is specified, the default for this value is `A128CBC-HS256`.
-     * When [authorizationEncryptedResponseEncoding] is included, [authorizationEncryptedResponseAlg] MUST also be
-     * provided.
-     */
+    @Deprecated("Not used in OpenID4VP 1.0, use [encryptedResponseEncValuesSupported] instead")
     @SerialName("authorization_encrypted_response_enc")
     val authorizationEncryptedResponseEncodingString: String? = null,
+
+    /**
+     * OpenID4VP: OPTIONAL. Non-empty array of strings, where each string is a JWE
+     * [RFC7516](https://datatracker.ietf.org/doc/html/rfc7516) `enc` algorithm that can be used as the content
+     * encryption algorithm for encrypting the Response. When a `response_mode` requiring encryption of the Response
+     * (such as `dc_api.jwt` or `direct_post.jwt`) is specified, this MUST be present for anything other than the
+     * default single value of `A128GCM`. Otherwise, this SHOULD be absent.
+     */
+    @SerialName("encrypted_response_enc_values_supported")
+    val encryptedResponseEncValuesSupportedString: Set<String>? = null,
 
     /**
      * OIDC Registration: OPTIONAL. JWE alg algorithm REQUIRED for encrypting the ID Token issued to this Client.
@@ -123,12 +121,9 @@ data class RelyingPartyMetadata(
     val clientIdScheme: OpenIdConstants.ClientIdScheme? = OpenIdConstants.ClientIdScheme.PreRegistered,
 ) {
 
-    /**
-     * OID JARM: JWE (RFC7516) `alg` algorithm JWA (RFC7518). REQUIRED for encrypting authorization responses.
-     * If both signing and encryption are requested, the response will be signed then encrypted, with the result being
-     * a Nested JWT, as defined in JWT (RFC7519). The default, if omitted, is that no encryption is performed.
-     */
+    @Suppress("DEPRECATION")
     @Transient
+    @Deprecated("Not used in OpenID4VP 1.0, use [encryptedResponseEncValues] instead")
     val authorizationEncryptedResponseAlg: JweAlgorithm? = authorizationEncryptedResponseAlgString
         ?.let { s -> JweAlgorithm.entries.firstOrNull { it.identifier == s } }
 
@@ -152,23 +147,22 @@ data class RelyingPartyMetadata(
     @Transient
     val idTokenSignedResponseAlg: JwsAlgorithm? = idTokenSignedResponseAlgString?.toJwsAlgorithm()
 
-    /**
-     * OID JARM: JWS (RFC7515) `alg` algorithm JWA (RFC7518). REQUIRED for signing authorization responses.
-     * If this is specified, the response will be signed using JWS and the configured algorithm.
-     * The algorithm `none` is not allowed. The default, if omitted, is [JwsAlgorithm.Signature.RS256].
-     */
+    @Suppress("DEPRECATION")
     @Transient
-    val authorizationSignedResponseAlg: JwsAlgorithm? = authorizationSignedResponseAlgString?.toJwsAlgorithm()
-
-    /**
-     * OID JARM: JWE (RFC7516) `enc` algorithm JWA (RFC7518). REQUIRED for encrypting authorization responses.
-     * If [authorizationEncryptedResponseAlg] is specified, the default for this value is [JweEncryption.A128CBC_HS256].
-     * When [authorizationEncryptedResponseEncoding] is included, [authorizationEncryptedResponseAlg] MUST also be
-     * provided.
-     */
-    @Transient
+    @Deprecated("Not used in OpenID4VP 1.0, use [encryptedResponseEncValues] instead")
     val authorizationEncryptedResponseEncoding: JweEncryption? = authorizationEncryptedResponseEncodingString
         ?.let { s -> JweEncryption.entries.firstOrNull { it.identifier == s } }
+
+    /**
+     * OpenID4VP: OPTIONAL. Non-empty array of strings, where each string is a JWE
+     * [RFC7516](https://datatracker.ietf.org/doc/html/rfc7516) `enc` algorithm that can be used as the content
+     * encryption algorithm for encrypting the Response. When a `response_mode` requiring encryption of the Response
+     * (such as `dc_api.jwt` or `direct_post.jwt`) is specified, this MUST be present for anything other than the
+     * default single value of `A128GCM`. Otherwise, this SHOULD be absent.
+     */
+    @Transient
+    val encryptedResponseEncValues: Set<JweEncryption?>? = encryptedResponseEncValuesSupportedString
+        ?.mapNotNull { s -> JweEncryption.entries.firstOrNull { it.identifier == s } }?.toSet()
 
     /**
      * OIDC Registration: OPTIONAL. JWE enc algorithm REQUIRED for encrypting the ID Token issued to this Client.

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SupportedAlgorithmsContainerIso.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SupportedAlgorithmsContainerIso.kt
@@ -20,7 +20,7 @@ data class SupportedAlgorithmsContainerIso(
      * P-256 key, then it matches an [issuerAuthAlgorithmInts] element of `-7` and `-9`.
      */
     @SerialName("issuerauth_alg_values")
-    val issuerAuthAlgorithmInts: Set<Int>,
+    val issuerAuthAlgorithmInts: Set<Int>? = null,
 
     /**
      * OID4VP: OPTIONAL. A non-empty array containing cryptographic algorithm identifiers. The Credential MUST be
@@ -53,8 +53,8 @@ data class SupportedAlgorithmsContainerIso(
      * P-256 key, then it matches an [issuerAuthAlgorithmInts] element of `-7` and `-9`.
      */
     @Transient
-    val issuerAuthAlgorithms: Set<CoseAlgorithm> = issuerAuthAlgorithmInts
-        .mapNotNull { s -> CoseAlgorithm.entries.firstOrNull { it.coseValue == s } }.toSet()
+    val issuerAuthAlgorithms: Set<CoseAlgorithm>? = issuerAuthAlgorithmInts
+        ?.mapNotNull { s -> CoseAlgorithm.entries.firstOrNull { it.coseValue == s } }?.toSet()
 
     /**
      * OID4VP: OPTIONAL. A non-empty array containing cryptographic algorithm identifiers. The Credential MUST be

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
@@ -152,7 +152,8 @@ internal class AuthenticationResponseFactory(
         val recipientKey = response.jsonWebKeys?.getEncryptionTargetKey()
             ?: throw InvalidRequest("no suitable ECDH ES key found")
         val algorithm = JweAlgorithm.ECDH_ES
-        val encryption = response.clientMetadata?.authorizationEncryptedResponseEncoding
+        val encryption = response.clientMetadata?.encryptedResponseEncValues?.firstNotNullOfOrNull { it }
+            ?: response.clientMetadata?.authorizationEncryptedResponseEncoding
             ?: JweEncryption.A128GCM
         val apv = request.parameters.nonce?.encodeToByteArray()
             ?: randomSource.nextBytes(16)
@@ -180,5 +181,7 @@ internal class AuthenticationResponseFactory(
 internal fun AuthenticationResponse.requestsEncryption(): Boolean =
     (clientMetadata != null && jsonWebKeys != null && clientMetadata.requestsEncryption())
 
+@Suppress("DEPRECATION")
 internal fun RelyingPartyMetadata.requestsEncryption() =
     (authorizationEncryptedResponseAlg != null && authorizationEncryptedResponseEncoding != null)
+            || (encryptedResponseEncValues != null)

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
@@ -74,7 +74,6 @@ val JarmTest by testSuite {
             clientMetadata = authnRequest.clientMetadata?.copy(
                 jsonWebKeySet = null,
                 jsonWebKeySetUrl = null,
-                authorizationSignedResponseAlgString = null
             )
         )
 


### PR DESCRIPTION
see https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5.1-2.4.1 and https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-encrypted-responses