### PR TITLE
OpenID4VpVerifier Interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release 5.11.0 (unreleased):
  - OpenID for Verifiable Presentations:
    - In `RequestOptions` deprecate property `encryption`, as this depends on the response mode
    - In `OpenId4VpVerifier` remove `validateAuthnResponse(input: Map)`
-   - In `OpenId4VpVerifier` add option to provide `externalId` when validating authn responses, useful for DCAPI flows
+   - In `OpenId4VpVerifier` add option to provide `externalId` to methods `validateAuthnRequest()` and `submitAuthnRequest()`, useful for DCAPI flows
 
 Release 5.10.0:
  - StatusListToken:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Release 5.11.0 (unreleased):
  - Proximity presentations:
    - Return multiple ISO mDoc credentials in one device response when generating a presentation in proximity flows
+ - OpenID for Verifiable Presentations:
+   - In `RequestOptions` deprecate property `encryption`, as this depends on the response mode
 
 Release 5.10.0:
  - StatusListToken:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Release 5.11.0 (unreleased):
    - Return multiple ISO mDoc credentials in one device response when generating a presentation in proximity flows
  - OpenID for Verifiable Presentations:
    - In `RequestOptions` deprecate property `encryption`, as this depends on the response mode
+   - In `AuthnResponseResult` returned from `OpenId4VpVerifier.validateAuthnResponse()` remove parameter `state`
 
 Release 5.10.0:
  - StatusListToken:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Release 5.11.0 (unreleased):
    - Return multiple ISO mDoc credentials in one device response when generating a presentation in proximity flows
  - OpenID for Verifiable Presentations:
    - In `RequestOptions` deprecate property `encryption`, as this depends on the response mode
-   - In `AuthnResponseResult` returned from `OpenId4VpVerifier.validateAuthnResponse()` remove parameter `state`
    - In `OpenId4VpVerifier` remove `validateAuthnResponse(input: Map)`
    - In `OpenId4VpVerifier` add option to provide `externalId` when validating authn responses, useful for DCAPI flows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Release 5.11.0 (unreleased):
  - OpenID for Verifiable Presentations:
    - In `RequestOptions` deprecate property `encryption`, as this depends on the response mode
    - In `AuthnResponseResult` returned from `OpenId4VpVerifier.validateAuthnResponse()` remove parameter `state`
