### PR TITLE
Add LibraryInitializer registration tests

### DIFF
--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/LibraryInitializerTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/LibraryInitializerTest.kt
@@ -1,0 +1,108 @@
+package at.asitplus.wallet.lib
+
+import at.asitplus.iso.IssuerSignedItem
+import at.asitplus.iso.IssuerSignedItemSerializer
+import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
+import at.asitplus.testballoon.invoke
+import at.asitplus.wallet.lib.data.AttributeIndex
+import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.CredentialSubject
+import at.asitplus.wallet.lib.data.JsonCredentialSerializer
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import com.benasher44.uuid.uuid4
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
+import kotlin.random.Random
+
+private data class TestCredentialScheme(
+    override val schemaUri: String,
+    override val vcType: String? = null,
+    override val sdJwtType: String? = null,
+    override val isoNamespace: String? = null,
+    override val isoDocType: String? = null,
+    override val claimNames: Collection<String> = emptyList(),
+    override val supportedRepresentations: Collection<ConstantIndex.CredentialRepresentation> = listOf(
+        ConstantIndex.CredentialRepresentation.PLAIN_JWT
+    ),
+) : ConstantIndex.CredentialScheme
+
+val LibraryInitializerTest by testSuite {
+    "registerExtensionLibrary registers schemes and serializers" {
+        @Serializable
+        @SerialName("TestCredentialSubject")
+        data class TestCredentialSubject(
+            override val id: String,
+            val subjectName: String,
+        ) : CredentialSubject()
+
+        val scheme = TestCredentialScheme(
+            schemaUri = "urn:test:${uuid4()}",
+            vcType = "TestCredential-${uuid4()}",
+        )
+        val serializersModule = SerializersModule {
+            polymorphic(CredentialSubject::class) {
+                subclass(TestCredentialSubject::class)
+            }
+        }
+
+        LibraryInitializer.registerExtensionLibrary(scheme, serializersModule)
+
+        AttributeIndex.resolveAttributeType(scheme.vcType!!) shouldBe scheme
+    }
+
+    "registerExtensionLibrary registers ISO encoders and serializers" {
+        @Serializable
+        data class MockIssuerSignedValue(val value: String)
+
+        val elementId = "element-${uuid4()}"
+        val isoNamespace = "namespace.${uuid4()}"
+        val scheme = TestCredentialScheme(
+            schemaUri = "urn:test:${uuid4()}",
+            vcType = "IsoCredential-${uuid4()}",
+            isoNamespace = isoNamespace,
+            isoDocType = "doctype.${uuid4()}",
+            supportedRepresentations = listOf(ConstantIndex.CredentialRepresentation.ISO_MDOC),
+        )
+
+        val jsonValueEncoder: JsonValueEncoder = { value ->
+            when (value) {
+                is MockIssuerSignedValue -> vckJsonSerializer.encodeToJsonElement(value)
+                else -> null
+            }
+        }
+        val itemValueSerializerMap = mapOf(
+            elementId to MockIssuerSignedValue.serializer()
+        )
+
+        LibraryInitializer.registerExtensionLibrary(
+            scheme,
+            serializersModule = null,
+            jsonValueEncoder = jsonValueEncoder,
+            itemValueSerializerMap = itemValueSerializerMap,
+        )
+
+        JsonCredentialSerializer.encode(MockIssuerSignedValue("encoded")) shouldBe
+            vckJsonSerializer.encodeToJsonElement(MockIssuerSignedValue("encoded"))
+
+        val item = IssuerSignedItem(
+            digestId = 1u,
+            random = Random.nextBytes(16),
+            elementIdentifier = elementId,
+            elementValue = MockIssuerSignedValue("round-trip"),
+        )
+        val encodedItem =
+            coseCompliantSerializer.encodeToByteArray(IssuerSignedItemSerializer(isoNamespace, elementId), item)
+        val decodedItem = coseCompliantSerializer.decodeFromByteArray(
+            IssuerSignedItemSerializer(isoNamespace, elementId),
+            encodedItem
+        )
+
+        decodedItem shouldBe item
+    }
+}


### PR DESCRIPTION
### Motivation

- Verify that `LibraryInitializer.registerExtensionLibrary` correctly registers credential schemes and polymorphic serializers for `CredentialSubject` subtypes.
- Ensure ISO-MDOC registration overload wires `jsonValueEncoder` and `CborCredentialSerializer` so values can be encoded/decoded in `IssuerSignedItem` instances.

### Description

- Add `src/commonTest/kotlin/at/asitplus/wallet/lib/LibraryInitializerTest.kt` containing tests that register a dummy `CredentialScheme` and a `SerializersModule` with a test `CredentialSubject` subclass.
- Create a `TestCredentialScheme` implementation and validate registration via `AttributeIndex.resolveAttributeType(...)` for the `vcType` lookup.
- Add an ISO-focused test that provides a `jsonValueEncoder` and `itemValueSerializerMap`, asserts `JsonCredentialSerializer.encode(...)` behavior, and performs a CBOR round-trip using `IssuerSignedItemSerializer` and `coseCompliantSerializer`.

### Testing

- No automated tests were executed as part of this change.
- A new unit test file `LibraryInitializerTest.kt` was added that exercises `LibraryInitializer.registerExtensionLibrary` and ISO encoder/serializer round-trip behavior, but it has not been run in CI for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6965443c538083309964bbcf96da89b6)