### PR TITLE
OpenID4VCI: Same scope values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Release 5.11.0 (unreleased):
  - Add `IdentifierList` and `IdentifierListInfo` and related classes
  - OpenID for Verifiable Credential Issuance:
    - In `SimpleAuthorizationService` add parameter `configurationIds` to method `credentialOfferWithAuthorizationCode`
+   - Support different supported credential formats having the same scope value (as this is covered by the spec)
 
 Release 5.10.1:
  - Proximity presentations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Release 5.11.0 (unreleased):
  - Add `VerifyStatusListTokenHAIP` and related resolver/tests to enforce HAIP d04
  - Add `IdentifierList` and `IdentifierListInfo` and related classes
+ - OpenID for Verifiable Credential Issuance:
+   - In `SimpleAuthorizationService` add parameter `configurationIds` to method `credentialOfferWithAuthorizationCode`
 
 Release 5.10.1:
  - Proximity presentations:

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialOffer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialOffer.kt
@@ -21,7 +21,7 @@ data class CredentialOffer(
      * Authorization Request, see [AuthenticationRequestParameters.scope].
      */
     @SerialName("credential_configuration_ids")
-    val configurationIds: Collection<String>,
+    val configurationIds: Set<String>,
 
     /**
      * OID4VCI: OPTIONAL. If [grants] is not present or is empty, the Wallet MUST determine the Grant Types the

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialOfferGrantsAuthCode.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialOfferGrantsAuthCode.kt
@@ -19,7 +19,7 @@ data class CredentialOfferGrantsAuthCode(
      * OID4VCI: OPTIONAL string that the Wallet can use to identify the Authorization Server to use with this grant
      * type when `authorization_servers` parameter in the Credential Issuer metadata has multiple entries. It MUST NOT
      * be used otherwise. The value of this parameter MUST match with one of the values in the `authorization_servers`
-     * array obtained from the Credential Issuer metadata.
+     * array obtained from the Credential Issuer metadata, see [IssuerMetadata.authorizationServers].
      */
     @SerialName("authorization_server")
     val authorizationServer: String? = null,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationServiceStrategy.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/AuthorizationServiceStrategy.kt
@@ -43,15 +43,24 @@ interface AuthorizationServiceStrategy {
         tokenRequestAuthnDetails: Set<AuthorizationDetails>,
     ): Set<AuthorizationDetails>
 
+    /** Validates the requested scope are valid for the given credential configuration ids. */
+    fun validateScope(scope: String, configurationIds: Set<String>): Boolean
+
     /** Filter the requested scope in the access token request to ones valid for credential issuance */
     fun filterScope(scope: String): String?
 
     /** Return all valid scopes for pre-authorized codes, that the client may use in token requests */
     fun validScopes(): String
 
+    /** Validates that the requested authorization details are valid for the given credential configuration ids. */
+    fun validateAuthorizationDetails(
+        authorizationDetails: Collection<AuthorizationDetails>,
+        configurationIds: Set<String>
+    ): Boolean
+
     /** Return all valid authorization details for pre-authorized codes, that the client may use in token requests */
     fun validAuthorizationDetails(location: String): Collection<AuthorizationDetails>
 
     /** Return all valid credential identifiers for all schemes. */
-    fun allCredentialIdentifier(): Collection<String>
+    fun allCredentialIdentifier(): Set<String>
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -225,7 +225,6 @@ class SimpleAuthorizationService(
         )
     )
 
