### PR TITLE
Add tests for RemoteResourceRetrieverFunction behavior

### DIFF
--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RemoteResourceRetrieverFunctionTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RemoteResourceRetrieverFunctionTest.kt
@@ -1,0 +1,87 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.CredentialOffer
+import at.asitplus.openid.RequestParameters
+import at.asitplus.openid.RequestParametersFrom
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import at.asitplus.wallet.lib.RemoteResourceRetrieverInput
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.oidvci.WalletService
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.http.URLBuilder
+
+private data class FakeHttpResponse(
+    val body: String? = null,
+    val location: String? = null,
+)
+
+private class FakeRemoteResourceRetriever(
+    private val responses: Map<String, FakeHttpResponse>,
+) {
+    suspend fun invoke(input: RemoteResourceRetrieverInput): String? {
+        val response = responses[input.url] ?: return null
+        return response.body ?: response.location
+    }
+}
+
+val RemoteResourceRetrieverFunctionTest by testSuite {
+    val requestUri = "https://client.example.org/request"
+    val authnRequest = AuthenticationRequestParameters(
+        responseType = "vp_token",
+        clientId = "client.example.org",
+        redirectUrl = "https://client.example.org/callback",
+        scope = "openid",
+    )
+    val authnRequestSerialized = vckJsonSerializer.encodeToString(RequestParameters.serializer(), authnRequest)
+
+    "body response is used when present" {
+        val retriever = FakeRemoteResourceRetriever(
+            mapOf(
+                requestUri to FakeHttpResponse(
+                    body = authnRequestSerialized,
+                    location = "https://redirect.example.org/not-used",
+                )
+            )
+        )
+        val parser = RequestParser(remoteResourceRetriever = retriever::invoke)
+        val input = URLBuilder("https://example.com").apply {
+            parameters.append("request_uri", requestUri)
+        }.buildString()
+
+        parser.parseRequestParameters(input).getOrThrow().apply {
+            shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
+            shouldBeInstanceOf<RequestParametersFrom.Json<*>>()
+            jsonString shouldBe authnRequestSerialized
+            parameters shouldBe authnRequest
+        }
+    }
+
+    "location response is used when body missing" {
+        val offerUri = "https://issuer.example.org/credential-offer"
+        val offer = CredentialOffer(
+            credentialIssuer = "https://issuer.example.org",
+            configurationIds = setOf("example-credential"),
+        )
+        val offerJson = joseCompliantSerializer.encodeToString(offer)
+        val locationUrl = URLBuilder("https://redirect.example.org/offer").apply {
+            parameters.append("credential_offer", offerJson)
+        }.buildString()
+        val retriever = FakeRemoteResourceRetriever(
+            mapOf(
+                offerUri to FakeHttpResponse(
+                    location = locationUrl,
+                )
+            )
+        )
+        val walletService = WalletService(remoteResourceRetriever = retriever::invoke)
+        val input = URLBuilder("https://wallet.example.org").apply {
+            parameters.append("credential_offer_uri", offerUri)
+        }.buildString()
+
+        walletService.parseCredentialOffer(input).getOrThrow() shouldBe offer
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure implementations of `RemoteResourceRetrieverFunction` follow the documented behavior of returning the response body when present or the `Location` header when the server responds with a redirect.
- Cover higher-level consumers that rely on the retriever to fetch referenced resources during request parsing and credential offer retrieval.

### Description
- Add a new test file `vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/RemoteResourceRetrieverFunctionTest.kt` with unit tests exercising the retriever behavior.
- Implement `FakeRemoteResourceRetriever` and `FakeHttpResponse` in the test to simulate responses with a body or a `Location` value.
- Add a test asserting that a body payload is used by `RequestParser` when present (`request_uri` case) and a test asserting that a `Location` redirect is followed by `WalletService` when fetching a `credential_offer_uri`.
- Wire the fake retriever into `RequestParser` and `WalletService` instances inside the tests to validate the end-to-end behavior.

### Testing
- Added unit tests under `vck-openid/src/commonTest`, specifically two tests validating body-first and location-redirect behavior.
- No automated test runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69660c3e3448833094dc8f4c4d0663cf)