### PR TITLE
Fix VP token array building

### DIFF
--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
@@ -113,7 +113,7 @@ sealed interface PresentationResponseParameters {
         private fun List<JsonPrimitive>.singleOrArray() = if (size == 1) {
             this[0]
         } else buildJsonArray {
-            forEach { add(it) }
+            this@singleOrArray.forEach(::add)
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the VP token array builder iterates over the existing list when multiple presentations are returned

## Testing
- ./gradlew :vck:check *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" while downloading Kotlin/Native dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912fa3f16e48330a044da54a0ec364b)