### PR TITLE
DCQL : Handle jwt_vc_json specific DCQL meta type_values + constraints validation

### DIFF
--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsSerializer.kt
@@ -1,5 +1,17 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsSerializer.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsSerializer.kt
@@ -15,6 +15,7 @@ object DCQLCredentialMetadataAndValidityConstraintsSerializer :
             parameters.isEmpty() -> DCQLEmptyCredentialMetadataAndValidityConstraints.serializer()
             DCQLSdJwtCredentialMetadataAndValidityConstraints.SerialNames.VCT_VALUES in parameters -> DCQLSdJwtCredentialMetadataAndValidityConstraints.serializer()
             DCQLIsoMdocCredentialMetadataAndValidityConstraints.SerialNames.DOCTYPE_VALUE in parameters -> DCQLIsoMdocCredentialMetadataAndValidityConstraints.serializer()
+            DCQLJwtVcCredentialMetadataAndValidityConstraints.SerialNames.TYPE_VALUES in parameters -> DCQLJwtVcCredentialMetadataAndValidityConstraints.serializer()
             else -> throw IllegalArgumentException("Deserializer not found")
         }
     }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
@@ -7,7 +7,6 @@ import at.asitplus.data.NonEmptyList.Companion.nonEmptyListOf
 import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.openid.CredentialFormatEnum
 import io.github.aakira.napier.Napier
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable(with = DCQLCredentialQuerySerializer::class)
@@ -139,6 +138,7 @@ sealed interface DCQLCredentialQuery {
         credentialFormatExtractor: (Credential) -> CredentialFormatEnum,
         mdocCredentialDoctypeExtractor: (Credential) -> String,
         sdJwtCredentialTypeExtractor: (Credential) -> String,
+        jwtVcCredentialTypeExtractor: (Credential) -> List<String>,
         credentialClaimStructureExtractor: (Credential) -> DCQLCredentialClaimStructure,
     ): KmmResult<DCQLCredentialQueryMatchingResult> = catching {
         if (credentialFormatExtractor(credential) != format) {
@@ -151,6 +151,7 @@ sealed interface DCQLCredentialQuery {
             credentialMetadataAndValidityConstraints = meta,
             mdocCredentialDoctypeExtractor = mdocCredentialDoctypeExtractor,
             sdJwtCredentialTypeExtractor = sdJwtCredentialTypeExtractor,
+            jwtVcCredentialTypeExtractor = jwtVcCredentialTypeExtractor
         ).getOrThrow()
 
         val claimQueries = claims
@@ -192,6 +193,7 @@ sealed interface DCQLCredentialQuery {
             credentialMetadataAndValidityConstraints: DCQLCredentialMetadataAndValidityConstraints?,
             mdocCredentialDoctypeExtractor: (Credential) -> String,
             sdJwtCredentialTypeExtractor: (Credential) -> String,
+            jwtVcCredentialTypeExtractor: (Credential) -> List<String>,
         ): KmmResult<Unit> = catching {
             when (credentialFormatIdentifier) {
                 CredentialFormatEnum.MSO_MDOC -> {
@@ -205,6 +207,13 @@ sealed interface DCQLCredentialQuery {
                     credentialMetadataAndValidityConstraints as DCQLSdJwtCredentialMetadataAndValidityConstraints
                     credentialMetadataAndValidityConstraints.validate(
                         sdJwtCredentialTypeExtractor(credential)
+                    ).getOrThrow()
+                }
+
+                CredentialFormatEnum.JWT_VC -> {
+                    credentialMetadataAndValidityConstraints as DCQLJwtVcCredentialMetadataAndValidityConstraints
+                    credentialMetadataAndValidityConstraints.validate(
+                        jwtVcCredentialTypeExtractor(credential)
                     ).getOrThrow()
                 }
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
@@ -1,5 +1,17 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.data.NonEmptyList

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuerySerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuerySerializer.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuerySerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuerySerializer.kt
@@ -1,5 +1,17 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.openid.CredentialFormatEnum
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuerySerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuerySerializer.kt
@@ -15,9 +15,10 @@ object DCQLCredentialQuerySerializer :
             parameters[DCQLCredentialQuery.SerialNames.FORMAT]?.jsonPrimitive?.content?.let {
                 CredentialFormatEnum.parse(it)
             }
-        return when {
-            credentialFormatIdentifier == CredentialFormatEnum.MSO_MDOC -> DCQLIsoMdocCredentialQuery.serializer()
-            credentialFormatIdentifier == CredentialFormatEnum.DC_SD_JWT -> DCQLSdJwtCredentialQuery.serializer()
+        return when (credentialFormatIdentifier) {
+            CredentialFormatEnum.MSO_MDOC -> DCQLIsoMdocCredentialQuery.serializer()
+            CredentialFormatEnum.DC_SD_JWT -> DCQLSdJwtCredentialQuery.serializer()
+            CredentialFormatEnum.JWT_VC -> DCQLJwtVcCredentialQuery.serializer()
             else -> DCQLCredentialQueryInstance.serializer()
         }
     }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt
@@ -1,0 +1,48 @@
+package at.asitplus.openid.dcql
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class DCQLJwtVcCredentialMetadataAndValidityConstraints(
+    /**
+     * OID4VP 1.0: type_values: REQUIRED. A non-empty array of string arrays.
+     * The value of each element in the type_values array is a non-empty array specifying the
+     * fully expanded types (IRIs) that the Verifier accepts in a Presentation, after applying
+     * the @context to the Verifiable Credential. If a type value in a Verifiable Credential is not
+     * defined in any @context, it remains unchanged, i.e., remains a relative IRI after JSON-LD
+     * processing. For this reason, JSON-LD processing MAY be skipped in such cases and the
+     * relative IRI is considered to be the fully expanded type, as applying the @context would not
+     * alter the value. Implementations MAY use alternative mechanisms to obtain the fully expanded
+     * types, as long as the results are equivalent to those produced by JSON-LD processing.
+     * Each of the top-level arrays specifies one alternative to match the fully expanded type
+     * values of the Verifiable Credential against. Each inner array specifies a set of fully
+     * expanded types that MUST be present in the fully expanded types in the type property of
+     * the Verifiable Credential, regardless of order or the presence of additional types.
+     */
+    @SerialName(SerialNames.TYPE_VALUES) val typeValues: List<List<String>>
+) : DCQLCredentialMetadataAndValidityConstraints {
+    object SerialNames {
+        const val TYPE_VALUES = "type_values"
+    }
+
+    fun validate(actualCredentialTypes: List<String>?): KmmResult<Unit> = catching {
+        var valid = false
+        if (actualCredentialTypes != null) {
+            for (typeValue in typeValues ){
+                if ( actualCredentialTypes.containsAll(typeValue) ) {
+                    valid = true
+                }
+            }
+        }
+
+        when (valid){
+            true -> Unit
+            false -> throw IllegalArgumentException("Incompatible JWT-VC document type")
+        }
+
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt
@@ -40,7 +40,7 @@ data class DCQLJwtVcCredentialMetadataAndValidityConstraints(
 
     fun validate(actualCredentialTypes: List<String>?): KmmResult<Unit> = catching {
         var valid = false
-        if (actualCredentialTypes != null) {
+        if (!actualCredentialTypes.isNullOrEmpty()) {
             for (typeValue in typeValues) {
                 if (actualCredentialTypes.containsAll(typeValue)) {
                     valid = true

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt
@@ -1,5 +1,14 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import kotlinx.serialization.SerialName

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) Orange Business
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt
@@ -41,14 +41,14 @@ data class DCQLJwtVcCredentialMetadataAndValidityConstraints(
     fun validate(actualCredentialTypes: List<String>?): KmmResult<Unit> = catching {
         var valid = false
         if (actualCredentialTypes != null) {
-            for (typeValue in typeValues ){
-                if ( actualCredentialTypes.containsAll(typeValue) ) {
+            for (typeValue in typeValues) {
+                if (actualCredentialTypes.containsAll(typeValue)) {
                     valid = true
                 }
             }
         }
 
-        when (valid){
+        when (valid) {
             true -> Unit
             false -> throw IllegalArgumentException("Incompatible JWT-VC document type")
         }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQuery.kt
@@ -1,0 +1,45 @@
+package at.asitplus.openid.dcql
+
+import at.asitplus.data.NonEmptyList
+import at.asitplus.openid.CredentialFormatEnum
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ *  6.1. Credential Query
+ *
+ * A Credential Query is an object representing a request for a presentation of one Credential.
+ * Note that multiple Credential Queries in a request MAY request a presentation of the same Credential.
+ */
+@Serializable
+data class DCQLJwtVcCredentialQuery(
+    @SerialName(DCQLCredentialQuery.SerialNames.ID)
+    override val id: DCQLCredentialQueryIdentifier,
+    @SerialName(DCQLCredentialQuery.SerialNames.FORMAT)
+    override val format: CredentialFormatEnum,
+    @SerialName(DCQLCredentialQuery.SerialNames.META)
+    override val meta: DCQLJwtVcCredentialMetadataAndValidityConstraints,
+    @SerialName(DCQLCredentialQuery.SerialNames.CLAIMS)
+    override val claims: DCQLClaimsQueryList<DCQLJsonClaimsQuery>? = null,
+    @SerialName(DCQLCredentialQuery.SerialNames.CLAIM_SETS)
+    override val claimSets: NonEmptyList<List<DCQLClaimsQueryIdentifier>>? = null,
+    @SerialName(DCQLCredentialQuery.SerialNames.MULTIPLE)
+    override val multiple: Boolean? = false,
+    @SerialName(DCQLCredentialQuery.SerialNames.TRUSTED_AUTHORITIES)
+    override val trustedAuthorities: List<String>? = null,
+    @SerialName(DCQLCredentialQuery.SerialNames.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING)
+    override val requireCryptographicHolderBinding: Boolean? = true,
+) : DCQLCredentialQuery {
+    init {
+        validate(this)
+    }
+
+    companion object Companion {
+        fun validate(query: DCQLJwtVcCredentialQuery) = query.run {
+            DCQLCredentialQuery.validate(this)
+            if (format != CredentialFormatEnum.JWT_VC) {
+                throw IllegalArgumentException("Value has an invalid format identifier in this context.")
+            }
+        }
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQuery.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) Orange Business
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQuery.kt
@@ -1,5 +1,14 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.data.NonEmptyList
 import at.asitplus.openid.CredentialFormatEnum
 import kotlinx.serialization.SerialName

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
@@ -60,6 +60,7 @@ data class DCQLQuery(
         credentialFormatExtractor: (Credential) -> CredentialFormatEnum,
         mdocCredentialDoctypeExtractor: (Credential) -> String,
         sdJwtCredentialTypeExtractor: (Credential) -> String,
+        jwtVcCredentialTypeExtractor: (Credential) -> List<String>,
         credentialClaimStructureExtractor: (Credential) -> DCQLCredentialClaimStructure,
     ): KmmResult<DCQLQueryResult<Credential>> = Procedures.executeQuery(
         credentials = credentials,
@@ -68,7 +69,8 @@ data class DCQLQuery(
         credentialFormatExtractor = credentialFormatExtractor,
         mdocCredentialDoctypeExtractor = mdocCredentialDoctypeExtractor,
         sdJwtCredentialTypeExtractor = sdJwtCredentialTypeExtractor,
-        credentialClaimStructureExtractor = credentialClaimStructureExtractor,
+        jwtVcCredentialTypeExtractor = jwtVcCredentialTypeExtractor,
+        credentialClaimStructureExtractor = credentialClaimStructureExtractor
     )
 
     object Procedures {
@@ -96,6 +98,7 @@ data class DCQLQuery(
             credentialFormatExtractor: (Credential) -> CredentialFormatEnum,
             mdocCredentialDoctypeExtractor: (Credential) -> String,
             sdJwtCredentialTypeExtractor: (Credential) -> String,
+            jwtVcCredentialTypeExtractor: (Credential) -> List<String>,
             credentialClaimStructureExtractor: (Credential) -> DCQLCredentialClaimStructure,
         ): KmmResult<DCQLQueryResult<Credential>> = catching {
             val credentialQueryMatches = findCredentialQueryMatches(
@@ -104,7 +107,8 @@ data class DCQLQuery(
                 credentialFormatExtractor = credentialFormatExtractor,
                 mdocCredentialDoctypeExtractor = mdocCredentialDoctypeExtractor,
                 sdJwtCredentialTypeExtractor = sdJwtCredentialTypeExtractor,
-                credentialClaimStructureExtractor = credentialClaimStructureExtractor,
+                jwtVcCredentialTypeExtractor = jwtVcCredentialTypeExtractor,
+                credentialClaimStructureExtractor = credentialClaimStructureExtractor
             )
 
             val satisfiableCredentialSetQueryOptions = findSatisfactoryCredentialSetQueryOptions(
@@ -126,6 +130,7 @@ data class DCQLQuery(
             credentialFormatExtractor: (Credential) -> CredentialFormatEnum,
             mdocCredentialDoctypeExtractor: (Credential) -> String,
             sdJwtCredentialTypeExtractor: (Credential) -> String,
+            jwtVcCredentialTypeExtractor: (Credential) -> List<String>,
             credentialClaimStructureExtractor: (Credential) -> DCQLCredentialClaimStructure,
         ): Map<DCQLCredentialQueryIdentifier, List<DCQLCredentialSubmissionOption<Credential>>> {
             return credentialQueries.associate { credentialQuery ->
@@ -135,7 +140,8 @@ data class DCQLQuery(
                         credentialFormatExtractor = credentialFormatExtractor,
                         mdocCredentialDoctypeExtractor = mdocCredentialDoctypeExtractor,
                         sdJwtCredentialTypeExtractor = sdJwtCredentialTypeExtractor,
-                        credentialClaimStructureExtractor = credentialClaimStructureExtractor,
+                        jwtVcCredentialTypeExtractor = jwtVcCredentialTypeExtractor,
+                        credentialClaimStructureExtractor = credentialClaimStructureExtractor
                     ).getOrNull()?.let {
                         DCQLCredentialSubmissionOption(
                             credential = credential,

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
@@ -1,5 +1,17 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.data.NonEmptyList

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsTest.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsTest.kt
@@ -1,5 +1,17 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.minus
 import de.infix.testBalloon.framework.core.testSuite

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsTest.kt
@@ -25,7 +25,7 @@ val DCQLCredentialMetadataAndValidityConstraintsTest by testSuite {
              DCQLIsoMdocCredentialMetadataAndValidityConstraints.SerialNames.DOCTYPE_VALUE shouldBeIn serialized.jsonObject.keys
          }
          "sd-jwt" {
-             val value = at.asitplus.openid.dcql.DCQLSdJwtCredentialMetadataAndValidityConstraints(
+             val value = DCQLSdJwtCredentialMetadataAndValidityConstraints(
                  vctValues = listOf("test")
              )
 
@@ -35,6 +35,18 @@ val DCQLCredentialMetadataAndValidityConstraintsTest by testSuite {
              serialized.jsonObject.entries shouldHaveSize 1
 
              DCQLSdJwtCredentialMetadataAndValidityConstraints.SerialNames.VCT_VALUES shouldBeIn serialized.jsonObject.keys
+         }
+         "jwt-vc" {
+             val value = DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                 typeValues = listOf(listOf("test"))
+             )
+
+             val base: DCQLCredentialMetadataAndValidityConstraints = value
+             val serialized = Json.encodeToJsonElement(base)
+             serialized shouldBe Json.encodeToJsonElement(value)
+             serialized.jsonObject.entries shouldHaveSize 1
+
+             DCQLJwtVcCredentialMetadataAndValidityConstraints.SerialNames.TYPE_VALUES shouldBeIn serialized.jsonObject.keys
          }
      }
 }

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocCredentialMetadataAndValidityConstraintsTest.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocCredentialMetadataAndValidityConstraintsTest.kt
@@ -1,5 +1,17 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.minus

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocCredentialMetadataAndValidityConstraintsTest.kt
@@ -41,6 +41,9 @@ val DCQLIsoMdocCredentialMetadataAndValidityConstraintsTest by testSuite {
                 mdocCredentialDoctypeExtractor = { "dummy document type" },
                 sdJwtCredentialTypeExtractor = {
                     throw IllegalArgumentException("SD-JWT credential type cannot be extracted")
+                },
+                jwtVcCredentialTypeExtractor = {
+                    throw IllegalArgumentException("JWT-VC credential type cannot be extracted")
                 }
             ).getOrThrow()
         }
@@ -59,7 +62,10 @@ val DCQLIsoMdocCredentialMetadataAndValidityConstraintsTest by testSuite {
                 mdocCredentialDoctypeExtractor = { "DIFFERENT dummy document type" },
                 sdJwtCredentialTypeExtractor = {
                     throw IllegalArgumentException("SD-JWT credential type cannot be extracted")
-                }
+                },
+                jwtVcCredentialTypeExtractor = {
+                    throw IllegalArgumentException("JWT-VC credential type cannot be extracted")
+                },
             ).getOrThrow()
         }
     }

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraintsTest.kt
@@ -1,5 +1,14 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.minus

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraintsTest.kt
@@ -1,0 +1,72 @@
+package at.asitplus.openid.dcql
+
+import at.asitplus.openid.CredentialFormatEnum
+import at.asitplus.testballoon.invoke
+import at.asitplus.testballoon.minus
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+
+val DCQLJwtVcCredentialMetadataAndValidityConstraintsTest by testSuite {
+    "specification" - {
+        "serial names" {
+            DCQLJwtVcCredentialMetadataAndValidityConstraints.SerialNames.TYPE_VALUES shouldBe "type_values"
+        }
+    }
+    "instance serialization" {
+        val serialized = Json.encodeToJsonElement(
+            DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                typeValues = listOf(listOf("dummy document type"))
+            )
+        ).jsonObject
+        DCQLJwtVcCredentialMetadataAndValidityConstraints.SerialNames.TYPE_VALUES shouldBeIn serialized.keys
+    }
+    "constraints query" {
+        shouldNotThrowAny {
+            DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                typeValues = listOf(listOf("dummy document type")),
+            ).validate(listOf("dummy document type")).getOrThrow()
+
+            DCQLCredentialQuery.Procedures.validateCredentialMetadataAndValidityConstraints(
+                credential = "",
+                credentialFormatIdentifier = CredentialFormatEnum.JWT_VC,
+                credentialMetadataAndValidityConstraints = DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                    typeValues = listOf(listOf("dummy document type")),
+                ),
+                mdocCredentialDoctypeExtractor = {
+                    throw IllegalArgumentException("MDOC credential type cannot be extracted")
+                },
+                sdJwtCredentialTypeExtractor = {
+                    throw IllegalArgumentException("JWT-VC credential type cannot be extracted")
+                },
+                jwtVcCredentialTypeExtractor = { listOf("dummy document type") }
+            ).getOrThrow()
+        }
+        shouldThrowAny {
+            DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                typeValues = listOf(listOf("dummy document type")),
+            ).validate(listOf("DIFFERENT dummy document type")).getOrThrow()
+        }
+        shouldThrowAny {
+            DCQLCredentialQuery.Procedures.validateCredentialMetadataAndValidityConstraints(
+                credential = "",
+                credentialFormatIdentifier = CredentialFormatEnum.JWT_VC,
+                credentialMetadataAndValidityConstraints = DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                    typeValues = listOf(listOf("dummy document type")),
+                ),
+                mdocCredentialDoctypeExtractor = {
+                    throw IllegalArgumentException("MDOC credential type cannot be extracted")
+                },
+                sdJwtCredentialTypeExtractor = {
+                    throw IllegalArgumentException("SD-JWT credential type cannot be extracted")
+                },
+                jwtVcCredentialTypeExtractor = { listOf("DIFFERENT dummy document type") }
+            ).getOrThrow()
+        }
+    }
+}

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraintsTest.kt
@@ -14,6 +14,7 @@ import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.minus
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.collections.shouldBeIn
 import io.kotest.matchers.shouldBe
@@ -34,6 +35,18 @@ val DCQLJwtVcCredentialMetadataAndValidityConstraintsTest by testSuite {
             )
         ).jsonObject
         DCQLJwtVcCredentialMetadataAndValidityConstraints.SerialNames.TYPE_VALUES shouldBeIn serialized.keys
+    }
+    "handle null or empty " {
+        shouldThrow<IllegalArgumentException> {
+            DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                typeValues = listOf(emptyList()),
+            ).validate(emptyList()).getOrThrow()
+        }
+        shouldThrow<IllegalArgumentException> {
+            DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                typeValues = listOf(listOf("dummy document type")),
+            ).validate(null).getOrThrow()
+        }
     }
     "constraints query" {
         shouldNotThrowAny {

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraintsTest.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) Orange Business
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQueryTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQueryTest.kt
@@ -1,5 +1,14 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.testballoon.invoke

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQueryTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQueryTest.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) Orange Business
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQueryTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQueryTest.kt
@@ -1,0 +1,56 @@
+package at.asitplus.openid.dcql
+
+import at.asitplus.openid.CredentialFormatEnum
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
+import at.asitplus.testballoon.invoke
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.matchers.shouldBe
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlin.random.Random
+
+val DCQLJwtVcCredentialQueryTest by testSuite {
+    "serialization" {
+        val value = DCQLJwtVcCredentialQuery(
+            id = DCQLCredentialQueryIdentifier(
+                Random.nextBytes(32).encodeToString(Base64UrlStrict)
+            ),
+            format = CredentialFormatEnum.JWT_VC,
+            claims = DCQLClaimsQueryList(
+                DCQLJsonClaimsQuery(
+                    path = DCQLClaimsPathPointer(null)
+                )
+            ),
+            meta = DCQLJwtVcCredentialMetadataAndValidityConstraints(listOf())
+        )
+
+        val expectedJsonObject = buildJsonObject {
+            put(DCQLCredentialQuery.SerialNames.ID, JsonPrimitive(value.id.string))
+            put(
+                DCQLCredentialQuery.SerialNames.FORMAT,
+                JsonPrimitive(CredentialFormatEnum.JWT_VC.text)
+            )
+            put(DCQLCredentialQuery.SerialNames.META,
+                buildJsonObject {
+                    put(DCQLJwtVcCredentialMetadataAndValidityConstraints.SerialNames.TYPE_VALUES, buildJsonArray {})
+                })
+            put(DCQLCredentialQuery.SerialNames.CLAIMS, buildJsonArray {
+                add(buildJsonObject {
+                    put(DCQLJsonClaimsQuery.SerialNames.PATH, buildJsonArray {
+                        add(JsonNull)
+                    })
+                })
+            })
+        }
+
+        val base: DCQLCredentialQuery = value
+        Json.encodeToJsonElement(base) shouldBe expectedJsonObject
+        Json.decodeFromJsonElement<DCQLCredentialQuery>(expectedJsonObject) shouldBe value
+    }
+}

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLSdJwtCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLSdJwtCredentialMetadataAndValidityConstraintsTest.kt
@@ -41,7 +41,10 @@ val DCQLSdJwtCredentialMetadataAndValidityConstraintsTest by testSuite {
                 mdocCredentialDoctypeExtractor = {
                     throw IllegalArgumentException("MDOC credential type cannot be extracted")
                 },
-                sdJwtCredentialTypeExtractor = { "dummy document type" }
+                sdJwtCredentialTypeExtractor = { "dummy document type" },
+                jwtVcCredentialTypeExtractor = {
+                    throw IllegalArgumentException("JWT-VC credential type cannot be extracted")
+                }
             ).getOrThrow()
         }
         shouldThrowAny {
@@ -59,7 +62,10 @@ val DCQLSdJwtCredentialMetadataAndValidityConstraintsTest by testSuite {
                 mdocCredentialDoctypeExtractor = {
                     throw IllegalArgumentException("MDOC credential type cannot be extracted")
                 },
-                sdJwtCredentialTypeExtractor = { "DIFFERENT dummy document type" }
+                sdJwtCredentialTypeExtractor = { "DIFFERENT dummy document type" },
+                jwtVcCredentialTypeExtractor = {
+                    throw IllegalArgumentException("JWT-VC credential type cannot be extracted")
+                }
             ).getOrThrow()
         }
     }

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLSdJwtCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLSdJwtCredentialMetadataAndValidityConstraintsTest.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLSdJwtCredentialMetadataAndValidityConstraintsTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLSdJwtCredentialMetadataAndValidityConstraintsTest.kt
@@ -1,5 +1,17 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.minus

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredential.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredential.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredential.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredential.kt
@@ -1,5 +1,17 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.openid.CredentialFormatEnum
 import kotlinx.serialization.json.JsonElement
 

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredential.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredential.kt
@@ -25,4 +25,12 @@ sealed interface TestCredential {
         override val format: CredentialFormatEnum
             get() = CredentialFormatEnum.MSO_MDOC
     }
+
+    data class JwtVcCredential(
+        override val claimStructure: JsonElement,
+        val types: List<String>,
+    ) : JsonCredential {
+        override val format: CredentialFormatEnum
+            get() = CredentialFormatEnum.JWT_VC
+    }
 }

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredentialQueryAdapter.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredentialQueryAdapter.kt
@@ -1,7 +1,7 @@
 package at.asitplus.openid.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredentialQueryAdapter.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredentialQueryAdapter.kt
@@ -29,8 +29,14 @@ value class TestCredentialQueryAdapter(val dcqlQuery: DCQLQuery) {
         sdJwtCredentialTypeExtractor = {
             when (it) {
                 is TestCredential.SdJwtCredential -> it.type
-                else -> throw IllegalArgumentException("Json Credentials do not have an MDOC document type.")
+                else -> throw IllegalArgumentException("Json Credentials do not have an SD-JWT document type.")
             }
-        }
+        },
+        jwtVcCredentialTypeExtractor = {
+            when (it) {
+                is TestCredential.JwtVcCredential -> it.types
+                else -> throw IllegalArgumentException("Json Credentials do not have an JWT-VC document type.")
+            }
+        },
     )
 }

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredentialQueryAdapter.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredentialQueryAdapter.kt
@@ -1,5 +1,17 @@
 package at.asitplus.openid.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import kotlin.jvm.JvmInline
 
 @JvmInline

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/dcql/DCQLQueryProcedureAdapter.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/dcql/DCQLQueryProcedureAdapter.kt
@@ -1,7 +1,7 @@
 package at.asitplus.wallet.lib.procedures.dcql
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/dcql/DCQLQueryProcedureAdapter.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/dcql/DCQLQueryProcedureAdapter.kt
@@ -1,5 +1,17 @@
 package at.asitplus.wallet.lib.procedures.dcql
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.KmmResult
 import at.asitplus.openid.dcql.DCQLCredentialClaimStructure
 import at.asitplus.openid.dcql.DCQLQuery

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
@@ -6,14 +6,15 @@ import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
 import at.asitplus.openid.dcql.DCQLCredentialQueryInstance
 import at.asitplus.openid.dcql.DCQLCredentialQueryList
+import at.asitplus.openid.dcql.DCQLJwtVcCredentialMetadataAndValidityConstraints
 import at.asitplus.openid.dcql.DCQLQuery
-import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.withFixtureGenerator
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
 import at.asitplus.wallet.lib.data.CredentialPresentation.PresentationExchangePresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListInfo
+import at.asitplus.wallet.lib.data.VcDataModelConstants.VERIFIABLE_CREDENTIAL
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusValidationResult
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.randomCwtOrJwtResolver
@@ -80,7 +81,10 @@ val AgentTest by testSuite {
             it.holder.getCredentials()?.size shouldBe 1
 
             val presentationParameters = it.holder.createPresentation(
-                request = PresentationRequestParameters(nonce = it.challenge, audience = it.verifierId),
+                request = PresentationRequestParameters(
+                    nonce = it.challenge,
+                    audience = it.verifierId
+                ),
                 credentialPresentation = singularPresentationDefinition,
             ).getOrThrow()
                 .shouldBeInstanceOf<PresentationResponseParameters.PresentationExchangeParameters>()
@@ -103,7 +107,10 @@ val AgentTest by testSuite {
             ).getOrThrow()
 
             val presentationParameters = it.holder.createPresentation(
-                request = PresentationRequestParameters(nonce = it.challenge, audience = it.issuerIdentifier),
+                request = PresentationRequestParameters(
+                    nonce = it.challenge,
+                    audience = it.issuerIdentifier
+                ),
                 credentialPresentation = singularPresentationDefinition,
             ).getOrThrow()
                 .shouldBeInstanceOf<PresentationResponseParameters.PresentationExchangeParameters>()
@@ -130,7 +137,7 @@ val AgentTest by testSuite {
             ).getOrThrow()
                 .shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-            val storedCredential = it.holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
+            it.holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
                 .shouldBeInstanceOf<SubjectCredentialStore.StoreEntry.Vc>()
 
             it.holderCredentialStore.getCredentials().getOrThrow().shouldHaveSize(1)
@@ -153,7 +160,7 @@ val AgentTest by testSuite {
             ).getOrThrow()
                 .shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-            val storedCredential = it.holder.storeCredential(credential.toStoreCredentialInput())
+            it.holder.storeCredential(credential.toStoreCredentialInput())
                 .getOrThrow()
                 .shouldBeInstanceOf<SubjectCredentialStore.StoreEntry.Vc>()
 
@@ -190,7 +197,10 @@ val AgentTest by testSuite {
             ).getOrThrow()
             it.holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
             val presentationParameters = it.holder.createPresentation(
-                request = PresentationRequestParameters(nonce = it.challenge, audience = it.verifierId),
+                request = PresentationRequestParameters(
+                    nonce = it.challenge,
+                    audience = it.verifierId
+                ),
                 credentialPresentation = singularPresentationDefinition,
             ).getOrNull()
                 .shouldBeInstanceOf<PresentationResponseParameters.PresentationExchangeParameters>()
@@ -218,7 +228,10 @@ val AgentTest by testSuite {
             ).getOrThrow()
             it.holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
             val presentationParameters = it.holder.createPresentation(
-                request = PresentationRequestParameters(nonce = it.challenge, audience = it.verifierId),
+                request = PresentationRequestParameters(
+                    nonce = it.challenge,
+                    audience = it.verifierId
+                ),
                 credentialPresentation = singularPresentationDefinition,
             ).getOrNull()
                 .shouldBeInstanceOf<PresentationResponseParameters.PresentationExchangeParameters>()
@@ -248,7 +261,15 @@ val AgentTest by testSuite {
             credentials = DCQLCredentialQueryList(
                 DCQLCredentialQueryInstance(
                     id = DCQLCredentialQueryIdentifier(uuid4().toString()),
-                    format = CredentialFormatEnum.JWT_VC
+                    format = CredentialFormatEnum.JWT_VC,
+                    meta = DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                        typeValues = listOf(
+                            listOf(
+                                VERIFIABLE_CREDENTIAL,
+                                ConstantIndex.AtomicAttribute2023.vcType
+                            )
+                        )
+                    )
                 )
             ),
         )
@@ -265,10 +286,14 @@ val AgentTest by testSuite {
             ).getOrThrow()
 
             it.holder.getCredentials()?.size shouldBe 1
-
             val presentationParameters = it.holder.createDefaultPresentation(
-                request = PresentationRequestParameters(nonce = it.challenge, audience = it.verifierId),
-                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(singularDCQLRequest)
+                request = PresentationRequestParameters(
+                    nonce = it.challenge,
+                    audience = it.verifierId
+                ),
+                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(
+                    singularDCQLRequest
+                )
             ).getOrThrow() as PresentationResponseParameters.DCQLParameters
             val vp = presentationParameters.verifiablePresentations.values.first()
                 .shouldBeInstanceOf<CreatePresentationResult.Signed>()
@@ -292,7 +317,9 @@ val AgentTest by testSuite {
                     nonce = it.challenge,
                     audience = it.issuerIdentifier,
                 ),
-                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(singularDCQLRequest)
+                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(
+                    singularDCQLRequest
+                )
             ).getOrThrow() as PresentationResponseParameters.DCQLParameters
             val vp = presentationParameters.verifiablePresentations.values.first()
                 .shouldBeInstanceOf<CreatePresentationResult.Signed>()
@@ -306,7 +333,9 @@ val AgentTest by testSuite {
                     nonce = it.challenge,
                     audience = "urn:${uuid4()}"
                 ),
-                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(singularDCQLRequest),
+                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(
+                    singularDCQLRequest
+                ),
             ).getOrNull() as PresentationResponseParameters.DCQLParameters? shouldBe null
         }
 
@@ -320,8 +349,13 @@ val AgentTest by testSuite {
             ).getOrThrow()
             it.holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
             val presentationParameters = it.holder.createDefaultPresentation(
-                request = PresentationRequestParameters(nonce = it.challenge, audience = it.verifierId),
-                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(singularDCQLRequest)
+                request = PresentationRequestParameters(
+                    nonce = it.challenge,
+                    audience = it.verifierId
+                ),
+                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(
+                    singularDCQLRequest
+                )
             ).getOrNull() as PresentationResponseParameters.DCQLParameters?
             presentationParameters.shouldNotBeNull()
             val vp = presentationParameters.verifiablePresentations.values.firstOrNull()
@@ -346,8 +380,13 @@ val AgentTest by testSuite {
             ).getOrThrow()
             it.holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
             val presentationParameters = it.holder.createDefaultPresentation(
-                request = PresentationRequestParameters(nonce = it.challenge, audience = it.verifierId),
-                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(singularDCQLRequest)
+                request = PresentationRequestParameters(
+                    nonce = it.challenge,
+                    audience = it.verifierId
+                ),
+                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(
+                    singularDCQLRequest
+                )
             ).getOrNull() as PresentationResponseParameters.DCQLParameters?
             presentationParameters.shouldNotBeNull()
             val vp = presentationParameters.verifiablePresentations.values.firstOrNull()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
@@ -1,7 +1,7 @@
 package at.asitplus.wallet.lib.agent
 
 /*
- * Software Name : vc-k
+ * Software Name : VC-K
  * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
@@ -1,5 +1,17 @@
 package at.asitplus.wallet.lib.agent
 
+/*
+ * Software Name : vc-k
+ * SPDX-FileCopyrightText: Copyright (c) A-SIT Plus GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Modifications: Added jwt_vc_json DCQL support for Orange implementation
+ * SPDX-FileCopyrightText: Copyright (c) Orange Business
+ *
+ * This software is distributed under the Apache License 2.0,
+ * see the "LICENSE" file for more details
+ */
+
 import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.dif.PresentationDefinition
 import at.asitplus.openid.CredentialFormatEnum


### PR DESCRIPTION
### Motivation
Support of W3C Verifiable Credentials authentication requests
We noticed (#467) that the class `at.asitplus.openid.dcql.DCQLCredentialMetadataAndValidityConstraintsSerializer` does not handle the field meta/type_values as defined in the OpenId4vp Spec 1.0: https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#appendix-B.1.1
We added some headers to the new files and modified files in link with this question : #486 

### Description
Adding a case in `openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraintsSerializer.kt` to detect type_values metadata.
Adding a class `openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialMetadataAndValidityConstraints.kt` to check type_values validity.
Adding a `jwtVcCredentialTypeExtractor` lambda in parameter of function `executeCredentialQueryAgainstCredential` in`openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt`
Adding `openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQuery.kt` has an implementation of `DCQLCredentialQuery` for JWT_VC format.

### Testing
Existing unit test has been updated and new ones has been created to test new classes.
We successfully performed a `jwt_vc_json` presentation with that implementation.
