### PR TITLE
Add unit tests for HttpResponse extensions (onFailure/onSuccess/dpopNonce)

### DIFF
--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/ExtensionsTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/ExtensionsTest.kt
@@ -1,0 +1,87 @@
+package at.asitplus.wallet.lib.ktor.openid
+
+import at.asitplus.openid.OpenIdConstants.Errors.USE_DPOP_NONCE
+import at.asitplus.wallet.lib.data.vckJsonSerializer
+import at.asitplus.wallet.lib.oidvci.OAuth2Error
+import com.benasher44.uuid.uuid4
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+
+val ExtensionsTest by testSuite {
+
+    suspend fun buildResponse(
+        status: HttpStatusCode,
+        body: String,
+        headers: Headers = headersOf(),
+    ): io.ktor.client.statement.HttpResponse {
+        val client = HttpClient(MockEngine { respond(body, status = status, headers = headers) }) {
+            install(ContentNegotiation) {
+                json(vckJsonSerializer)
+            }
+        }
+        return try {
+            client.get("https://example.com")
+        } finally {
+            client.close()
+        }
+    }
+
+    test("onFailure returns failure with OAuth2Error") {
+        val expectedError = OAuth2Error(error = "invalid_client", errorDescription = "Nope")
+
+        buildResponse(
+            status = HttpStatusCode.BadRequest,
+            body = vckJsonSerializer.encodeToString(OAuth2Error.serializer(), expectedError),
+            headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+        ).onFailure<OAuth2Error?> { _ -> this }
+            .shouldBeInstanceOf<IntermediateResult.Failure<OAuth2Error?>>().apply {
+                this.result shouldBe expectedError
+            }
+    }
+
+    test("onSuccess unwraps response body") {
+        val expectedBody = uuid4().toString()
+
+        buildResponse(
+            status = HttpStatusCode.OK,
+            body = expectedBody,
+            headers = headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString())
+        ).onFailure<String> { "failure" }
+            .onSuccess<String, String> { this }.apply {
+                this shouldBe expectedBody
+            }
+    }
+
+    test("dpopNonce extracts nonce from error or WWW-Authenticate") {
+        val authServerNonce = uuid4().toString()
+        val authServerResponse = buildResponse(
+            status = HttpStatusCode.BadRequest,
+            body = vckJsonSerializer.encodeToString(OAuth2Error.serializer(), OAuth2Error(error = USE_DPOP_NONCE)),
+            headers = headers {
+                append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                append(HttpHeaders.DPoPNonce, authServerNonce)
+            }
+        )
+
+        OAuth2Error(error = USE_DPOP_NONCE).dpopNonce(authServerResponse) shouldBe authServerNonce
+
+        val resourceServerNonce = uuid4().toString()
+        val resourceServerResponse = buildResponse(
+            status = HttpStatusCode.Unauthorized,
+            body = "",
+            headers = headers {
+                append(HttpHeaders.WWWAuthenticate, "Bearer error=\"$USE_DPOP_NONCE\"")
+                append(HttpHeaders.DPoPNonce, resourceServerNonce)
+            }
+        )
+
+        null.dpopNonce(resourceServerResponse) shouldBe resourceServerNonce
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure the HttpResponse handling helpers in `Extensions.kt` behave correctly for error and success cases and when extracting DPoP nonces.
- Cover both authorization-server-provided and resource-server-provided DPoP nonce scenarios per RFC 9449.

### Description

- Add new test file `vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/ExtensionsTest.kt` implementing tests with `MockEngine`/`HttpClient` to simulate responses.
- Create tests that return a non-2xx response with an `OAuth2Error` body and `DPoP-Nonce` header and a 2xx response with a plain body to validate behavior.
- Assert that `HttpResponse.onFailure` yields `IntermediateResult.Failure` exposing the `OAuth2Error`, that `IntermediateResult.onSuccess` unwraps the response body to the expected type, and that `dpopNonce(...)` extracts the nonce from either `WWW-Authenticate` or the `DPoP-Nonce` header.
- Adjust the test helper `buildResponse` to return an `HttpResponse` and to explicitly close the `HttpClient` in a `finally` block.

### Testing

- Added three unit tests: `onFailure returns failure with OAuth2Error`, `onSuccess unwraps response body`, and `dpopNonce extracts nonce from error or WWW-Authenticate` (all in `ExtensionsTest.kt`).
- Tests use `MockEngine` to simulate the HTTP responses and run inside the existing test framework (`testSuite`).
- No automated test run was executed as part of this change (tests were added but not executed in CI here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696544498d7c8330ac3c453c3087c320)