+   - In `OpenId4VpVerifier` remove `validateAuthnResponse(input: Map)`
+   - In `OpenId4VpVerifier` add option to provide `externalId` when validating authn responses, useful for DCAPI flows
 
 Release 5.10.0:
  - StatusListToken:

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthorizationDetails.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/AuthorizationDetails.kt
@@ -28,7 +28,7 @@ data class OpenIdAuthorizationDetails(
      * Credential being described in [IssuerMetadata.supportedCredentialConfigurations].
      * The referenced object in [IssuerMetadata.supportedCredentialConfigurations] conveys the details, such as the
      * format and format-specific parameters like `vct` for SD-JWT VC or `doctype` for ISO mdoc.
-     * Note: Set by the Wallet in the token request.
+     * Note: Set by the Wallet in the token request and by the issuer in the token response.
      */
     @SerialName("credential_configuration_id")
     val credentialConfigurationId: String? = null,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
@@ -117,7 +117,6 @@ private fun Collection<OpenIdAuthorizationDetails>.matchesAuthnRequest(
 
 private fun Collection<OpenIdAuthorizationDetails>.forTokenResponse() = map {
     it.copy(
-        credentialConfigurationId = null,
         credentialIdentifiers = setOf(it.credentialConfigurationId!!),
     )
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -17,7 +17,7 @@ sealed class AuthnResponseResult {
         val reason: String,
         @Deprecated("Will be removed in release after 5.10.0")
         val state: String? = null,
-        val cause: Throwable? = null,
+        val cause: Throwable,
     ) : AuthnResponseResult()
 
     /**
@@ -27,7 +27,7 @@ sealed class AuthnResponseResult {
         val field: String,
         @Deprecated("Will be removed in release after 5.10.0")
         val state: String? = null,
-        val cause: Throwable? = null,
+        val cause: Throwable,
     ) : AuthnResponseResult()
 
     /**

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -13,37 +13,53 @@ sealed class AuthnResponseResult {
     /**
      * Error in parsing the URL or content itself, before verifying the contents of the OpenId response
      */
-    data class Error(val reason: String, val state: String?, val cause: Throwable? = null) : AuthnResponseResult()
+    data class Error(
+        val reason: String,
+        @Deprecated("Will be removed in release after 5.10.0")
+        val state: String? = null,
+        val cause: Throwable? = null,
+    ) : AuthnResponseResult()
 
     /**
      * Error when validating the `vpToken` or `idToken`
      */
-    data class ValidationError(val field: String, val state: String?, val cause: Throwable? = null) :
-        AuthnResponseResult()
+    data class ValidationError(
+        val field: String,
+        @Deprecated("Will be removed in release after 5.10.0")
+        val state: String? = null,
+        val cause: Throwable? = null,
+    ) : AuthnResponseResult()
 
     /**
      * Wallet provided an `id_token`, no `vp_token` (as requested by us!)
      */
-    data class IdToken(val idToken: at.asitplus.openid.IdToken, val state: String?) : AuthnResponseResult()
+    data class IdToken(
+        val idToken: at.asitplus.openid.IdToken,
+        @Deprecated("Will be removed in release after 5.10.0")
+        val state: String? = null,
+    ) : AuthnResponseResult()
 
     /**
      * Validation results of all returned verifiable presentations
      */
-    data class VerifiablePresentationValidationResults(val validationResults: List<AuthnResponseResult>) :
-        AuthnResponseResult()
+    data class VerifiablePresentationValidationResults(
+        val validationResults: List<AuthnResponseResult>,
+    ) : AuthnResponseResult()
 
     /**
      * Validation results of all returned verifiable presentations
      */
-    data class VerifiableDCQLPresentationValidationResults(val validationResults: Map<DCQLCredentialQueryIdentifier, AuthnResponseResult>) :
-        AuthnResponseResult()
+    data class VerifiableDCQLPresentationValidationResults(
+        val validationResults: Map<DCQLCredentialQueryIdentifier, AuthnResponseResult>,
+    ) : AuthnResponseResult()
 
     /**
      * Successfully decoded and validated the response from the Wallet (VC in JWT)
      */
     data class Success(
         val vp: VerifiablePresentationParsed,
-        val state: String?,
+        @Deprecated("Will be removed in release after 5.10.0")
+        val state: String? = null,
     ) : AuthnResponseResult()
 
     /**
@@ -54,7 +70,8 @@ sealed class AuthnResponseResult {
         val verifiableCredentialSdJwt: VerifiableCredentialSdJwt,
         val reconstructed: JsonObject,
         val disclosures: Collection<SelectiveDisclosureItem>,
-        val state: String?,
+        @Deprecated("Will be removed in release after 5.10.0")
+        val state: String? = null,
         val freshnessSummary: CredentialFreshnessSummary.SdJwt,
     ) : AuthnResponseResult()
 
@@ -63,6 +80,7 @@ sealed class AuthnResponseResult {
      */
     data class SuccessIso(
         val documents: Collection<IsoDocumentParsed>,
-        val state: String?,
+        @Deprecated("Will be removed in release after 5.10.0")
+        val state: String? = null,
     ) : AuthnResponseResult()
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -15,7 +15,6 @@ sealed class AuthnResponseResult {
      */
     data class Error(
         val reason: String,
-        @Deprecated("Will be removed in release after 5.10.0")
         val state: String? = null,
         val cause: Throwable,
     ) : AuthnResponseResult()
@@ -25,7 +24,6 @@ sealed class AuthnResponseResult {
      */
     data class ValidationError(
         val field: String,
-        @Deprecated("Will be removed in release after 5.10.0")
         val state: String? = null,
         val cause: Throwable,
     ) : AuthnResponseResult()
@@ -35,7 +33,6 @@ sealed class AuthnResponseResult {
      */
     data class IdToken(
         val idToken: at.asitplus.openid.IdToken,
-        @Deprecated("Will be removed in release after 5.10.0")
         val state: String? = null,
     ) : AuthnResponseResult()
 
@@ -58,7 +55,6 @@ sealed class AuthnResponseResult {
      */
     data class Success(
         val vp: VerifiablePresentationParsed,
-        @Deprecated("Will be removed in release after 5.10.0")
         val state: String? = null,
     ) : AuthnResponseResult()
 
@@ -70,7 +66,6 @@ sealed class AuthnResponseResult {
         val verifiableCredentialSdJwt: VerifiableCredentialSdJwt,
         val reconstructed: JsonObject,
         val disclosures: Collection<SelectiveDisclosureItem>,
-        @Deprecated("Will be removed in release after 5.10.0")
         val state: String? = null,
         val freshnessSummary: CredentialFreshnessSummary.SdJwt,
     ) : AuthnResponseResult()
@@ -80,7 +75,6 @@ sealed class AuthnResponseResult {
      */
     data class SuccessIso(
         val documents: Collection<IsoDocumentParsed>,
-        @Deprecated("Will be removed in release after 5.10.0")
         val state: String? = null,
     ) : AuthnResponseResult()
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -385,6 +385,7 @@ class OpenId4VpVerifier(
         authenticationRequestParameters,
     )
 
+    @Suppress("DEPRECATION")
     private fun RequestOptions.clientMetadata(): RelyingPartyMetadata? = when (clientIdScheme) {
         is ClientIdScheme.RedirectUri,
         is ClientIdScheme.VerifierAttestation,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
@@ -72,9 +72,7 @@ data class RequestOptions(
     /** Opaque value which will be returned by the OpenId Provider and also in [AuthnResponseResult]. */
     val state: String = uuid4().toString(),
 
-    /**
-     * Set this value to include metadata with encryption parameters set.
-     */
+    @Deprecated("Encryption depends on [responseMode]")
     val encryption: Boolean = false,
 
     /**

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestOptions.kt
@@ -99,6 +99,10 @@ data class RequestOptions(
         get() = (responseMode == OpenIdConstants.ResponseMode.DirectPost) ||
                 (responseMode == OpenIdConstants.ResponseMode.DirectPostJwt)
 
+    val isDcApi: Boolean
+        get() = (responseMode == OpenIdConstants.ResponseMode.DcApi) ||
+                (responseMode == OpenIdConstants.ResponseMode.DcApiJwt)
+
     val isSiop: Boolean
         get() = responseType.contains(OpenIdConstants.ID_TOKEN)
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpIsoProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpIsoProtocolTest.kt
@@ -180,7 +180,6 @@ val OpenId4VpIsoProtocolTest by testSuite {
                 ),
                 responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                 responseUrl = "https://example.com/response",
-                encryption = true
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions, Query(it.walletUrl)

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509HashTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509HashTest.kt
@@ -100,7 +100,6 @@ val OpenId4VpX509HashTest by testSuite {
                     ),
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = "https://example.com/response",
-                    encryption = true
                 ),
                 CreationOptions.SignedRequestByReference("haip://", requestUrl)
             ).getOrThrow()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509SanDnsTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509SanDnsTest.kt
@@ -120,7 +120,6 @@ val OpenId4VpX509SanDnsTest by testSuite {
                     ),
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = "https://example.com/response",
-                    encryption = true
                 ),
                 OpenId4VpVerifier.CreationOptions.SignedRequestByReference("haip://", requestUrl)
             ).getOrThrow()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -136,7 +136,6 @@ val PreRegisteredClientTest by testSuite {
             it.verifierOid4vp.validateAuthnResponse(authnResponse.url)
                 .shouldBeInstanceOf<AuthnResponseResult.Success>().apply {
                     vp.freshVerifiableCredentials.shouldNotBeEmpty()
-                    state.shouldBe(expectedState)
                 }
         }
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -184,7 +184,7 @@ val PreRegisteredClientTest by testSuite {
 
             it.verifierOid4vp.validateAuthnResponse(authnResponse.url)
                 .shouldBeInstanceOf<AuthnResponseResult.ValidationError>()
-                .field shouldBe "state"
+                .field shouldBe "input"
         }
 
         "test with QR Code" {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
@@ -134,7 +134,7 @@ val RedirectUriClientTest by testSuite {
 
             verifierOid4vp.validateAuthnResponse(authnResponse.url)
                 .shouldBeInstanceOf<AuthnResponseResult.ValidationError>()
-                .field shouldBe "state"
+                .field shouldBe "input"
         }
 
         "signed requests not allowed for redirect-uri" {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
@@ -215,7 +215,6 @@ val RedirectUriClientTest by testSuite {
             it.verifierOid4vp.validateAuthnResponse(authnResponse.url)
                 .shouldBeInstanceOf<AuthnResponseResult.Success>().apply {
                     vp.freshVerifiableCredentials.shouldNotBeEmpty()
-                    state.shouldBe(expectedState)
                 }
         }
 


### PR DESCRIPTION
Cleans up the code a bit, and provides the option to specify an external ID for loading the authn request when validating the authn response. For DCAPI the caller needs to pass the `state` parameter from the `RequestOptions` to `validateAuthnRequest`.