### PR TITLE
Add KDoc to OpenID public sealed classes

### DIFF
--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2Client.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/OAuth2Client.kt
@@ -152,6 +152,10 @@ class OAuth2Client(
             .also { stateToCodeStore.put(state, it) }
             .encodeToByteArray().sha256().encodeToString(Base64UrlStrict)
 
+    /**
+     * Authorization input used to request or refresh an OAuth2 access token.
+     * Use to indicate which grant or token exchange flow should be performed.
+     */
     sealed class AuthorizationForToken {
         /** Authorization code from an actual OAuth2 Authorization Server, or [SimpleAuthorizationService.authorize]. */
         data class Code(val code: String) : AuthorizationForToken()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/OAuth2Exception.kt
@@ -26,6 +26,10 @@ import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
 
+/**
+ * OAuth2/OIDC error representation for issuer and wallet flows.
+ * Use to model protocol errors and serialize them for responses.
+ */
 @Serializable
 sealed class OAuth2Exception(
     val error: String,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -9,6 +9,10 @@ import at.asitplus.wallet.lib.data.VerifiablePresentationParsed
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 import kotlinx.serialization.json.JsonObject
 
+/**
+ * Result of validating an OpenID authentication response, covering success and error cases.
+ * Use to inspect how a wallet response was parsed and whether presentation validation succeeded.
+ */
 sealed class AuthnResponseResult {
     /**
      * Error in parsing the URL or content itself, before verifying the contents of the OpenId response

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ClientIdScheme.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ClientIdScheme.kt
@@ -8,6 +8,10 @@ import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.pki.CertificateChain
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 
+/**
+ * Represents the OpenID client identifier scheme used to validate verifier identity.
+ * Use to select the client-id flavor (redirect URI, X.509, attestation) and derive IDs/URIs accordingly.
+ */
 sealed class ClientIdScheme(
     val scheme: OpenIdConstants.ClientIdScheme,
     val clientIdWithoutPrefix: String,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -188,6 +188,10 @@ class OpenId4VpVerifier(
         )
     }
 
+    /**
+     * Options for creating authorization requests (query, by value, or by reference).
+     * Use to control how the verifier delivers the request to the wallet.
+     */
     sealed class CreationOptions {
         /**
          * Creates authentication request with parameters encoded as URL query parameters to [walletUrl].

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/OAuth2RqesParameters.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/rqes/OAuth2RqesParameters.kt
@@ -11,6 +11,10 @@ import at.asitplus.signum.indispensable.josef.JsonWebToken
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Parameters used for remote qualified electronic signature (RQES) OAuth2 authorization.
+ * Use to group required and optional CSC fields when building authorization requests.
+ */
 sealed class OAuth2RqesParameters {
     data class CredentialRequired(
         /**

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/jws/JwsService.kt
@@ -407,6 +407,10 @@ fun interface DecryptJweFun {
     ): KmmResult<JweDecrypted<String>>
 }
 
+/**
+ * Decrypts JWE payloads using the recipient's key material.
+ * Use when handling encrypted messages targeted at the holder's key.
+ */
 class DecryptJwe(
     val keyMaterial: KeyMaterial,
 ) : DecryptJweFun {
@@ -429,6 +433,10 @@ class DecryptJwe(
 
 }
 
+/**
+ * Decrypts JWE payloads using a shared symmetric key.
+ * Use when the content is encrypted for a pre-shared secret between parties.
+ */
 class DecryptJweSymmetric(
     val keyMaterial: SymmetricKey<AuthCapability<out KeyType>, NonceTrait, out KeyType>,
 ) : DecryptJweFun {
@@ -481,6 +489,10 @@ fun interface VerifyJwsSignatureFun {
     ): KmmResult<Verifier.Success>
 }
 
+/**
+ * Verifies a JWS signature against a provided public key.
+ * Use when the verification key is already resolved out of band.
+ */
 class VerifyJwsSignature(
     val verifySignature: VerifySignatureFun = VerifySignature(),
 ) : VerifyJwsSignatureFun {
@@ -506,6 +518,10 @@ fun interface VerifyJwsSignatureWithKeyFun {
     ): KmmResult<Verifier.Success>
 }
 
+/**
+ * Verifies a JWS signature using a JSON Web Key.
+ * Use when the signer key is available in JWK form.
+ */
 class VerifyJwsSignatureWithKey(
     val verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
 ) : VerifyJwsSignatureWithKeyFun {
@@ -522,6 +538,10 @@ fun interface VerifyJwsSignatureWithCnfFun {
     ): Boolean
 }
 
+/**
+ * Verifies a JWS signature using the confirmation claim (cnf) key material.
+ * Use when tokens bind signatures to a subject key in the payload.
+ */
 class VerifyJwsSignatureWithCnf(
     val verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
     /**
@@ -612,6 +632,10 @@ fun interface VerifyJwsObjectFun {
     ): KmmResult<Verifier.Success>
 }
 
+/**
+ * Verifies a JWS by loading possible signing keys from headers or lookup callbacks.
+ * Use for validating incoming JWS objects in verification flows.
+ */
 class VerifyJwsObject(
     val verifyJwsSignature: VerifyJwsSignatureFun = VerifyJwsSignature(),
     /**


### PR DESCRIPTION
### Motivation
- Improve discoverability and comprehension of public OpenID/OAuth2 types by adding class-level KDoc and short usage guidance.
- Clarify intended usage and semantics for parsing/validation results, client-id schemes and token authorization inputs used in verifier and wallet flows.
- Make public API documentation more consistent with prior JWS/COSE/JWE helper KDoc so callers understand header/key lookup and verification/encryption flows.
- Reduce confusion about when to use specific sealed classes (e.g. presentation success variants, RQES parameters, creation options).

### Description
- Added class-level KDoc to `AuthnResponseResult`, `ClientIdScheme`, `OAuth2Exception`, and `OAuth2RqesParameters` to explain purpose and usage.
- Documented sealed classes `AuthorizationForToken` in `OAuth2Client` and `CreationOptions` in `OpenId4VpVerifier` to describe grant/token flows and request creation modes.
- Complemented earlier documentation additions for JOSE helpers by keeping only wording/placement edits and no behavioral changes to code.
- No functional code changes were introduced; changes are limited to comments/KDoc and formatting.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965128d45dc83309de4927b95a56c26)