### PR TITLE
ISO: ZK data classes

### DIFF
--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/DeviceResponse.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/DeviceResponse.kt
@@ -12,6 +12,8 @@ data class DeviceResponse(
     val version: String,
     @SerialName("documents")
     val documents: Array<Document>? = null,
+    @SerialName("zkDocuments")
+    val zkDocuments: Array<ZkDocument>? = null,
     @SerialName("documentErrors")
     val documentErrors: Array<Pair<String, UInt>>? = null,
     @SerialName("status")
@@ -29,6 +31,10 @@ data class DeviceResponse(
             if (other.documents == null) return false
             if (!documents.contentEquals(other.documents)) return false
         } else if (other.documents != null) return false
+        if (zkDocuments != null) {
+            if (other.zkDocuments == null) return false
+            if (!zkDocuments.contentEquals(other.zkDocuments)) return false
+        } else if (other.zkDocuments != null) return false
         if (documentErrors != null) {
             if (other.documentErrors == null) return false
             if (!documentErrors.contentEquals(other.documentErrors)) return false
@@ -39,6 +45,7 @@ data class DeviceResponse(
     override fun hashCode(): Int {
         var result = version.hashCode()
         result = 31 * result + (documents?.contentHashCode() ?: 0)
+        result = 31 * result + (zkDocuments?.contentHashCode() ?: 0)
         result = 31 * result + (documentErrors?.contentHashCode() ?: 0)
         result = 31 * result + status.hashCode()
         return result

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/DocRequestInfo.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/DocRequestInfo.kt
@@ -18,4 +18,34 @@ data class DocRequestInfo(
     @SerialName("docResponseEncryption")
     val docResponseEncryption: EncryptionParameters? = null,
     // TODO: Implement alternativeDataElements
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as DocRequestInfo
+
+        if (uniqueDocSetRequired != other.uniqueDocSetRequired) return false
+        if (issuerIdentifiers != null && other.issuerIdentifiers != null) {
+            if (issuerIdentifiers.size != other.issuerIdentifiers.size) return false
+            if (!issuerIdentifiers.zip(other.issuerIdentifiers).all {
+                (a, b) -> a.contentEquals(b)
+            }) return false
+        } else if (issuerIdentifiers != other.issuerIdentifiers) return false
+
+        if (maximumResponseSize != other.maximumResponseSize) return false
+        if (zkRequest != other.zkRequest) return false
+        if (docResponseEncryption != other.docResponseEncryption) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = uniqueDocSetRequired?.hashCode() ?: 0
+        result = 31 * result + (issuerIdentifiers?.fold(1) { acc, arr -> 31 * acc + arr.contentHashCode() } ?: 0)
+        result = 31 * result + (maximumResponseSize?.hashCode() ?: 0)
+        result = 31 * result + (zkRequest?.hashCode() ?: 0)
+        result = 31 * result + (docResponseEncryption?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/DocRequestInfo.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/DocRequestInfo.kt
@@ -1,0 +1,21 @@
+package at.asitplus.iso
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.ByteString
+
+@Serializable
+data class DocRequestInfo(
+    @SerialName("issuerIdentifiers")
+    @ByteString
+    val issuerIdentifiers: List<ByteArray>? = null,
+    @SerialName("uniqueDocSetRequired")
+    val uniqueDocSetRequired: Boolean? = null,
+    @SerialName("maximumResponseSize")
+    val maximumResponseSize: UInt? = null,
+    @SerialName("zkRequest")
+    val zkRequest: ZkRequest? = null,
+    @SerialName("docResponseEncryption")
+    val docResponseEncryption: EncryptionParameters? = null,
+    // TODO: Implement alternativeDataElements
+)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/IssuerSignedItem.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/IssuerSignedItem.kt
@@ -17,10 +17,10 @@ data class IssuerSignedItem(
     @ByteString
     val random: ByteArray,
     @SerialName(PROP_ELEMENT_ID)
-    val elementIdentifier: String,
+    override val elementIdentifier: String,
     @SerialName(PROP_ELEMENT_VALUE)
-    val elementValue: Any,
-) {
+    override val elementValue: Any,
+) : Item {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/Item.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/Item.kt
@@ -1,0 +1,6 @@
+package at.asitplus.iso
+
+interface Item {
+    val elementIdentifier: String
+    val elementValue: Any
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ItemsRequest.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ItemsRequest.kt
@@ -13,5 +13,5 @@ data class ItemsRequest(
     @SerialName("nameSpaces")
     val namespaces: Map<String, ItemsRequestList>,
     @SerialName("requestInfo")
-    val requestInfo: Map<String, String>? = null,
+    val requestInfo: DocRequestInfo? = null,
 )

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/NamespacedZkSignedListSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/NamespacedZkSignedListSerializer.kt
@@ -1,0 +1,50 @@
+package at.asitplus.iso
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+object NamespacedZkSignedListSerializer : KSerializer<Map<String, ZkSignedList>> {
+    private val mapSerializer = MapSerializer(String.serializer(), object :
+        ZkSignedListSerializer("") {})
+
+    override val descriptor = mapSerializer.descriptor
+    override fun deserialize(decoder: Decoder): Map<String, ZkSignedList> = NamespacedMapEntryDeserializer().let {
+        MapSerializer(it.namespaceSerializer, it.itemSerializer).deserialize(decoder)
+    }
+
+    class NamespacedMapEntryDeserializer {
+        lateinit var key: String
+        val namespaceSerializer = NamespaceSerializer()
+        val itemSerializer = ZkSignedListSerializer()
+
+        inner class NamespaceSerializer internal constructor() : KSerializer<String> {
+            override val descriptor = PrimitiveSerialDescriptor("ISO namespace", PrimitiveKind.STRING)
+
+            override fun deserialize(decoder: Decoder): String = decoder.decodeString().apply { key = this }
+
+            override fun serialize(encoder: Encoder, value: String) {
+                encoder.encodeString(value).also { key = value }
+            }
+        }
+
+        inner class ZkSignedListSerializer internal constructor() : KSerializer<ZkSignedList> {
+            override val descriptor = mapSerializer.descriptor
+
+            override fun deserialize(decoder: Decoder): ZkSignedList =
+                decoder.decodeSerializableValue(ZkSignedListSerializer(key))
+
+            override fun serialize(encoder: Encoder, value: ZkSignedList) =
+                encoder.encodeSerializableValue(ZkSignedListSerializer(key), value)
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: Map<String, ZkSignedList>) =
+        NamespacedMapEntryDeserializer().let {
+            MapSerializer(it.namespaceSerializer, it.itemSerializer).serialize(encoder, value)
+        }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkDocument.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkDocument.kt
@@ -20,9 +20,7 @@ data class ZkDocument (
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ZkDocument
+        if (other !is ZkDocument) return false
 
         if (zkDocumentDataBytes != other.zkDocumentDataBytes) return false
         if (!proof.contentEquals(other.proof)) return false

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkDocument.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkDocument.kt
@@ -1,0 +1,38 @@
+package at.asitplus.iso
+
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.ByteString
+import kotlinx.serialization.cbor.ValueTags
+
+/**
+ * Part of the ISO/IEC 18013-5:2021 standard: Data structure for mdoc request in ZK (10.3.4)
+ */
+@Serializable
+data class ZkDocument (
+    @SerialName("zkDocumentDataBytes")
+    @ValueTags(24U)
+    val zkDocumentDataBytes: ByteStringWrapper<ZkDocumentData>,
+    @SerialName("proof")
+    @ByteString
+    val proof: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as ZkDocument
+
+        if (zkDocumentDataBytes != other.zkDocumentDataBytes) return false
+        if (!proof.contentEquals(other.proof)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = zkDocumentDataBytes.hashCode()
+        result = 31 * result + proof.contentHashCode()
+        return result
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkDocumentData.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkDocumentData.kt
@@ -1,0 +1,40 @@
+package at.asitplus.iso
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.ByteString
+import kotlinx.serialization.cbor.CborLabel
+import kotlin.time.Instant
+
+@Serializable
+data class ZkDocumentData (
+    @SerialName("docType")
+    val docType: String,
+    @SerialName("zkSystemId")
+    val zkSystemId: String,
+    @SerialName("timestamp")
+    val timestamp: Instant,
+    @SerialName("issuerSigned")
+    @Serializable(with = NamespacedZkSignedListSerializer::class)
+    val issuerSigned: Map<String, @Contextual ZkSignedList>? = null,
+    @SerialName("deviceSigned")
+    @Serializable(with = NamespacedZkSignedListSerializer::class)
+    val deviceSigned: Map<String, @Contextual ZkSignedList>? = null,
+    /**
+     * This header parameter contains an ordered array of X.509 certificates. The certificates are to be ordered
+     * starting with the certificate containing the end-entity key followed by the certificate that signed it, and so
+     * on. There is no requirement for the entire chain to be present in the element if there is reason to believe that
+     * the relying party already has, or can locate, the missing certificates. This means that the relying party is
+     * still required to do path building but that a candidate path is proposed in this header parameter.
+     *
+     * This header parameter allows for a single X.509 certificate or a chain of X.509 certificates to be carried in
+     * the message.
+     *
+     * See [RFC9360](https://www.rfc-editor.org/rfc/rfc9360.html)
+     */
+    @CborLabel(33)
+    @SerialName("msoX5chain")
+    @ByteString
+    val certificateChain: List<ByteArray>? = null,
+)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkRequest.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkRequest.kt
@@ -9,4 +9,13 @@ data class ZkRequest (
     val zkRequired: Boolean,
     @SerialName("systemSpecs")
     val systemSpecs: List<ZkSystemSpec>,
-)
+) {
+    fun validate() {
+        require(!zkRequired || systemSpecs.isNotEmpty()) {
+            "systemSpecs list cannot be empty if Zero-Knowledge is enforced"
+        }
+    }
+    companion object {
+        val Default = ZkRequest(false, emptyList())
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkRequest.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkRequest.kt
@@ -1,0 +1,12 @@
+package at.asitplus.iso
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ZkRequest (
+    @SerialName("ZkRequired")
+    val zkRequired: Boolean,
+    @SerialName("systemSpecs")
+    val systemSpecs: List<ZkSystemSpec>,
+)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSignedItem.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSignedItem.kt
@@ -1,0 +1,28 @@
+package at.asitplus.iso
+
+import at.asitplus.signum.indispensable.cosef.io.Base16Strict
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.serialization.SerialName
+
+
+data class ZkSignedItem(
+    @SerialName(PROP_ELEMENT_ID)
+    override val elementIdentifier: String,
+
+    @SerialName(PROP_ELEMENT_VALUE)
+    override val elementValue: Any,
+) : Item {
+    override fun toString(): String = "IssuerSignedItem(elementIdentifier='$elementIdentifier'," +
+            " elementValue=${elementValue.toCustomString()})"
+
+    companion object {
+        internal const val PROP_ELEMENT_ID = "elementIdentifier"
+        internal const val PROP_ELEMENT_VALUE = "elementValue"
+    }
+}
+
+private fun Any.toCustomString(): String = when (this) {
+    is ByteArray -> this.encodeToString(Base16Strict)
+    is Array<*> -> this.contentDeepToString()
+    else -> this.toString()
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSignedItem.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSignedItem.kt
@@ -12,7 +12,7 @@ data class ZkSignedItem(
     @SerialName(PROP_ELEMENT_VALUE)
     override val elementValue: Any,
 ) : Item {
-    override fun toString(): String = "IssuerSignedItem(elementIdentifier='$elementIdentifier'," +
+    override fun toString(): String = "ZkSignedItem(elementIdentifier='$elementIdentifier'," +
             " elementValue=${elementValue.toCustomString()})"
 
     companion object {

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSignedItemSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSignedItemSerializer.kt
@@ -1,0 +1,150 @@
+package at.asitplus.iso
+
+import at.asitplus.catchingUnwrapped
+import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
+import io.github.aakira.napier.Napier
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ByteArraySerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.cbor.ValueTags
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.CompositeEncoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeStructure
+import kotlin.time.Instant
+
+open class ZkSignedItemSerializer(private val namespace: String) :
+    KSerializer<ZkSignedItem> {
+
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("ZkSignedItem") {
+        element(ZkSignedItem.PROP_ELEMENT_ID, String.serializer().descriptor)
+        element(ZkSignedItem.PROP_ELEMENT_VALUE, String.serializer().descriptor)
+    }
+
+    override fun serialize(encoder: Encoder, value: ZkSignedItem) {
+        encoder.encodeStructure(descriptor) {
+            encodeStringElement(descriptor, 0, value.elementIdentifier)
+            encodeAnything(value, 1)
+        }
+    }
+
+    private fun CompositeEncoder.encodeAnything(value: ZkSignedItem, index: Int) {
+        val elementValueSerializer = buildElementValueSerializer(namespace, value.elementValue, value.elementIdentifier)
+        val descriptor = buildClassSerialDescriptor("ZkSignedItem") {
+            element(ZkSignedItem.PROP_ELEMENT_ID, String.serializer().descriptor)
+            element(ZkSignedItem.PROP_ELEMENT_VALUE, elementValueSerializer.descriptor, value.elementValue.annotations())
+        }
+
+        when (val it = value.elementValue) {
+            is String -> encodeStringElement(descriptor, index, it)
+            is Int -> encodeIntElement(descriptor, index, it)
+            is Long -> encodeLongElement(descriptor, index, it)
+            is LocalDate -> encodeSerializableElement(descriptor, index, LocalDate.serializer(), it)
+            is Instant -> encodeSerializableElement(descriptor, index, InstantStringSerializer, it)
+            is Boolean -> encodeBooleanElement(descriptor, index, it)
+            is ByteArray -> encodeSerializableElement(descriptor, index, ByteArraySerializer(), it)
+            else -> CborCredentialSerializer.encode(namespace, value.elementIdentifier, descriptor, index, this, it)
+        }
+    }
+
+    /**
+     * Tags date time elements correctly,
+     * see [RFC 8949 3.4.1](https://datatracker.ietf.org/doc/html/rfc8949#name-standard-date-time-string) for [Instant]
+     * (or "date-time"), see [RFC 8943](https://datatracker.ietf.org/doc/html/rfc8943) for [LocalDate] (or "full-date")
+     */
+    @OptIn(ExperimentalUnsignedTypes::class)
+    private fun Any.annotations() =
+        when (this) {
+            is LocalDate -> listOf(ValueTags(1004uL))
+            is Instant -> listOf(ValueTags(0uL))
+            else -> emptyList()
+        }
+
+
+    override fun deserialize(decoder: Decoder): ZkSignedItem {
+        var elementIdentifier: String? = null
+        var elementValue: Any? = null
+        coseCompliantSerializer
+        decoder.decodeStructure(descriptor) {
+            while (true) {
+                val name = decodeStringElement(descriptor, 0)
+                // Don't call decodeElementIndex, as it would check for tags. this would break decodeAnything
+                val index = descriptor.getElementIndex(name)
+                when (name) {
+                    ZkSignedItem.PROP_ELEMENT_ID -> elementIdentifier = decodeStringElement(descriptor, index)
+                    ZkSignedItem.PROP_ELEMENT_VALUE -> elementValue = decodeAnything(index, elementIdentifier)
+
+                    // TODO: Fix broken by design implementation. In non-canonicalized cbor, the order of
+                    //  elementIdentifier and elementValue may vary. We can't correctly predict how the elementValue
+                    //  should be deserialized. Possible solution: obor maps
+                }
+                if (elementValue != null && elementIdentifier != null) break
+            }
+        }
+        return ZkSignedItem(
+            elementIdentifier = elementIdentifier!!,
+            elementValue = elementValue!!
+        )
+    }
+
+    private fun CompositeDecoder.decodeAnything(index: Int, elementIdentifier: String?): Any {
+        if (namespace.isBlank())
+            Napier.w("This decoder is not namespace-aware! Unspeakable things may happen…")
+
+        // Tags are not read out here but skipped because `decodeElementIndex` is never called, so we cannot
+        // discriminate technically, this should be a good thing though, because otherwise we'd consume more from the
+        // input
+        elementIdentifier?.let {
+            CborCredentialSerializer.decode(descriptor, index, this, elementIdentifier, namespace)
+                ?.let { return it }
+                ?: Napier.v(
+                    "Falling back to defaults for namespace $namespace and elementIdentifier $elementIdentifier"
+                )
+        }
+
+        // These are the ones that map to different CBOR data types, the rest don't, so if it is not registered, we'll
+        // lose type information. No others must be added here, as they could consume data from the underlying bytes
+        catchingUnwrapped { return decodeStringElement(descriptor, index) }
+        catchingUnwrapped { return decodeLongElement(descriptor, index) }
+        catchingUnwrapped { return decodeDoubleElement(descriptor, index) }
+        catchingUnwrapped { return decodeBooleanElement(descriptor, index) }
+
+        throw IllegalArgumentException("Could not decode value at $index")
+    }
+
+    companion object {
+        private fun <T> buildElementValueSerializer(
+            namespace: String,
+            elementValue: T,
+            elementIdentifier: String
+        ) = when (elementValue) {
+            is String -> String.serializer()
+            is Int -> Int.serializer()
+            is Long -> Long.serializer()
+            is LocalDate -> LocalDate.serializer()
+            is Instant -> InstantStringSerializer
+            is Boolean -> Boolean.serializer()
+            is ByteArray -> ByteArraySerializer()
+            is Any -> CborCredentialSerializer.lookupSerializer(namespace, elementIdentifier)
+                ?: error("serializer not found for $elementIdentifier, with value $elementValue")
+
+            else -> error("serializer not found for $elementIdentifier, with value $elementValue")
+        }
+
+        fun serializeElementValue(
+            namespace: String,
+            elementValue: Any,
+            elementIdentifier: String
+        ): ByteArray {
+            val elementValueSerializer = buildElementValueSerializer(namespace, elementValue, elementIdentifier)
+            @Suppress("UNCHECKED_CAST")
+            return  coseCompliantSerializer.encodeToByteArray(elementValueSerializer as KSerializer<Any>, elementValue)
+        }
+    }
+}
+

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSignedList.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSignedList.kt
@@ -1,0 +1,5 @@
+package at.asitplus.iso
+
+data class ZkSignedList(
+    val entries: List<ZkSignedItem>,
+)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSignedListSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSignedListSerializer.kt
@@ -1,0 +1,77 @@
+package at.asitplus.iso
+
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SealedSerializationApi
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.SerialKind
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeCollection
+
+open class ZkSignedListSerializer(private val namespace: String) : KSerializer<ZkSignedList> {
+
+    @OptIn(SealedSerializationApi::class)
+    override val descriptor: SerialDescriptor = object : SerialDescriptor {
+        @ExperimentalSerializationApi
+        override val elementsCount: Int = 1
+
+        @ExperimentalSerializationApi
+        override val kind: SerialKind = StructureKind.LIST
+
+        @ExperimentalSerializationApi
+        override val serialName: String = "kotlin.collections.ArrayList"
+
+        @ExperimentalSerializationApi
+        @OptIn(ExperimentalUnsignedTypes::class)
+        override fun getElementAnnotations(index: Int): List<Annotation> = emptyList()
+
+        @ExperimentalSerializationApi
+        override fun getElementDescriptor(index: Int): SerialDescriptor =
+            ZkSignedItemSerializer(namespace).descriptor
+
+        @ExperimentalSerializationApi
+        override fun getElementIndex(name: String): Int = name.toInt()
+
+        @ExperimentalSerializationApi
+        override fun getElementName(index: Int): String = index.toString()
+
+        @ExperimentalSerializationApi
+        override fun isElementOptional(index: Int): Boolean = false
+    }
+
+    override fun serialize(encoder: Encoder, value: ZkSignedList) {
+        var index = 0
+        encoder.encodeCollection(descriptor, value.entries.size) {
+            value.entries.forEach { item ->
+                encodeSerializableElement(
+                    descriptor,
+                    index++,
+                    ZkSignedItemSerializer(namespace),
+                    item
+                )
+            }
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): ZkSignedList {
+        val entries = mutableListOf<ZkSignedItem>()
+        decoder.decodeStructure(descriptor) {
+            while (true) {
+                val index = decodeElementIndex(descriptor)
+                if (index == CompositeDecoder.DECODE_DONE) break
+                val item = decodeSerializableElement(
+                    descriptor,
+                    index,
+                    ZkSignedItemSerializer(namespace)
+                )
+                entries += item
+            }
+        }
+        return ZkSignedList(entries)
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystemParamRegistry.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystemParamRegistry.kt
@@ -1,0 +1,39 @@
+package at.asitplus.iso
+
+import kotlinx.serialization.KSerializer
+
+/**
+ * Each Zk system should register serializers for its param keys to allow [ZkSystemSpec.params] to be properly
+ * deserialized into a Map<String, Any>
+ */
+object ZkSystemParamRegistry {
+    private val serializerMap = mutableMapOf<String, Map<String, KSerializer<*>>>()
+
+    /**
+     * Registers param serializers for a specific Iso mDoc ZK proof system.
+     * If the same [systemName] is already registered, compatible serializers are merged
+     */
+    fun register(systemName: String, paramSerializers: Map<String, KSerializer<*>>) {
+        serializerMap[systemName]?.let { existing ->
+            if (!existing.isCompatibleWith(paramSerializers)) {
+                throw IllegalStateException(
+                    "Conflicting param serializers for ZK system '$systemName'. " +
+                            "Existing: ${existing.mapValues { it.value.descriptor.serialName }}, " +
+                            "New: ${paramSerializers.mapValues { it.value.descriptor.serialName }}"
+                )
+            }
+            serializerMap[systemName] = existing + paramSerializers
+            return
+
+        }
+
+        serializerMap[systemName] = paramSerializers
+    }
+
+    fun lookupSerializer(systemName: String, paramKey: String): KSerializer<*>?
+            = serializerMap[systemName]?.get(paramKey)
+
+}
+
+private fun Map<String, KSerializer<*>>.isCompatibleWith(otherSerializers: Map<String, KSerializer<*>>): Boolean =
+    this.keys.intersect(otherSerializers.keys).all { this[it] == otherSerializers[it] }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystemSpec.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystemSpec.kt
@@ -1,0 +1,17 @@
+package at.asitplus.iso
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ZkSystemSpec (
+    @SerialName("zkSystemId")
+    val zkSystemId: String,
+    @SerialName("system")
+    val system: String,
+
+    // TODO: Fix type! According to ISO/IEC 18013-5:2021 2nd edition, 10.2.7 "params" should be a Map<String, Any>
+    //  Implement a custom serializer.
+    @SerialName("params")
+    val params: Map<String, String>
+)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystemSpec.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystemSpec.kt
@@ -3,15 +3,20 @@ package at.asitplus.iso
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-@Serializable
+@Serializable(with = ZkSystemSpecSerializer::class)
 data class ZkSystemSpec (
-    @SerialName("zkSystemId")
+    @SerialName(PROP_ZK_SYSTEM_ID)
     val zkSystemId: String,
-    @SerialName("system")
+    @SerialName(PROP_SYSTEM)
     val system: String,
+    @SerialName(PROP_PARAMS)
+    val params: Map<String, Any>
+) {
 
-    // TODO: Fix type! According to ISO/IEC 18013-5:2021 2nd edition, 10.2.7 "params" should be a Map<String, Any>
-    //  Implement a custom serializer.
-    @SerialName("params")
-    val params: Map<String, String>
-)
+
+    companion object {
+        const val PROP_ZK_SYSTEM_ID = "zkSystemId"
+        const val PROP_SYSTEM = "system"
+        const val PROP_PARAMS = "params"
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystemSpecSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystemSpecSerializer.kt
@@ -1,0 +1,147 @@
+package at.asitplus.iso
+
+import at.asitplus.catchingUnwrapped
+import io.github.aakira.napier.Napier
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ByteArraySerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.StructureKind
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.decodeStructure
+import kotlinx.serialization.encoding.encodeStructure
+import kotlin.time.Instant
+
+object ZkSystemSpecSerializer : KSerializer<ZkSystemSpec> {
+    override val descriptor = buildClassSerialDescriptor("ZkSystemSpec") {
+        element(ZkSystemSpec.PROP_ZK_SYSTEM_ID, String.serializer().descriptor)
+        element(ZkSystemSpec.PROP_SYSTEM, String.serializer().descriptor)
+        element(ZkSystemSpec.PROP_PARAMS, ZkSystemParamsMapSerializer("dummy").descriptor)
+    }
+    override fun deserialize(decoder: Decoder): ZkSystemSpec {
+        var zkSystemId: String? = null
+        var system: String? = null
+        var params: Map<String, Any>? = null
+
+        decoder.decodeStructure(descriptor) {
+            while (true) {
+                val name = decodeStringElement(descriptor, 0)
+                val index = descriptor.getElementIndex(name)
+
+                when(name) {
+                    ZkSystemSpec.PROP_ZK_SYSTEM_ID -> zkSystemId = decodeStringElement(descriptor, index)
+                    ZkSystemSpec.PROP_SYSTEM -> system = decodeStringElement(descriptor, index)
+                    ZkSystemSpec.PROP_PARAMS -> {
+                        params = decodeSerializableElement(
+                            descriptor, index,
+                            ZkSystemParamsMapSerializer(system ?: "")
+                        )
+                    }
+                }
+
+                if (zkSystemId != null && system != null && params != null) break
+            }
+        }
+
+        return ZkSystemSpec(
+            zkSystemId = zkSystemId ?: error("Missing zkSystemId"),
+            system = system ?: error("Missing system"),
+            params = params ?: error("Missing params"),
+        )
+    }
+
+    override fun serialize(encoder: Encoder, value: ZkSystemSpec) {
+        ZkSystemParamsMapSerializer(value.system).let { paramsSerializer ->
+            encoder.encodeStructure(descriptor) {
+                encodeStringElement(descriptor, 0, value.zkSystemId)
+                encodeStringElement(descriptor, 1, value.system)
+                encodeSerializableElement(descriptor, 2, paramsSerializer, value.params)
+            }
+        }
+
+    }
+}
+
+internal class ZkSystemParamsMapSerializer(
+    private val systemName: String,
+): KSerializer<Map<String, Any>> {
+    @OptIn(InternalSerializationApi::class)
+    override val descriptor = buildSerialDescriptor("ZkSystemParams", StructureKind.MAP)
+
+
+    override fun serialize(encoder: Encoder, value: Map<String, Any>) {
+        ParamMapEntrySerializer().let {entrySerializer ->
+            MapSerializer(entrySerializer.keySerializer, entrySerializer.valueSerializer).serialize(encoder, value)
+        }
+    }
+    override fun deserialize(decoder: Decoder): Map<String, Any> {
+        return ParamMapEntrySerializer().let {entrySerializer ->
+            MapSerializer(entrySerializer.keySerializer, entrySerializer.valueSerializer).deserialize(decoder)
+        }
+    }
+
+    private inner class ParamMapEntrySerializer {
+        lateinit var currentKey: String
+
+        val keySerializer = object: KSerializer<String> {
+            override val descriptor = PrimitiveSerialDescriptor("ParamKey", PrimitiveKind.STRING)
+
+            override fun serialize(encoder: Encoder, value: String) {
+                currentKey = value
+                encoder.encodeString(value)
+            }
+
+            override fun deserialize(decoder: Decoder): String {
+                return decoder.decodeString().also {currentKey = it}
+            }
+        }
+
+        val valueSerializer = object : KSerializer<Any> {
+            override val descriptor = PrimitiveSerialDescriptor("ValueKey", PrimitiveKind.STRING)
+
+            override fun serialize(encoder: Encoder, value: Any) {
+                ZkSystemParamRegistry.lookupSerializer(systemName, currentKey)?.let { serializer ->
+                    @Suppress("UNCHECKED_CAST")
+                    encoder.encodeSerializableValue(serializer as KSerializer<Any>, value)
+                    return
+                }
+                Napier.d("param '$currentKey' not registered, using defaults")
+                when (value) {
+                    is String -> encoder.encodeString(value)
+                    is Int -> encoder.encodeInt(value)
+                    is Long -> encoder.encodeLong(value)
+                    is LocalDate -> encoder.encodeSerializableValue(LocalDate.serializer(), value)
+                    is Instant -> encoder.encodeSerializableValue(InstantStringSerializer, value)
+                    is Boolean -> encoder.encodeBoolean(value)
+                    is ByteArray -> encoder.encodeSerializableValue(ByteArraySerializer(), value)
+                    else -> error("Unexpected value: $value")
+                }
+
+
+            }
+
+            override fun deserialize(decoder: Decoder): Any {
+                ZkSystemParamRegistry.lookupSerializer(systemName, currentKey)?.let { serializer ->
+                    @Suppress("UNCHECKED_CAST")
+                    return decoder.decodeSerializableValue(serializer)
+                        ?: error("Null value for param '$currentKey' is not supported")
+                }
+                Napier.d("param '$currentKey' not registered, using fallbacks to")
+                catchingUnwrapped { return decoder.decodeString() }
+                catchingUnwrapped { return decoder.decodeLong() }
+                catchingUnwrapped { return decoder.decodeDouble() }
+                catchingUnwrapped { return decoder.decodeBoolean() }
+
+                error("Could not decode param '$currentKey' for system '$systemName'")
+            }
+
+        }
+    }
+}

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/iso/ZkSystemSpecSerializerTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/iso/ZkSystemSpecSerializerTest.kt
@@ -1,0 +1,280 @@
+package at.asitplus.iso
+
+import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.encodeToByteArray
+
+private const val TEST_SYSTEM_NAME = "test-system-v1"
+
+val ZkSystemSpecSerializerTest by testSuite {
+    
+    ZkSystemParamRegistry.register(
+        TEST_SYSTEM_NAME,
+        mapOf(
+            "string_param" to String.serializer(),
+            "int_param" to Int.serializer(),
+            "long_param" to Long.serializer(),
+            "bool_param" to Boolean.serializer(),
+        )
+    )
+
+    "serialize and deserialize ZkSystemSpec with string param" {
+        val input = ZkSystemSpec(
+            zkSystemId = "test-id-123",
+            system = TEST_SYSTEM_NAME,
+            params = mapOf("string_param" to "hello world")
+        )
+
+        val serialized = coseCompliantSerializer.encodeToByteArray(input)
+        val deserialized = coseCompliantSerializer.decodeFromByteArray<ZkSystemSpec>(serialized)
+
+        deserialized shouldBe input
+        deserialized.params["string_param"] shouldBe "hello world"
+        deserialized.params["string_param"].shouldBeInstanceOf<String>()
+    }
+
+    "serialize and deserialize ZkSystemSpec with int param" {
+        val input = ZkSystemSpec(
+            zkSystemId = "test-id-456",
+            system = TEST_SYSTEM_NAME,
+            params = mapOf("int_param" to 42)
+        )
+
+        val serialized = coseCompliantSerializer.encodeToByteArray(input)
+        val deserialized = coseCompliantSerializer.decodeFromByteArray<ZkSystemSpec>(serialized)
+
+        deserialized shouldBe input
+        deserialized.params["int_param"] shouldBe 42
+        deserialized.params["int_param"].shouldBeInstanceOf<Int>()
+    }
+
+    "serialize and deserialize ZkSystemSpec with long param" {
+        val input = ZkSystemSpec(
+            zkSystemId = "test-id-789",
+            system = TEST_SYSTEM_NAME,
+            params = mapOf("long_param" to 9876543210L)
+        )
+
+        val serialized = coseCompliantSerializer.encodeToByteArray(input)
+        val deserialized = coseCompliantSerializer.decodeFromByteArray<ZkSystemSpec>(serialized)
+
+        deserialized shouldBe input
+        deserialized.params["long_param"] shouldBe 9876543210L
+        deserialized.params["long_param"].shouldBeInstanceOf<Long>()
+    }
+
+    "serialize and deserialize ZkSystemSpec with boolean param" {
+        val input = ZkSystemSpec(
+            zkSystemId = "test-id-bool",
+            system = TEST_SYSTEM_NAME,
+            params = mapOf("bool_param" to true)
+        )
+
+        val serialized = coseCompliantSerializer.encodeToByteArray(input)
+        val deserialized = coseCompliantSerializer.decodeFromByteArray<ZkSystemSpec>(serialized)
+
+        deserialized shouldBe input
+        deserialized.params["bool_param"] shouldBe true
+        deserialized.params["bool_param"].shouldBeInstanceOf<Boolean>()
+    }
+
+    "serialize and deserialize ZkSystemSpec with multiple params" {
+        val input = ZkSystemSpec(
+            zkSystemId = "test-id-multi",
+            system = TEST_SYSTEM_NAME,
+            params = mapOf(
+                "string_param" to "test string",
+                "int_param" to 123,
+                "long_param" to 999999999999L,
+                "bool_param" to false
+            )
+        )
+
+        val serialized = coseCompliantSerializer.encodeToByteArray(input)
+        val deserialized = coseCompliantSerializer.decodeFromByteArray<ZkSystemSpec>(serialized)
+
+        deserialized shouldBe input
+        deserialized.params["string_param"] shouldBe "test string"
+        deserialized.params["int_param"] shouldBe 123
+        deserialized.params["long_param"] shouldBe 999999999999L
+        deserialized.params["bool_param"] shouldBe false
+    }
+
+    "serialize and deserialize ZkSystemSpec with empty params" {
+        val input = ZkSystemSpec(
+            zkSystemId = "test-id-empty",
+            system = TEST_SYSTEM_NAME,
+            params = emptyMap()
+        )
+
+        val serialized = coseCompliantSerializer.encodeToByteArray(input)
+        val deserialized = coseCompliantSerializer.decodeFromByteArray<ZkSystemSpec>(serialized)
+
+        deserialized shouldBe input
+        deserialized.params shouldBe emptyMap()
+    }
+
+    "serialize and deserialize ZkSystemSpec with unregistered system falls back to string" {
+        val unregisteredSystem = "unregistered-system"
+        val input = ZkSystemSpec(
+            zkSystemId = "test-id-unregistered",
+            system = unregisteredSystem,
+            params = mapOf("unknown_param" to "some value")
+        )
+
+        val serialized = coseCompliantSerializer.encodeToByteArray(input)
+        val deserialized = coseCompliantSerializer.decodeFromByteArray<ZkSystemSpec>(serialized)
+
+        deserialized.zkSystemId shouldBe input.zkSystemId
+        deserialized.system shouldBe input.system
+        // Fallback decodes as string
+        deserialized.params["unknown_param"] shouldBe "some value"
+    }
+
+    "getParam returns typed value" {
+        val spec = ZkSystemSpec(
+            zkSystemId = "test",
+            system = TEST_SYSTEM_NAME,
+            params = mapOf(
+                "string_param" to "hello",
+                "int_param" to 42
+            )
+        )
+
+        spec.getParam<String>("string_param") shouldBe "hello"
+        spec.getParam<Int>("int_param") shouldBe 42
+        spec.getParam<String>("nonexistent") shouldBe null
+        spec.getParam<Int>("string_param") shouldBe null // wrong type
+    }
+
+    "requireParam throws on missing param" {
+        val spec = ZkSystemSpec(
+            zkSystemId = "test",
+            system = TEST_SYSTEM_NAME,
+            params = mapOf("string_param" to "hello")
+        )
+
+        spec.requireParam<String>("string_param") shouldBe "hello"
+
+        shouldThrow<IllegalStateException> {
+            spec.requireParam<String>("nonexistent")
+        }
+    }
+}
+
+val ZkSystemParamRegistryTest by testSuite {
+
+    "register and lookup serializer" {
+        val testSystem = "registry-test-system-lookup"
+        ZkSystemParamRegistry.register(
+            testSystem,
+            mapOf("param1" to String.serializer())
+        )
+
+        ZkSystemParamRegistry.lookupSerializer(testSystem, "param1") shouldBe String.serializer()
+        ZkSystemParamRegistry.lookupSerializer(testSystem, "nonexistent") shouldBe null
+        ZkSystemParamRegistry.lookupSerializer("unknown-system", "param1") shouldBe null
+    }
+
+    "register multiple systems independently" {
+        val testSystem1 = "registry-test-system-1"
+        val testSystem2 = "registry-test-system-2"
+
+        ZkSystemParamRegistry.register(
+            testSystem1,
+            mapOf("param_a" to String.serializer())
+        )
+        ZkSystemParamRegistry.register(
+            testSystem2,
+            mapOf("param_b" to Int.serializer())
+        )
+
+        ZkSystemParamRegistry.lookupSerializer(testSystem1, "param_a") shouldBe String.serializer()
+        ZkSystemParamRegistry.lookupSerializer(testSystem1, "param_b") shouldBe null
+        ZkSystemParamRegistry.lookupSerializer(testSystem2, "param_b") shouldBe Int.serializer()
+        ZkSystemParamRegistry.lookupSerializer(testSystem2, "param_a") shouldBe null
+    }
+
+    "register same system twice with compatible serializers merges" {
+        val system = "merge-test-system"
+
+        ZkSystemParamRegistry.register(
+            system,
+            mapOf("param1" to String.serializer())
+        )
+        ZkSystemParamRegistry.register(
+            system,
+            mapOf("param2" to Int.serializer())
+        )
+
+        ZkSystemParamRegistry.lookupSerializer(system, "param1") shouldBe String.serializer()
+        ZkSystemParamRegistry.lookupSerializer(system, "param2") shouldBe Int.serializer()
+    }
+
+    "register same system with conflicting serializers throws" {
+        val system = "conflict-test-system"
+
+        ZkSystemParamRegistry.register(
+            system,
+            mapOf("param1" to String.serializer())
+        )
+
+        shouldThrow<IllegalStateException> {
+            ZkSystemParamRegistry.register(
+                system,
+                mapOf("param1" to Int.serializer()) // Conflict: same key, different type
+            )
+        }
+    }
+
+    "register same system with identical serializers is idempotent" {
+        val system = "idempotent-test-system"
+
+        ZkSystemParamRegistry.register(
+            system,
+            mapOf("param1" to String.serializer())
+        )
+        // Should not throw - same registration
+        ZkSystemParamRegistry.register(
+            system,
+            mapOf("param1" to String.serializer())
+        )
+
+        ZkSystemParamRegistry.lookupSerializer(system, "param1") shouldBe String.serializer()
+    }
+
+    "register same system with compatible serializers is idempotent" {
+        val system = "idempotent-test-system"
+
+        ZkSystemParamRegistry.register(
+            system,
+            mapOf(
+                "param1" to String.serializer(),
+                "param2" to Int.serializer(),
+            )
+        )
+        // Should not throw - same registration
+        ZkSystemParamRegistry.register(
+            system,
+            mapOf(
+                "param1" to String.serializer(),
+                "param3" to Long.serializer(),
+            )
+        )
+
+        ZkSystemParamRegistry.lookupSerializer(system, "param1") shouldBe String.serializer()
+        ZkSystemParamRegistry.lookupSerializer(system, "param2") shouldBe Int.serializer()
+        ZkSystemParamRegistry.lookupSerializer(system, "param3") shouldBe Long.serializer()
+    }
+}
+
+inline fun <reified T> ZkSystemSpec.getParam(key: String): T? = params[key] as? T
+
+inline fun<reified T> ZkSystemSpec.requireParam(key: String): T = getParam<T>(key)
+    ?: error("Required param '$key' not found or has wrong type in ZkSystemSpec")

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/ZkDocumentSerializationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/cbor/ZkDocumentSerializationTest.kt
@@ -1,0 +1,79 @@
+package at.asitplus.wallet.lib.cbor
+
+import at.asitplus.iso.ZkDocument
+import at.asitplus.iso.ZkDocumentData
+import at.asitplus.iso.ZkSignedItem
+import at.asitplus.iso.ZkSignedList
+import at.asitplus.openid.truncateToSeconds
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
+import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import com.benasher44.uuid.uuid4
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.equals.shouldBeEqual
+import kotlinx.serialization.encodeToByteArray
+import kotlin.time.Clock
+
+val ZkDocumentSerializationTest by testSuite {
+
+    "Serialize then Deserialize to get identity" {
+        val doc = ZkDocument(
+            ByteStringWrapper(
+                ZkDocumentData(
+                    docType = uuid4().toString(),
+                    zkSystemId = uuid4().toString(),
+                    timestamp = Clock.System.now().truncateToSeconds(),
+                    issuerSigned = mapOf(
+                        uuid4().toString() to ZkSignedList(
+                            mutableListOf(
+                                ZkSignedItem(
+                                    uuid4().toString(),
+                                    uuid4().toString()
+                                ),
+                                ZkSignedItem(
+                                    uuid4().toString(),
+                                    uuid4().toString()
+                                ),
+                                ZkSignedItem(
+                                    uuid4().toString(),
+                                    uuid4().toString()
+                                )
+                            )
+                        ),
+                        uuid4().toString() to ZkSignedList(
+                            mutableListOf(
+                                ZkSignedItem(
+                                    uuid4().toString(),
+                                    uuid4().toString()
+                                )
+                            )
+                        ),
+
+                        ),
+                    deviceSigned = mapOf(
+                        uuid4().toString() to ZkSignedList(
+                            mutableListOf(
+                                ZkSignedItem(
+                                    uuid4().toString(),
+                                    uuid4().toString()
+                                ),
+                                ZkSignedItem(
+                                    uuid4().toString(),
+                                    uuid4().toString()
+                                )
+                            )
+                        )
+                    ),
+                )
+            ),
+            proof = "test".encodeToByteArray()
+        )
+
+        val serialized = coseCompliantSerializer.encodeToByteArray(doc)
+        val deserialized = coseCompliantSerializer.decodeFromByteArray(ZkDocument.serializer(), serialized)
+
+        doc shouldBeEqual deserialized
+    }
+
+
+}


### PR DESCRIPTION
Basic data classes for mDoc revision (ISO18013-5 2nd edition)
- Contains the classes themselves
- Defines to allow ZKSystem backends to register custom serializers
- 1 simple testcase

Please review @nodh 