### PR TITLE
Add tests for StatusList compression fallback

### DIFF
--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/extensions/StatusListCompressionTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/extensions/StatusListCompressionTest.kt
@@ -1,0 +1,88 @@
+package at.asitplus.wallet.lib.extensions
+
+import at.asitplus.testballoon.invoke
+import at.asitplus.testballoon.minus
+import at.asitplus.wallet.lib.ZlibService
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusList
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListView
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusBitSize
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random
+
+private class FakeZlibService(
+    private val compressResult: ByteArray? = null,
+    private val decompressResult: ByteArray? = byteArrayOf(0x5a, 0x6b),
+) : ZlibService {
+    override fun compress(input: ByteArray) = compressResult
+
+    override fun decompress(input: ByteArray) = decompressResult
+}
+
+val StatusListCompressionTest by testSuite {
+    "StatusList.toView" - {
+        "uses decompressed bytes when available" {
+            val compressed = Random.nextBytes(16)
+            val decompressed = Random.nextBytes(16)
+            val statusList = StatusList(
+                compressed = compressed,
+                statusBitSize = TokenStatusBitSize.ONE,
+                aggregationUri = null,
+            )
+
+            val view = statusList.toView(FakeZlibService(decompressResult = decompressed))
+
+            view.uncompressed shouldBe decompressed
+            view.statusBitSize shouldBe TokenStatusBitSize.ONE
+        }
+
+        "falls back to compressed bytes when decompression fails" {
+            val compressed = Random.nextBytes(16)
+            val statusList = StatusList(
+                compressed = compressed,
+                statusBitSize = TokenStatusBitSize.TWO,
+                aggregationUri = null,
+            )
+
+            val view = statusList.toView(FakeZlibService(decompressResult = null))
+
+            view.uncompressed shouldBe compressed
+            view.statusBitSize shouldBe TokenStatusBitSize.TWO
+        }
+    }
+
+    "StatusListView.toStatusList" - {
+        "uses compressed bytes when available" {
+            val uncompressed = Random.nextBytes(16)
+            val compressed = Random.nextBytes(16)
+            val view = StatusListView(
+                uncompressed = uncompressed,
+                statusBitSize = TokenStatusBitSize.FOUR,
+            )
+
+            val statusList = view.toStatusList(
+                zlibService = FakeZlibService(compressResult = compressed),
+                statusListAggregationUrl = null,
+            )
+
+            statusList.compressed shouldBe compressed
+            statusList.statusBitSize shouldBe TokenStatusBitSize.FOUR
+        }
+
+        "falls back to uncompressed bytes when compression fails" {
+            val uncompressed = Random.nextBytes(16)
+            val view = StatusListView(
+                uncompressed = uncompressed,
+                statusBitSize = TokenStatusBitSize.EIGHT,
+            )
+
+            val statusList = view.toStatusList(
+                zlibService = FakeZlibService(),
+                statusListAggregationUrl = null,
+            )
+
+            statusList.compressed shouldBe uncompressed
+            statusList.statusBitSize shouldBe TokenStatusBitSize.EIGHT
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure `StatusList` and `StatusListView` correctly use a `ZlibService` when available and fall back to raw bytes when compression/decompression returns `null`.
- Validate that byte arrays are preserved according to the expected fallback behavior.
- Verify that `statusBitSize` is preserved across conversions between `StatusList` and `StatusListView`.

### Description
- Add `vck/src/commonTest/kotlin/at/asitplus/wallet/lib/extensions/StatusListCompressionTest.kt` containing unit tests for compression/decompression fallbacks.
- Introduce a minimal `FakeZlibService` implementing `ZlibService` that can return `null` for `compress` to force fallback and return known bytes for `decompress` to verify use.
- Add tests asserting `StatusList.toView` uses `decompress` when available and falls back to raw bytes when it returns `null`.
- Add tests asserting `StatusListView.toStatusList` uses `compress` when available and falls back to raw bytes when it returns `null`, while checking `statusBitSize` preservation.

### Testing
- Added unit tests to the repository under `vck/src/commonTest/kotlin/at/asitplus/wallet/lib/extensions/StatusListCompressionTest.kt`.
- No automated test suite (`gradle test` or similar) was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69654440c6ac8330b521dd5bf5244d65)