### PR TITLE
Token status: Use correct CBOR encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Release 5.11.0 (unreleased):
  - OAuth 2.0:
    - In `SimpleAuthorizationService` offer `client_attestation_pop_signing_alg_values_supported` and `client_attestation_signing_alg_values_supported` in line with [OAuth 2.0 Attestation-Based Client Authentication](https://www.ietf.org/archive/id/draft-ietf-oauth-attestation-based-client-auth-07.html#name-authorization-server-metada)
    - Use DPoP proofs on client calls
+ - Token status list:
+   - CBOR encoded token status list shall not be tagged with 24 like other COSE payloads (`d818` in hex)
 
 Release 5.10.1:
  - Proximity presentations:
@@ -23,7 +25,7 @@ Release 5.10.1:
    - In `OpenId4VpVerifier` add option to provide `externalId` to methods `validateAuthnRequest()` and `submitAuthnRequest()`, useful for DCAPI flows
 
 Release 5.10.0:
- - StatusListToken:
+ - Token status list:
    - Remove `StatusTokenValidator`
    - Remove `StatusTokenIntegrityValidator` class
    - Refactor `StatusListToken.StatusListJwt` to `StatusListJwt`
@@ -350,7 +352,7 @@ Release 5.6.2:
 
 Release 5.6.1:
  - Expose details for `ConstraintFieldsEvaluationException`
- - Token status:
+ - Token status list:
    - Errors in status list lookup lead to a `null` token status, not to an error as before, i.e. `TokenStatusEvaluationException` is never thrown
  - Remote Qualified Electronic Signatures:
    - In `RqesOpenId4VpHolder` fix validation of signing credentials
@@ -383,7 +385,7 @@ Release 5.6.0:
    - Replace `CoseService.createSignedCoseWithDetachedPayload()` with `SignCoseDetachedFun`
 
 Release 5.5.4:
- - Token status:
+ - Token status list:
    - Add considerations for separating the semantics "no token status mechanism is defined" from "evaluating token status failed"
    - Provide revocation status to verifier
  - DCQL:
@@ -541,7 +543,7 @@ Release 5.3.1:
 - Fix validation of KB-JWT for SD-JWT presentations
 
 Release 5.3.0:
-- Implement [token-status-list-06](https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-06.html), replacing implementation of Revocation List 2020:
+- Implement token status list from [token-status-list-06](https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-06.html), replacing implementation of Revocation List 2020:
   - `Holder`:
     - Remove `setRevocationList`
     - Change `StoredCredential` revocation status to token status

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListIssuer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListIssuer.kt
@@ -14,7 +14,7 @@ import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.StatusProvider
  * It can issue Verifiable Credentials, revoke credentials and build a revocation list.
  */
 interface StatusListIssuer :
-    StatusIssuer<JwsSigned<StatusListTokenPayload>, CoseSigned<StatusListTokenPayload>>,
+    StatusIssuer<JwsSigned<StatusListTokenPayload>, CoseSigned<ByteArray>>,
     StatusProvider<StatusListToken> {
 
     /**

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/TokenStatusResolver.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/validation/TokenStatusResolver.kt
@@ -32,7 +32,7 @@ class TokenStatusResolverImpl(
     private val clock: Clock = Clock.System,
     private val zlibService: ZlibService = DefaultZlibService(),
     private val verifyJwsObjectIntegrity: VerifyJwsObjectFun = VerifyJwsObject(),
-    private val verifyCoseSignature: VerifyCoseSignatureFun<StatusListTokenPayload> = VerifyCoseSignature(),
+    private val verifyCoseSignature: VerifyCoseSignatureFun<ByteArray> = VerifyCoseSignature(),
 ) : TokenStatusResolver {
     override suspend fun invoke(status: Status): KmmResult<TokenStatus> = catching {
         val token = resolveStatusListToken(status.statusList!!.uri)
@@ -62,7 +62,7 @@ fun StatusListTokenResolver.toTokenStatusResolver(
     clock: Clock = Clock.System,
     zlibService: ZlibService = DefaultZlibService(),
     verifyJwsObjectIntegrity: VerifyJwsObjectFun = VerifyJwsObject(),
-    verifyCoseSignature: VerifyCoseSignatureFun<StatusListTokenPayload> = VerifyCoseSignature(),
+    verifyCoseSignature: VerifyCoseSignatureFun<ByteArray> = VerifyCoseSignature(),
 ) = TokenStatusResolver { status ->
     catching {
         val token = this(status.statusList!!.uri)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/StatusListJwt.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/StatusListJwt.kt
@@ -13,7 +13,6 @@ data class StatusListJwt(
     val value: JwsSigned<StatusListTokenPayload>,
     override val resolvedAt: Instant?,
 ) : StatusListToken() {
-    override val payload = value.payload
 
     /**
      * Validate the Status List Token:

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/StatusListToken.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/StatusListToken.kt
@@ -13,7 +13,6 @@ import kotlin.time.Instant
 
 sealed class StatusListToken {
     abstract val resolvedAt: Instant?
-    abstract val payload: StatusListTokenPayload
 
     /**
      * Validate the Status List Token:
@@ -26,7 +25,7 @@ sealed class StatusListToken {
      */
     suspend fun validate(
         verifyJwsObject: VerifyJwsObjectFun = VerifyJwsObject(),
-        verifyCoseSignature: VerifyCoseSignatureFun<StatusListTokenPayload> = VerifyCoseSignature(),
+        verifyCoseSignature: VerifyCoseSignatureFun<ByteArray> = VerifyCoseSignature(),
         statusListInfo: StatusListInfo,
         isInstantInThePast: (Instant) -> Boolean
     ): KmmResult<StatusListTokenPayload> = when (this) {

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
@@ -13,7 +13,6 @@ import at.asitplus.openid.dcql.DCQLJsonClaimsQuery
 import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.openid.dcql.DCQLSdJwtCredentialMetadataAndValidityConstraints
 import at.asitplus.openid.dcql.DCQLSdJwtCredentialQuery
-import at.asitplus.signum.indispensable.josef.JwsHeader
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.withFixtureGenerator
@@ -26,8 +25,6 @@ import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.CredentialPresentation.PresentationExchangePresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.KeyBindingJws
-import at.asitplus.wallet.lib.data.StatusListCwt
-import at.asitplus.wallet.lib.data.StatusListJwt
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.communication.primitives.StatusListTokenMediaType
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.data.rfc3986.toUri
@@ -37,8 +34,8 @@ import at.asitplus.wallet.lib.jws.JwsHeaderIdentifierFun
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.jws.SignJwtFun
-import at.asitplus.wallet.lib.randomCwtOrJwtResolver
 import at.asitplus.wallet.lib.jws.VerifyStatusListTokenHAIP
+import at.asitplus.wallet.lib.randomCwtOrJwtResolver
 import com.benasher44.uuid.uuid4
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.collections.shouldContain


### PR DESCRIPTION
Fixes https://github.com/a-sit-plus/valera/issues/413 by correctly encoding the payload of a status list in CWT, i.e. without tagging it in COSE (24, or in hex `d818`).