### PR TITLE
Add expiration and cleanup to default map store

### DIFF
--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -47,6 +47,7 @@ import io.github.aakira.napier.Napier
 import io.ktor.http.*
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.json.JsonObject
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 
 
@@ -105,7 +106,8 @@ class SimpleAuthorizationService(
     /** Associates issued codes with the auth request from the client. */
     private val codeToClientAuthRequest: MapStore<String, ClientAuthRequest> = DefaultMapStore(),
     /** Associates issued refresh tokens with the auth request from the client. *Refresh tokens are usually long-lived!* */
-    private val refreshTokenToAuthRequest: MapStore<String, ClientAuthRequest> = DefaultMapStore(),
+    private val refreshTokenToAuthRequest: MapStore<String, ClientAuthRequest> =
+        DefaultMapStore(lifetime = 30.days),
     /** Associates the issued request_uri to the auth request from the client. */
     private val requestUriToPushedAuthorizationRequest: MapStore<String, AuthenticationRequestParameters> = DefaultMapStore(),
     /** Service to create and validate access tokens. */

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/DefaultMapStoreTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/DefaultMapStoreTest.kt
@@ -1,0 +1,46 @@
+package at.asitplus.wallet.lib.oidvci
+
+import com.benasher44.uuid.uuid4
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.nulls.shouldBeNull
+import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
+
+val DefaultMapStoreTest by testSuite {
+
+    test("simple types are working") {
+        with(
+            DefaultMapStore<String, String>(
+                lifetime = 1.milliseconds,
+                sizeToCheckForExpiration = 1U
+            )
+        ) {
+            val key = uuid4().toString()
+            get(key).shouldBeNull()
+            put(key, "value")
+            delay(10.milliseconds)
+            get(key).shouldBeNull()
+        }
+    }
+
+    test("key array type is prevented") {
+        with(
+            DefaultMapStore<Array<String>, String>()
+        ) {
+            shouldThrowAny {
+                put(arrayOf("key"), "value")
+            }
+        }
+    }
+
+    test("value array type is prevented") {
+        with(
+            DefaultMapStore<String, Array<String>>()
+        ) {
+            shouldThrowAny {
+                put("key", arrayOf("value"))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Saves the default map stores from unbound growth.