-
     /**
      * Pushed authorization request endpoint as defined in [RFC 9126](https://www.rfc-editor.org/rfc/rfc9126.html).
      * Clients send their authorization request as HTTP `POST` with `application/x-www-form-urlencoded` to the AS.

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenGenerationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenGenerationService.kt
@@ -19,7 +19,7 @@ import at.asitplus.wallet.lib.oidvci.DefaultNonceService
 import at.asitplus.wallet.lib.oidvci.MapStore
 import at.asitplus.wallet.lib.oidvci.NonceService
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidDpopProof
-import io.github.aakira.napier.Napier
+import at.asitplus.wallet.lib.oidvci.OAuth2Exception.UseDpopNonce
 import kotlin.time.Clock
 import kotlin.time.Clock.System
 import kotlin.time.Duration.Companion.days
@@ -71,7 +71,7 @@ class JwtTokenGenerationService(
         scope: String?,
         validatedClientKey: JsonWebKey?,
     ): TokenResponseParameters = if (httpRequest?.dpop == null) {
-        throw InvalidDpopProof("no DPoP header value")
+        throw InvalidDpopProof("no dpop proof in header")
     } else {
         val notBefore = clock.now().truncateToSeconds()
         TokenResponseParameters(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
@@ -136,8 +136,10 @@ class JwtTokenVerificationService(
         if (dpopProof.header.type != JwsContentTypeConstants.DPOP_JWT) {
             throw InvalidDpopProof("invalid type: ${dpopProof.header.type}")
         }
-        if (dpopProof.payload.nonce == null || !dpopNonceService.verifyAndRemoveNonce(dpopProof.payload.nonce!!)) {
-            throw UseDpopNonce(dpopNonceService.provideNonce(), "DPoP JWT nonce not valid: ${dpopProof.payload.nonce}")
+        val nonce = dpopProof.payload.nonce
+            ?: throw UseDpopNonce(dpopNonceService.provideNonce(), "DPoP JWT nonce is null")
+        if (!dpopNonceService.verifyAndRemoveNonce(nonce)) {
+            throw UseDpopNonce(dpopNonceService.provideNonce(), "DPoP JWT nonce not valid: $nonce")
         }
         if (dpopProof.payload.httpTargetUrl != httpRequest.url) {
             throw InvalidDpopProof("DPoP JWT htu incorrect: ${dpopProof.payload.httpTargetUrl}")
@@ -182,11 +184,10 @@ class JwtTokenVerificationService(
             }
         } else {
             // DPoP-JWT has already been verified, so we can't check for the nonce twice
-            if (dpopProof.payload.nonce == null || !dpopNonceService.verifyAndRemoveNonce(dpopProof.payload.nonce!!)) {
-                throw UseDpopNonce(
-                    dpopNonceService.provideNonce(),
-                    "DPoP JWT nonce not valid: ${dpopProof.payload.nonce}"
-                )
+            val nonce = dpopProof.payload.nonce
+                ?: throw UseDpopNonce(dpopNonceService.provideNonce(), "DPoP JWT nonce is null")
+            if (!dpopNonceService.verifyAndRemoveNonce(nonce)) {
+                throw UseDpopNonce(dpopNonceService.provideNonce(), "DPoP JWT nonce not valid: $nonce")
             }
         }
         if (dpopProof.payload.httpTargetUrl != httpRequest.url) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
@@ -25,12 +25,23 @@ class CredentialAuthorizationServiceStrategy(
 
     override fun validScopes(): String = supportedCredentialSchemes.map { it.value.scope }.distinct().joinToString(" ")
 
-    override fun allCredentialIdentifier(): Collection<String> = supportedCredentialSchemes.map { it.key }
+    override fun allCredentialIdentifier(): Set<String> = supportedCredentialSchemes.keys
+
+    override fun validateAuthorizationDetails(
+        authorizationDetails: Collection<AuthorizationDetails>,
+        configurationIds: Set<String>
+    ): Boolean = authorizationDetails.all { it.validate() && it.credentialConfigurationId in configurationIds }
 
     override fun validAuthorizationDetails(location: String): Collection<OpenIdAuthorizationDetails> =
         supportedCredentialSchemes.entries.map {
             OpenIdAuthorizationDetails(credentialConfigurationId = it.key, locations = setOf(location))
         }
+
+    override fun validateScope(
+        scope: String,
+        configurationIds: Set<String>
+    ): Boolean = scope.trim().split(" ")
+        .all { supportedCredentialSchemes.filter { it.key in configurationIds }.map { it.value.scope }.contains(it) }
 
     override fun filterScope(scope: String): String = scope.trim().split(" ")
         .mapNotNull { scope ->

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
@@ -4,7 +4,6 @@ import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.OpenIdAuthorizationDetails
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.oauth2.AuthorizationServiceStrategy
-import at.asitplus.wallet.lib.oidvci.CredentialSchemeMapping.toSupportedCredentialFormat
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidAuthorizationDetails
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
@@ -16,13 +15,15 @@ import kotlin.contracts.contract
 class CredentialAuthorizationServiceStrategy(
     /** List of supported schemes. */
     credentialSchemes: Set<ConstantIndex.CredentialScheme>,
