### PR TITLE
5.9.1: remove bogus testballoon-shim dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+Release 5.9.1
+- Remove bogus testballoon-shim dependency
+
 Release 5.9.0
  - Refactor `RqesWalletService` to be stateless
  - Remove code elements deprecated in 5.8.0

--- a/conventions-vclib/src/main/kotlin/VcLibConventions.kt
+++ b/conventions-vclib/src/main/kotlin/VcLibConventions.kt
@@ -72,7 +72,7 @@ class VcLibConventions : K2Conventions() {
                     sourceSets.forEach {
                         it.languageSettings.enableLanguageFeature("ContextParameters")
                     }
-                    sourceSets.commonMain.get()
+                    sourceSets.commonTest.get()
                         .dependencies { implementation("at.asitplus.gradle:testballoon-shim:$buildDate") }
                 }
                 tasks.withType<Test>().configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ kotlin.mpp.enableCInteropCommonization=true
 kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 
-artifactVersion = 5.9.0
+artifactVersion = 5.9.1
 
 # JVM version, auto download
 jdk.version=17


### PR DESCRIPTION
@nodh if you have no objections, just publish and back onto main with it. current develop branch is unaffected by this issue