+    /** Maps from/to strings in metadata from/to credential schemes. */
+    private val mapper: CredentialSchemeMapper = DefaultCredentialSchemeMapper(),
 ) : AuthorizationServiceStrategy {
 
     private val supportedCredentialSchemes = credentialSchemes
-        .flatMap { it.toSupportedCredentialFormat().entries }
+        .flatMap { mapper.map(it).entries }
         .associate { it.key to it.value }
 
-    override fun validScopes(): String = supportedCredentialSchemes.map { it.value.scope }.joinToString(" ")
+    override fun validScopes(): String = supportedCredentialSchemes.map { it.value.scope }.distinct().joinToString(" ")
 
     override fun allCredentialIdentifier(): Collection<String> = supportedCredentialSchemes.map { it.key }
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/DummyAuthorizationServiceStrategy.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oauth2/DummyAuthorizationServiceStrategy.kt
@@ -3,7 +3,6 @@ package at.asitplus.wallet.lib.oauth2
 import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.OpenIdAuthorizationDetails
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception.InvalidAuthorizationDetails
-import at.asitplus.wallet.lib.oidvci.matches
 
 class DummyAuthorizationServiceStrategy(
     private val scope: String,
@@ -13,43 +12,36 @@ class DummyAuthorizationServiceStrategy(
 
     override fun validAuthorizationDetails(location: String): Collection<OpenIdAuthorizationDetails> = listOf()
 
+    override fun validateAuthorizationDetails(
+        authorizationDetails: Collection<AuthorizationDetails>,
+        configurationIds: Set<String>
+    ): Boolean = false
+
     @Throws(InvalidAuthorizationDetails::class)
     override fun validateAuthorizationDetails(
         authorizationDetails: Collection<AuthorizationDetails>,
     ) {
-        authorizationDetails.toSet().also {
-            if (it.isEmpty())
-                throw InvalidAuthorizationDetails("No valid authorization details in $authorizationDetails")
-        }
+        throw InvalidAuthorizationDetails()
     }
 
     override fun filterAuthorizationDetailsForTokenResponse(
         authorizationDetails: Collection<AuthorizationDetails>
     ) = authorizationDetails.filterIsInstance<OpenIdAuthorizationDetails>().toSet()
 
-
     @Throws(InvalidAuthorizationDetails::class)
     override fun matchAndFilterAuthorizationDetailsForTokenResponse(
         authnRequestAuthnDetails: Collection<AuthorizationDetails>?,
         tokenRequestAuthnDetails: Set<AuthorizationDetails>,
-    ) = tokenRequestAuthnDetails
-        .filterIsInstance<OpenIdAuthorizationDetails>()
-        .toSet()
-        .apply {
-            this.forEach { filter ->
-                if (!filter.requestedFromAuthnRequest(authnRequestAuthnDetails))
-                    throw InvalidAuthorizationDetails("Authorization details not from auth code: $filter")
-            }
-        }
-
-
-    private fun OpenIdAuthorizationDetails.requestedFromAuthnRequest(
-        details: Collection<AuthorizationDetails>?
-    ): Boolean = details!!.filterIsInstance<OpenIdAuthorizationDetails>().any { matches(it) }
+    ) = throw InvalidAuthorizationDetails()
 
     override fun filterScope(scope: String): String = scope
 
-    override fun allCredentialIdentifier(): Collection<String> = listOf()
+    override fun validateScope(
+        scope: String,
+        configurationIds: Set<String>
+    ): Boolean = scope == this.scope
+
+    override fun allCredentialIdentifier(): Set<String> = setOf()
 
 }
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/CredentialSchemeMappingTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/CredentialSchemeMappingTest.kt
@@ -3,9 +3,6 @@ package at.asitplus.wallet.lib.oidvci
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
-import at.asitplus.wallet.lib.oidvci.CredentialSchemeMapping.decodeFromCredentialIdentifier
-import at.asitplus.wallet.lib.oidvci.CredentialSchemeMapping.toCredentialIdentifier
-import at.asitplus.wallet.lib.oidvci.CredentialSchemeMapping.toSupportedCredentialFormat
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.maps.shouldContainKey
 import io.kotest.matchers.nulls.shouldBeNull
@@ -13,43 +10,45 @@ import io.kotest.matchers.shouldBe
 
 val CredentialSchemeMappingTest by testSuite {
 
+    val mapper = DefaultCredentialSchemeMapper()
+
     test("AtomicAttribute in plain JWT") {
         val expectedKey = "${AtomicAttribute2023.vcType}#${CredentialFormatEnum.JWT_VC.text}"
-        AtomicAttribute2023.toCredentialIdentifier(PLAIN_JWT) shouldBe expectedKey
-        AtomicAttribute2023.toSupportedCredentialFormat().shouldContainKey(expectedKey)
-        decodeFromCredentialIdentifier(expectedKey) shouldBe Pair(AtomicAttribute2023, PLAIN_JWT)
+        mapper.toCredentialIdentifier(AtomicAttribute2023, PLAIN_JWT) shouldBe expectedKey
+        mapper.map(AtomicAttribute2023).shouldContainKey(expectedKey)
+        mapper.decodeFromCredentialIdentifier(expectedKey) shouldBe Pair(AtomicAttribute2023, PLAIN_JWT)
     }
 
     test("AtomicAttribute in SD-JWT") {
         val expectedKey = "${AtomicAttribute2023.sdJwtType}#${CredentialFormatEnum.DC_SD_JWT.text}"
-        AtomicAttribute2023.toCredentialIdentifier(SD_JWT) shouldBe expectedKey
-        AtomicAttribute2023.toSupportedCredentialFormat().shouldContainKey(expectedKey)
-        decodeFromCredentialIdentifier(expectedKey) shouldBe Pair(AtomicAttribute2023, SD_JWT)
+        mapper.toCredentialIdentifier(AtomicAttribute2023, SD_JWT) shouldBe expectedKey
+        mapper.map(AtomicAttribute2023).shouldContainKey(expectedKey)
+        mapper.decodeFromCredentialIdentifier(expectedKey) shouldBe Pair(AtomicAttribute2023, SD_JWT)
     }
 
     test("AtomicAttribute in ISO mDoc") {
         val expectedKey = AtomicAttribute2023.isoNamespace
-        AtomicAttribute2023.toCredentialIdentifier(ISO_MDOC) shouldBe expectedKey
-        AtomicAttribute2023.toSupportedCredentialFormat().shouldContainKey(expectedKey)
-        decodeFromCredentialIdentifier(expectedKey) shouldBe Pair(AtomicAttribute2023, ISO_MDOC)
+        mapper.toCredentialIdentifier(AtomicAttribute2023, ISO_MDOC) shouldBe expectedKey
+        mapper.map(AtomicAttribute2023).shouldContainKey(expectedKey)
+        mapper.decodeFromCredentialIdentifier(expectedKey) shouldBe Pair(AtomicAttribute2023, ISO_MDOC)
     }
 
     test("unknown scheme in plain JWT") {
         val key = "${randomString()}#${CredentialFormatEnum.JWT_VC.text}"
-        decodeFromCredentialIdentifier(key).shouldBeNull()
+        mapper.decodeFromCredentialIdentifier(key).shouldBeNull()
     }
 
     test("unknown scheme in SD-JWT") {
         val key = "${randomString()}#${CredentialFormatEnum.DC_SD_JWT.text}"
-        decodeFromCredentialIdentifier(key).shouldBeNull()
+        mapper.decodeFromCredentialIdentifier(key).shouldBeNull()
     }
 
     test("unknown scheme in ISO mDoc") {
         val key = "${randomString()}#${CredentialFormatEnum.MSO_MDOC.text}"
-        decodeFromCredentialIdentifier(key).shouldBeNull()
+        mapper.decodeFromCredentialIdentifier(key).shouldBeNull()
     }
 
     test("unknown scheme, no format") {
-        decodeFromCredentialIdentifier(randomString()).shouldBeNull()
+        mapper.decodeFromCredentialIdentifier(randomString()).shouldBeNull()
     }
 }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciSameScopeTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciSameScopeTest.kt
@@ -1,0 +1,146 @@
+package at.asitplus.wallet.lib.oidvci
+
+import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
+import at.asitplus.openid.RequestParameters
+import at.asitplus.openid.TokenResponseParameters
+import at.asitplus.signum.indispensable.josef.JwsSigned
+import at.asitplus.testballoon.withFixtureGenerator
+import at.asitplus.wallet.lib.agent.IssuerAgent
+import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
+import at.asitplus.wallet.lib.data.VerifiableCredentialJws
+import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
+import at.asitplus.wallet.lib.data.rfc3986.toUri
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.oauth2.OAuth2Client
+import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
+import at.asitplus.wallet.lib.oidvci.WalletService.RequestOptions
+import at.asitplus.wallet.lib.openid.AuthenticationResponseResult
+import at.asitplus.wallet.lib.openid.DummyOAuth2IssuerCredentialDataProvider
+import at.asitplus.wallet.lib.openid.DummyUserProvider
+import at.asitplus.wallet.mdl.MobileDrivingLicenceScheme
+import com.benasher44.uuid.uuid4
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+val OidvciSameScopeTest by testSuite {
+
+    withFixtureGenerator {
+        object {
+            val mapper = SameScopeCredentialSchemeMapper()
+            val authorizationService = SimpleAuthorizationService(
+                strategy = CredentialAuthorizationServiceStrategy(
+                    credentialSchemes = setOf(AtomicAttribute2023, MobileDrivingLicenceScheme),
+                    mapper = mapper,
+                ),
+            )
+            val issuer = CredentialIssuer(
+                authorizationService = authorizationService,
+                issuer = IssuerAgent(
+                    identifier = "https://issuer.example.com".toUri(),
+                    randomSource = RandomSource.Default
+                ),
+                credentialSchemes = setOf(AtomicAttribute2023, MobileDrivingLicenceScheme),
+                credentialSchemeMapper = mapper,
+            )
+            val client = WalletService()
+            val oauth2Client = OAuth2Client()
+            val state = uuid4().toString()
+
+            suspend fun getToken(scope: String, setScopeInTokenRequest: Boolean = true): TokenResponseParameters {
+                val authnRequest = oauth2Client.createAuthRequestJar(
+                    state = state,
+                    scope = scope,
+                    resource = issuer.metadata.credentialIssuer
+                )
+                val input = authnRequest as RequestParameters
+                val authnResponse = authorizationService.authorize(input) { catching { DummyUserProvider.user } }
+                    .getOrThrow()
+                    .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+                val code = authnResponse.params?.code
+                    .shouldNotBeNull()
+                val tokenRequest = oauth2Client.createTokenRequestParameters(
+                    state = state,
+                    authorization = OAuth2Client.AuthorizationForToken.Code(code),
+                    scope = if (setScopeInTokenRequest) scope else null,
+                    resource = issuer.metadata.credentialIssuer
+                )
+                return authorizationService.token(tokenRequest, null).getOrThrow()
+            }
+
+        }
+    } - {
+        test("request one credential, using scope") {
+            val requestOptions = RequestOptions(AtomicAttribute2023, PLAIN_JWT)
+            val credentialFormat = it.client.selectSupportedCredentialFormat(requestOptions, it.issuer.metadata)
+                .shouldNotBeNull()
+            val scope = credentialFormat.scope.shouldNotBeNull()
+            val token = it.getToken(scope)
+            val credential = it.issuer.credential(
+                authorizationHeader = token.toHttpHeaderValue(),
+                params = it.client.createCredential(
+                    tokenResponse = token,
+                    metadata = it.issuer.metadata,
+                    credentialFormat = credentialFormat,
+                    clientNonce = it.issuer.nonceWithDpopNonce().getOrThrow().response.clientNonce,
+                ).getOrThrow().shouldBeSingleton().first(),
+                credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
+            ).getOrThrow()
+                .shouldBeInstanceOf<CredentialIssuer.CredentialResponse.Plain>()
+                .response
+            val serializedCredential = credential.credentials.shouldNotBeEmpty()
+                .first().credentialString.shouldNotBeNull()
+
+            JwsSigned.deserialize<VerifiableCredentialJws>(
+                VerifiableCredentialJws.serializer(),
+                serializedCredential,
+                vckJsonSerializer
+            ).getOrThrow()
+                .payload.vc.credentialSubject.shouldBeInstanceOf<at.asitplus.wallet.lib.data.AtomicAttribute2023>()
+        }
+
+        test("request multiple credentials, using scope") {
+            val requestOptions = setOf(
+                RequestOptions(AtomicAttribute2023, SD_JWT),
+                RequestOptions(AtomicAttribute2023, ISO_MDOC),
+            ).associateBy { requestOption ->
+                it.client.selectSupportedCredentialFormat(requestOption, it.issuer.metadata)!!
+            }
+            val scope = requestOptions.keys.joinToString(" ") { it.scope.shouldNotBeNull() }
+            val token = it.getToken(scope)
+
+            requestOptions.forEach { requestOption ->
+                it.issuer.credential(
+                    authorizationHeader = token.toHttpHeaderValue(),
+                    params = it.client.createCredential(
+                        tokenResponse = token,
+                        metadata = it.issuer.metadata,
+                        credentialFormat = requestOption.key,
+                        clientNonce = it.issuer.nonceWithDpopNonce().getOrThrow().response.clientNonce,
+                    ).getOrThrow().shouldBeSingleton().first(),
+                    credentialDataProvider = DummyOAuth2IssuerCredentialDataProvider,
+                ).getOrThrow()
+                    .shouldBeInstanceOf<CredentialIssuer.CredentialResponse.Plain>()
+                    .response
+                    .credentials.shouldNotBeEmpty()
+                    .map { it.credentialString.shouldNotBeNull() }.any {
+                        catchingUnwrapped { it.assertSdJwtReceived() }.isSuccess
+                    }
+            }
+        }
+    }
+}
+
+private fun String.assertSdJwtReceived(): Int =
+    JwsSigned.deserialize(
+        VerifiableCredentialSdJwt.serializer(),
+        substringBefore("~")
+    ).getOrThrow().payload.disclosureDigests
+        .shouldNotBeNull()
+        .size shouldBeGreaterThan 1

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/SameScopeCredentialSchemeMapper.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/SameScopeCredentialSchemeMapper.kt
@@ -1,0 +1,89 @@
+package at.asitplus.wallet.lib.oidvci
+
+import at.asitplus.openid.ClaimDescription
+import at.asitplus.openid.CredentialFormatEnum
+import at.asitplus.openid.CredentialFormatEnum.DC_SD_JWT
+import at.asitplus.openid.CredentialFormatEnum.JWT_VC
+import at.asitplus.openid.OpenIdConstants.BINDING_METHOD_COSE_KEY
+import at.asitplus.openid.OpenIdConstants.BINDING_METHOD_JWK
+import at.asitplus.openid.OpenIdConstants.URN_TYPE_JWK_THUMBPRINT
+import at.asitplus.openid.SupportedCredentialFormat
+import at.asitplus.openid.SupportedCredentialFormatDefinition
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialScheme
+import at.asitplus.wallet.lib.data.ConstantIndex.supportsIso
+import at.asitplus.wallet.lib.data.ConstantIndex.supportsSdJwt
+import at.asitplus.wallet.lib.data.ConstantIndex.supportsVcJwt
+import at.asitplus.wallet.lib.data.VcDataModelConstants
+import at.asitplus.wallet.lib.oidvci.CredentialSchemeMapping.encodeToCredentialIdentifier
+import com.benasher44.uuid.uuid4
+
+class SameScopeCredentialSchemeMapper(
+    private val scope: String = uuid4().toString(),
+) : CredentialSchemeMapper {
+
+    override fun map(scheme: CredentialScheme): Map<String, SupportedCredentialFormat> =
+        scheme.toSupportedCredentialFormatWithSameScope(scope)
+
+    override fun decodeFromCredentialIdentifier(input: String): Pair<CredentialScheme, CredentialRepresentation>? =
+        CredentialSchemeMapping.decodeFromCredentialIdentifier(input)
+
+    override fun encodeToCredentialIdentifier(type: String, format: CredentialFormatEnum): String =
+        "${type.replace(" ", "_")}#${format.text}"
+
+    override fun toCredentialIdentifier(
+        scheme: CredentialScheme,
+        rep: CredentialRepresentation
+    ) = when (rep) {
+        CredentialRepresentation.PLAIN_JWT -> encodeToCredentialIdentifier(scheme.vcType!!, JWT_VC)
+        CredentialRepresentation.SD_JWT -> encodeToCredentialIdentifier(scheme.sdJwtType!!, DC_SD_JWT)
+        CredentialRepresentation.ISO_MDOC -> scheme.isoNamespace!!
+    }
+}
+
+
+@Suppress("DEPRECATION")
+private fun CredentialScheme.toSupportedCredentialFormatWithSameScope(scope: String): Map<String, SupportedCredentialFormat> {
+    val iso = if (supportsIso) {
+        with(isoNamespace!!) {
+            this to SupportedCredentialFormat.forIsoMdoc(
+                format = CredentialFormatEnum.MSO_MDOC,
+                scope = scope,
+                docType = isoDocType!!,
+                supportedBindingMethods = setOf(BINDING_METHOD_JWK, BINDING_METHOD_COSE_KEY),
+                isoClaims = claimNames.map {
+                    ClaimDescription(path = listOf(isoNamespace!!) + it.split("."))
+                }.toSet()
+            )
+        }
+    } else null
+    val jwtVc = if (supportsVcJwt) {
+        with(encodeToCredentialIdentifier(vcType!!, CredentialFormatEnum.JWT_VC)) {
+            this to SupportedCredentialFormat.forVcJwt(
+                format = CredentialFormatEnum.JWT_VC,
+                scope = scope,
+                credentialDefinition = SupportedCredentialFormatDefinition(
+                    types = setOf(VcDataModelConstants.VERIFIABLE_CREDENTIAL, vcType!!),
+                ),
+                supportedBindingMethods = setOf(BINDING_METHOD_JWK, URN_TYPE_JWK_THUMBPRINT),
+                vcJwtClaims = claimNames.map {
+                    ClaimDescription(path = it.split("."))
+                }.toSet()
+            )
+        }
+    } else null
+    val sdJwt = if (supportsSdJwt) {
+        with(encodeToCredentialIdentifier(sdJwtType!!, CredentialFormatEnum.DC_SD_JWT)) {
+            this to SupportedCredentialFormat.forSdJwt(
+                format = CredentialFormatEnum.DC_SD_JWT,
+                scope = scope,
+                sdJwtVcType = sdJwtType!!,
+                supportedBindingMethods = setOf(BINDING_METHOD_JWK, URN_TYPE_JWK_THUMBPRINT),
+                sdJwtClaims = claimNames.map {
+                    ClaimDescription(path = it.split("."))
+                }.toSet()
+            )
+        }
+    } else null
+    return listOfNotNull(iso, jwtVc, sdJwt).toMap()
+}


### PR DESCRIPTION
Handles the legitimate case of issuers advertising same scope values for different credential configurations (distinguished by their credential representation). Had to do some refactoring in our code to cleanly test this scenario.