### PR TITLE
OID4VCI refresh token storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,15 @@ Release 5.12.0 (unreleased):
  - ISO mdoc:
    - Preserve `Document.errors` in parsed ISO document results instead of failing validation
  - Change: Executing unsatisfiable DCQL queries no longer throws on matching, only on submission.
+ - OID4VCI refresh token storage:
+ - Moved the class `RefreshTokenInfo` from `OpenId4VciClient` to `SubjectCredentialStore.kt` and renamed it to `CredentialRenewalInfo` to better describe its role in the renewal process.
+   Kept `RefreshTokenInfo` in the original package for backward compatibility
+ - Added `CredentialRenewalInfo` to `SubjectCredentialStore.StoreEntry`
+ - Added support for refresh tokens in BearerTokenService
 
 Release 5.11.1:
  - OAuth 2.0:
    - Fix bug in `SimpleAuthorizationRequest` validating `issuer_state` on pushed authorization requests twice (and failing on the second time)
- - OID4VCI refresh token storage:
-   - Moved the class `RefreshTokenInfo` from `OpenId4VciClient` to `SubjectCredentialStore.kt` and renamed it to `CredentialRenewalInfo` to better describe its role in the renewal process.
-     Kept `RefreshTokenInfo` as a typealias in the original package for backward compatibility
-   - Added `CredentialRenewalInfo` to `SubjectCredentialStore.StoreEntry`
-   - Added support for refresh tokens in BearerTokenService
 
 Release 5.11.0:
  - Digital Credentials API:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Release 5.12.0 (unreleased):
 Release 5.11.1:
  - OAuth 2.0:
    - Fix bug in `SimpleAuthorizationRequest` validating `issuer_state` on pushed authorization requests twice (and failing on the second time)
+ - OID4VCI refresh token storage:
+   - Moved the class `RefreshTokenInfo` from `OpenId4VciClient` to `SubjectCredentialStore.kt` and renamed it to `CredentialRenewalInfo` to better describe its role in the renewal process.
+     Kept `RefreshTokenInfo` as a typealias in the original package for backward compatibility
+   - Added `CredentialRenewalInfo` to `SubjectCredentialStore.StoreEntry`
+   - Added support for refresh tokens in BearerTokenService
 
 Release 5.11.0:
  - Digital Credentials API:

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -10,6 +10,7 @@ import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OpenIdConstants.WellKnownPaths
 import at.asitplus.openid.SupportedCredentialFormat
 import at.asitplus.wallet.lib.agent.Holder
+import at.asitplus.wallet.lib.agent.RefreshTokenInfo
 import at.asitplus.wallet.lib.data.AttributeIndex
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.IsoMdocFallbackCredentialScheme
@@ -212,12 +213,14 @@ class OpenId4VciClient(
         refreshTokenInfo: RefreshTokenInfo,
     ): KmmResult<CredentialIssuanceResult.Success> = catching {
         with(refreshTokenInfo) {
+            val currentRefreshToken = refreshToken
+                ?: throw IllegalArgumentException("Refresh token is missing in RefreshTokenInfo")
             Napier.i("refreshCredential")
             Napier.d("refreshCredential: $refreshToken, $credentialFormat, $credentialIdentifier")
             val tokenResponse = oauth2Client.requestTokenWithRefreshToken(
                 oauthMetadata = oauthMetadata,
                 credentialIssuer = issuerMetadata.credentialIssuer,
-                refreshToken = refreshToken,
+                refreshToken = currentRefreshToken,
                 scope = credentialFormat.scope,
                 authorizationDetails = oid4vciService.buildAuthorizationDetails(
                     credentialIdentifier,
@@ -487,19 +490,6 @@ data class CredentialIdentifierInfo(
     val credentialIdentifier: String,
     val supportedCredentialFormat: SupportedCredentialFormat,
 )
-
-/**
- * Holds all information needed to refresh a credential, pass it to [OpenId4VciClient.refreshCredential].
- */
-@Serializable
-data class RefreshTokenInfo(
-    val refreshToken: String,
-    val issuerMetadata: IssuerMetadata,
-    val oauthMetadata: OAuth2AuthorizationServerMetadata,
-    val credentialFormat: SupportedCredentialFormat,
-    val credentialIdentifier: String,
-)
-
 
 private suspend inline fun <R> IntermediateResult<R>.onSuccessCredential(
     block: String.(httpResponse: HttpResponse) -> R,

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -245,6 +245,19 @@ class OpenId4VciClient(
         }
     }
 
+    @Deprecated(
+        message = "Use refreshCredentialReturningResult(CredentialRenewalInfo)",
+        replaceWith = ReplaceWith(
+            "refreshCredentialReturningResult(refreshTokenInfo.toCredentialRenewalInfo())"
+        )
+    )
+    suspend fun refreshCredentialReturningResult(
+        refreshTokenInfo: RefreshTokenInfo
+    ): KmmResult<CredentialIssuanceResult.Success> =
+        refreshCredentialReturningResult(
+            refreshTokenInfo.toCredentialRenewalInfo()
+        )
+
     /**
      * Will use the [tokenResponse] to request a credential and store it with [storeCredential].
      */
@@ -501,7 +514,23 @@ data class CredentialIdentifierInfo(
         "at.asitplus.wallet.lib.agent.CredentialRenewalInfo"
     )
 )
-typealias RefreshTokenInfo = CredentialRenewalInfo
+@Serializable
+data class RefreshTokenInfo(
+    val refreshToken: String,
+    val issuerMetadata: IssuerMetadata,
+    val oauthMetadata: OAuth2AuthorizationServerMetadata,
+    val credentialFormat: SupportedCredentialFormat,
+    val credentialIdentifier: String,
+)
+
+fun RefreshTokenInfo.toCredentialRenewalInfo() =
+    CredentialRenewalInfo(
+        refreshToken = refreshToken,
+        issuerMetadata = issuerMetadata,
+        oauthMetadata = oauthMetadata,
+        credentialFormat = credentialFormat,
+        credentialIdentifier = credentialIdentifier
+    )
 
 private suspend inline fun <R> IntermediateResult<R>.onSuccessCredential(
     block: String.(httpResponse: HttpResponse) -> R,

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -9,8 +9,8 @@ import at.asitplus.openid.IssuerMetadata
 import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.OpenIdConstants.WellKnownPaths
 import at.asitplus.openid.SupportedCredentialFormat
+import at.asitplus.wallet.lib.agent.CredentialRenewalInfo
 import at.asitplus.wallet.lib.agent.Holder
-import at.asitplus.wallet.lib.agent.RefreshTokenInfo
 import at.asitplus.wallet.lib.data.AttributeIndex
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.IsoMdocFallbackCredentialScheme
@@ -210,17 +210,15 @@ class OpenId4VciClient(
      * but falls back to authorization details if needed.
      */
     suspend fun refreshCredentialReturningResult(
-        refreshTokenInfo: RefreshTokenInfo,
+        refreshTokenInfo: CredentialRenewalInfo,
     ): KmmResult<CredentialIssuanceResult.Success> = catching {
         with(refreshTokenInfo) {
-            val currentRefreshToken = refreshToken
-                ?: throw IllegalArgumentException("Refresh token is missing in RefreshTokenInfo")
             Napier.i("refreshCredential")
             Napier.d("refreshCredential: $refreshToken, $credentialFormat, $credentialIdentifier")
             val tokenResponse = oauth2Client.requestTokenWithRefreshToken(
                 oauthMetadata = oauthMetadata,
                 credentialIssuer = issuerMetadata.credentialIssuer,
-                refreshToken = currentRefreshToken,
+                refreshToken = refreshToken ?: throw IllegalArgumentException("Refresh token is missing in RefreshTokenInfo"),
                 scope = credentialFormat.scope,
                 authorizationDetails = oid4vciService.buildAuthorizationDetails(
                     credentialIdentifier,
@@ -290,7 +288,7 @@ class OpenId4VciClient(
         return CredentialIssuanceResult.Success(
             storeCredentialInputs,
             tokenResponse.params.refreshToken?.let {
-                RefreshTokenInfo(
+                CredentialRenewalInfo(
                     refreshToken = tokenResponse.params.refreshToken!!,
                     issuerMetadata = issuerMetadata,
                     oauthMetadata = oauthMetadata,
@@ -467,7 +465,7 @@ sealed interface CredentialIssuanceResult {
      */
     data class Success(
         val credentials: Collection<Holder.StoreCredentialInput>,
-        val refreshToken: RefreshTokenInfo? = null,
+        val refreshToken: CredentialRenewalInfo? = null,
     ) : CredentialIssuanceResult
 
     /**
@@ -490,6 +488,18 @@ data class CredentialIdentifierInfo(
     val credentialIdentifier: String,
     val supportedCredentialFormat: SupportedCredentialFormat,
 )
+
+/**
+ * Holds all information needed to refresh a credential, pass it to [OpenId4VciClient.refreshCredential].
+ */
+@Deprecated(
+    message = "Moved to at.asitplus.wallet.lib.agent and renamed to CredentialRenewalInfo",
+    replaceWith = ReplaceWith(
+        "CredentialRenewalInfo",
+        "at.asitplus.wallet.lib.agent.CredentialRenewalInfo"
+    )
+)
+typealias RefreshTokenInfo = CredentialRenewalInfo
 
 private suspend inline fun <R> IntermediateResult<R>.onSuccessCredential(
     block: String.(httpResponse: HttpResponse) -> R,

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -127,6 +127,7 @@ class OpenId4VciClient(
     suspend fun startProvisioningWithAuthRequestReturningResult(
         credentialIssuerUrl: String,
         credentialIdentifierInfo: CredentialIdentifierInfo,
+        reissuingStoreEntryId: Long? = null
     ): KmmResult<CredentialIssuanceResult.OpenUrlForAuthnRequest> = catching {
         Napier.i("startProvisioningWithAuthRequest: $credentialIssuerUrl with $credentialIdentifierInfo")
         val issuerMetadata = credentialIdentifierInfo.issuerMetadata
@@ -149,7 +150,8 @@ class OpenId4VciClient(
                     state = it.state,
                     credential = credentialIdentifierInfo,
                     oauthMetadata = oauthMetadata,
-                    issuerMetadata = issuerMetadata
+                    issuerMetadata = issuerMetadata,
+                    reissuingStoreEntryId = reissuingStoreEntryId
                 )
             )
         }
@@ -452,6 +454,7 @@ data class ProvisioningContext(
     val credential: CredentialIdentifierInfo,
     val oauthMetadata: OAuth2AuthorizationServerMetadata,
     val issuerMetadata: IssuerMetadata,
+    val reissuingStoreEntryId: Long? = null,
 )
 
 /**

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClient.kt
@@ -287,15 +287,14 @@ class OpenId4VciClient(
         }
         return CredentialIssuanceResult.Success(
             storeCredentialInputs,
-            tokenResponse.params.refreshToken?.let {
-                CredentialRenewalInfo(
-                    refreshToken = tokenResponse.params.refreshToken!!,
+            CredentialRenewalInfo(
+                    refreshToken = tokenResponse.params.refreshToken,
                     issuerMetadata = issuerMetadata,
                     oauthMetadata = oauthMetadata,
                     credentialFormat = credentialFormat,
                     credentialIdentifier = credentialIdentifier,
                 )
-            })
+            )
     }
 
     private suspend fun fetchCredential(

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
@@ -13,6 +13,7 @@ import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
 import at.asitplus.wallet.eupid.EuPidScheme
 import at.asitplus.wallet.lib.agent.ClaimToBeIssued
+import at.asitplus.wallet.lib.agent.CredentialRenewalInfo
 import at.asitplus.wallet.lib.agent.CredentialToBeIssued.Iso
 import at.asitplus.wallet.lib.agent.CredentialToBeIssued.VcSd
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
@@ -20,7 +21,6 @@ import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
-import at.asitplus.wallet.lib.agent.RefreshTokenInfo
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
 import at.asitplus.wallet.lib.data.rfc3986.toUri
@@ -300,7 +300,7 @@ val OpenId4VciClientExternalAuthorizationServerTest by testSuite {
         val expectedAttributeValue = uuid4().toString()
         val expectedAttributeName = EuPidScheme.Attributes.FAMILY_NAME
         with(setup(EuPidScheme, SD_JWT, mapOf(expectedAttributeName to expectedAttributeValue))) {
-            var refreshTokenStore: RefreshTokenInfo? = null
+            var refreshTokenStore: CredentialRenewalInfo? = null
             // Load credential identifier infos from Issuing service
             val credentialIdentifierInfos = client.loadCredentialMetadata(issuerPublicContext).getOrThrow()
             // just pick the first credential in SD-JWT that is available
@@ -339,7 +339,7 @@ val OpenId4VciClientExternalAuthorizationServerTest by testSuite {
         val expectedAttributeValue = uuid4().toString()
         val expectedAttributeName = EuPidScheme.Attributes.GIVEN_NAME
         with(setup(EuPidScheme, ISO_MDOC, mapOf(expectedAttributeName to expectedAttributeValue))) {
-            var refreshTokenStore: RefreshTokenInfo? = null
+            var refreshTokenStore: CredentialRenewalInfo? = null
             // Load credential identifier infos from Issuing service
             val credentialIdentifierInfos = client.loadCredentialMetadata(issuerPublicContext).getOrThrow()
             // just pick the first credential in MSO_MDOC that is available

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientExternalAuthorizationServerTest.kt
@@ -20,6 +20,7 @@ import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.agent.RefreshTokenInfo
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
 import at.asitplus.wallet.lib.data.rfc3986.toUri

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientIntegratedDPoPTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientIntegratedDPoPTest.kt
@@ -8,6 +8,7 @@ import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
 import at.asitplus.testballoon.withFixtureGenerator
 import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.lib.agent.CredentialRenewalInfo
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.IssuerAgent
@@ -22,6 +23,7 @@ import at.asitplus.wallet.lib.ktor.openid.TestUtils.respond
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.respondIncludingDpopNonce
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.toRequestInfo
 import at.asitplus.wallet.lib.ktor.openid.TestUtils.verifySdJwtCredential
+import at.asitplus.wallet.lib.ktor.openid.toCredentialRenewalInfo
 import at.asitplus.wallet.lib.oauth2.ClientAuthenticationService
 import at.asitplus.wallet.lib.oauth2.OAuth2Client
 import at.asitplus.wallet.lib.oauth2.SimpleAuthorizationService
@@ -201,7 +203,7 @@ val OpenId4VciClientIntegratedDPoPTest by testSuite {
         )
     } - {
         test("loadEuPidCredentialSdJwt") { context ->
-            var refreshTokenStore: RefreshTokenInfo? = null
+            var refreshTokenStore: CredentialRenewalInfo? = null
 
             val credentialIdentifierInfos = context.client.loadCredentialMetadata("http://localhost").getOrThrow()
             val selectedCredential = credentialIdentifierInfos

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -12,7 +12,6 @@ import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
-import at.asitplus.wallet.lib.agent.RefreshTokenInfo
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
@@ -47,6 +46,8 @@ import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.util.*
+import at.asitplus.testballoon.invoke
+import at.asitplus.wallet.lib.agent.CredentialRenewalInfo
 
 /**
  * Tests [OpenId4VciClient] against [CredentialIssuer] with our own internal [SimpleAuthorizationService].
@@ -204,7 +205,7 @@ val OpenId4VciClientTest by testSuite {
         val expectedFamilyName = uuid4().toString()
         val expectedAttributeName = EuPidScheme.Attributes.FAMILY_NAME
         with(setup(EuPidScheme, SD_JWT, mapOf(expectedAttributeName to expectedFamilyName))) {
-            var refreshTokenStore: RefreshTokenInfo? = null
+            var refreshTokenStore: CredentialRenewalInfo? = null
 
             // Load credential identifier infos from Issuing service
             val credentialIdentifierInfos = client.loadCredentialMetadata("http://localhost").getOrThrow()
@@ -244,7 +245,7 @@ val OpenId4VciClientTest by testSuite {
         val expectedAttributeValue = uuid4().toString()
         val expectedAttributeName = EuPidScheme.Attributes.GIVEN_NAME
         with(setup(EuPidScheme, ISO_MDOC, mapOf(expectedAttributeName to expectedAttributeValue))) {
-            var refreshTokenStore: RefreshTokenInfo? = null
+            var refreshTokenStore: CredentialRenewalInfo? = null
             // Load credential identifier infos from Issuing service
             val credentialIdentifierInfos = client.loadCredentialMetadata("http://localhost").getOrThrow()
             // just pick the first credential in MSO_MDOC that is available

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientTest.kt
@@ -6,13 +6,13 @@ import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
-import at.asitplus.testballoon.invoke
 import at.asitplus.wallet.eupid.EuPidScheme
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.agent.RefreshTokenInfo
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientWithEncryptionTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientWithEncryptionTest.kt
@@ -9,12 +9,12 @@ import at.asitplus.openid.RequestParameters
 import at.asitplus.openid.TokenRequestParameters
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
 import at.asitplus.wallet.eupid.EuPidScheme
+import at.asitplus.wallet.lib.agent.CredentialRenewalInfo
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
-import at.asitplus.wallet.lib.agent.RefreshTokenInfo
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
@@ -217,7 +217,7 @@ val OpenId4VciClientWithEncryptionTest by testSuite {
         val expectedFamilyName = uuid4().toString()
         val expectedAttributeName = EuPidScheme.Attributes.FAMILY_NAME
         with(setup(EuPidScheme, SD_JWT, mapOf(expectedAttributeName to expectedFamilyName))) {
-            var refreshTokenStore: RefreshTokenInfo? = null
+            var refreshTokenStore: CredentialRenewalInfo? = null
 
             // Load credential identifier infos from Issuing service
             val credentialIdentifierInfos = client.loadCredentialMetadata("http://localhost").getOrThrow()
@@ -249,7 +249,7 @@ val OpenId4VciClientWithEncryptionTest by testSuite {
         val expectedAttributeValue = uuid4().toString()
         val expectedAttributeName = EuPidScheme.Attributes.GIVEN_NAME
         with(setup(EuPidScheme, ISO_MDOC, mapOf(expectedAttributeName to expectedAttributeValue))) {
-            var refreshTokenStore: RefreshTokenInfo? = null
+            var refreshTokenStore: CredentialRenewalInfo? = null
 
             // Load credential identifier infos from Issuing service
             val credentialIdentifierInfos = client.loadCredentialMetadata("http://localhost").getOrThrow()

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientWithEncryptionTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VciClientWithEncryptionTest.kt
@@ -14,6 +14,7 @@ import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.agent.RefreshTokenInfo
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -110,7 +110,7 @@ class SimpleAuthorizationService(
     /** Associates the issued request_uri to the auth request from the client. */
     private val requestUriToPushedAuthorizationRequest: MapStore<String, AuthenticationRequestParameters> = DefaultMapStore(),
     /** Service to create and validate access tokens. */
-    private val tokenService: TokenService = TokenService.bearer(issueRefreshTokens = true),
+    private val tokenService: TokenService = TokenService.bearer(),
     /** Handles client authentication in [par] and [token]. */
     private val clientAuthenticationService: ClientAuthenticationService = ClientAuthenticationService(
         enforceClientAuthentication = false,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -110,7 +110,7 @@ class SimpleAuthorizationService(
     /** Associates the issued request_uri to the auth request from the client. */
     private val requestUriToPushedAuthorizationRequest: MapStore<String, AuthenticationRequestParameters> = DefaultMapStore(),
     /** Service to create and validate access tokens. */
-    private val tokenService: TokenService = TokenService.bearer(),
+    private val tokenService: TokenService = TokenService.bearer(issueRefreshTokens = true),
     /** Handles client authentication in [par] and [token]. */
     private val clientAuthenticationService: ClientAuthenticationService = ClientAuthenticationService(
         enforceClientAuthentication = false,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenGenerationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenGenerationService.kt
@@ -141,7 +141,33 @@ class BearerTokenGenerationService(
     /** Used to create nonces for tokens during issuing. */
     internal val nonceService: NonceService = DefaultNonceService(),
     private val accessTokenToValidatedAccessToken: MapStore<String, ValidatedAccessToken> = DefaultMapStore(),
+    private val refreshTokenToValidatedAccessToken: MapStore<String, ValidatedAccessToken> = DefaultMapStore(),
+    private val issueRefreshToken: Boolean = false
 ) : TokenGenerationService {
+
+//    override suspend fun buildToken(
+//        httpRequest: RequestInfo?,
+//        userInfo: OidcUserInfoExtended,
+//        authorizationDetails: Set<AuthorizationDetails>?,
+//        scope: String?,
+//        validatedClientKey: JsonWebKey?
+//    ): TokenResponseParameters = TokenResponseParameters(
+//        expires = 5.minutes,
+//        tokenType = TOKEN_TYPE_BEARER,
+//        accessToken = nonceService.provideNonce(),
+//        authorizationDetails = authorizationDetails,
+//        scope = scope,
+//    ).also {
+//        accessTokenToValidatedAccessToken.put(
+//            it.accessToken,
+//            ValidatedAccessToken(
+//                token = it.accessToken,
+//                userInfoExtended = userInfo,
+//                authorizationDetails = authorizationDetails,
+//                scope = scope
+//            )
+//        )
+//    }
 
     override suspend fun buildToken(
         httpRequest: RequestInfo?,
@@ -149,21 +175,24 @@ class BearerTokenGenerationService(
         authorizationDetails: Set<AuthorizationDetails>?,
         scope: String?,
         validatedClientKey: JsonWebKey?
-    ): TokenResponseParameters = TokenResponseParameters(
-        expires = 5.minutes,
-        tokenType = TOKEN_TYPE_BEARER,
-        accessToken = nonceService.provideNonce(),
-        authorizationDetails = authorizationDetails,
-        scope = scope,
-    ).also {
-        accessTokenToValidatedAccessToken.put(
-            it.accessToken,
-            ValidatedAccessToken(
-                token = it.accessToken,
-                userInfoExtended = userInfo,
-                authorizationDetails = authorizationDetails,
-                scope = scope
-            )
+    ): TokenResponseParameters {
+        val accessToken = nonceService.provideNonce()
+        val refreshToken = if (issueRefreshToken) nonceService.provideNonce() else null
+        val validatedToken = ValidatedAccessToken(
+            token = accessToken,
+            userInfoExtended = userInfo,
+            authorizationDetails = authorizationDetails,
+            scope = scope
+        )
+        accessTokenToValidatedAccessToken.put(accessToken, validatedToken)
+        if (issueRefreshToken) refreshTokenToValidatedAccessToken.put(refreshToken!!, validatedToken.copy(token = refreshToken))
+        return TokenResponseParameters(
+            expires = 5.minutes,
+            tokenType = TOKEN_TYPE_BEARER,
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            authorizationDetails = authorizationDetails,
+            scope = scope,
         )
     }
 
@@ -172,6 +201,12 @@ class BearerTokenGenerationService(
 
     suspend fun verifyAccessToken(accessToken: String) =
         accessTokenToValidatedAccessToken.get(accessToken)
+
+    suspend fun verifyRefreshToken(token: String) =
+        refreshTokenToValidatedAccessToken.get(token)
+
+    suspend fun removeRefreshToken(token: String) =
+        refreshTokenToValidatedAccessToken.remove(token)
 
     override suspend fun dpopNonce() = null
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenGenerationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenGenerationService.kt
@@ -161,7 +161,7 @@ class BearerTokenGenerationService(
             scope = scope
         )
         accessTokenToValidatedAccessToken.put(accessToken, validatedToken)
-        if (issueRefreshToken) refreshTokenToValidatedAccessToken.put(refreshToken!!, validatedToken.copy(token = refreshToken))
+        refreshToken?.let { refreshTokenToValidatedAccessToken.put(it, validatedToken.copy(token = it)) }
         return TokenResponseParameters(
             expires = 5.minutes,
             tokenType = TOKEN_TYPE_BEARER,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenGenerationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenGenerationService.kt
@@ -145,30 +145,6 @@ class BearerTokenGenerationService(
     private val issueRefreshToken: Boolean = false
 ) : TokenGenerationService {
 
-//    override suspend fun buildToken(
-//        httpRequest: RequestInfo?,
-//        userInfo: OidcUserInfoExtended,
-//        authorizationDetails: Set<AuthorizationDetails>?,
-//        scope: String?,
-//        validatedClientKey: JsonWebKey?
-//    ): TokenResponseParameters = TokenResponseParameters(
-//        expires = 5.minutes,
-//        tokenType = TOKEN_TYPE_BEARER,
-//        accessToken = nonceService.provideNonce(),
-//        authorizationDetails = authorizationDetails,
-//        scope = scope,
-//    ).also {
-//        accessTokenToValidatedAccessToken.put(
-//            it.accessToken,
-//            ValidatedAccessToken(
-//                token = it.accessToken,
-//                userInfoExtended = userInfo,
-//                authorizationDetails = authorizationDetails,
-//                scope = scope
-//            )
-//        )
-//    }
-
     override suspend fun buildToken(
         httpRequest: RequestInfo?,
         userInfo: OidcUserInfoExtended,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
@@ -113,6 +113,7 @@ interface TokenService {
         /** Build a [TokenService] combining [BearerTokenGenerationService] and [BearerTokenVerificationService]. */
         fun bearer(
             nonceService: NonceService = DefaultNonceService(),
+            issueRefreshTokens: Boolean = false
         ) = BearerTokenGenerationService(
             nonceService = nonceService
         ).let { generationService ->
@@ -122,7 +123,7 @@ interface TokenService {
                     tokenGenerationService = generationService
                 ),
                 dpopSigningAlgValuesSupportedStrings = null,
-                supportsRefreshTokens = false,
+                supportsRefreshTokens = issueRefreshTokens,
             )
         }
     }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenService.kt
@@ -115,7 +115,8 @@ interface TokenService {
             nonceService: NonceService = DefaultNonceService(),
             issueRefreshTokens: Boolean = false
         ) = BearerTokenGenerationService(
-            nonceService = nonceService
+            nonceService = nonceService,
+            issueRefreshToken = issueRefreshTokens
         ).let { generationService ->
             BearerTokenService(
                 generation = generationService,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
@@ -261,7 +261,6 @@ class BearerTokenVerificationService(
         httpRequest: RequestInfo?,
         validatedClientKey: JsonWebKey?,
     ): String {
-//        throw InvalidToken("Refresh tokens are not supported by this verifier")
         val validated = tokenGenerationService.verifyRefreshToken(refreshToken)
             ?: throw InvalidToken("Refresh token not valid")
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/TokenVerificationService.kt
@@ -261,7 +261,11 @@ class BearerTokenVerificationService(
         httpRequest: RequestInfo?,
         validatedClientKey: JsonWebKey?,
     ): String {
-        throw InvalidToken("Refresh tokens are not supported by this verifier")
+//        throw InvalidToken("Refresh tokens are not supported by this verifier")
+        val validated = tokenGenerationService.verifyRefreshToken(refreshToken)
+            ?: throw InvalidToken("Refresh token not valid")
+
+        return validated.token
     }
 
     /** Not supported for Bearer tokens. */

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
@@ -54,11 +54,6 @@ interface Holder {
     suspend fun storeCredential(credential: StoreCredentialInput, refreshTokenInfo: CredentialRenewalInfo? = null): KmmResult<SubjectCredentialStore.StoreEntry>
 
     /**
-     * Deletes a credential from the store.
-     */
-    suspend fun deleteCredential(credential: SubjectCredentialStore.StoreEntry)
-
-    /**
      * Gets a list of all stored credentials, with a revocation status.
      */
     suspend fun getCredentials(): Collection<SubjectCredentialStore.StoreEntry>?
@@ -128,6 +123,10 @@ interface Holder {
         filterById: String? = null
     ): KmmResult<DCQLQueryResult<SubjectCredentialStore.StoreEntry>>
 
-    suspend fun getInvalidCredentials(filterById: String? = null): List<SubjectCredentialStore.StoreEntry>?
+    /**
+     * Deletes a credential from the store.
+     */
+    suspend fun deleteCredential(id: Long)
+    suspend fun getInvalidCredentials(): List<Pair<Long, SubjectCredentialStore.StoreEntry>>
 }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
@@ -51,7 +51,7 @@ interface Holder {
      * Stores the verifiable credential in [credential] if it parses and validates,
      * and returns it for future reference.
      */
-    suspend fun storeCredential(credential: StoreCredentialInput, refreshTokenInfo: RefreshTokenInfo? = null): KmmResult<SubjectCredentialStore.StoreEntry>
+    suspend fun storeCredential(credential: StoreCredentialInput, refreshTokenInfo: CredentialRenewalInfo? = null): KmmResult<SubjectCredentialStore.StoreEntry>
 
     /**
      * Gets a list of all stored credentials, with a revocation status.

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
@@ -122,5 +122,7 @@ interface Holder {
         dcqlQuery: DCQLQuery,
         filterById: String? = null
     ): KmmResult<DCQLQueryResult<SubjectCredentialStore.StoreEntry>>
+
+    suspend fun getInvalidCredentials(filterById: String? = null): List<SubjectCredentialStore.StoreEntry>?
 }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
@@ -122,11 +122,5 @@ interface Holder {
         dcqlQuery: DCQLQuery,
         filterById: String? = null
     ): KmmResult<DCQLQueryResult<SubjectCredentialStore.StoreEntry>>
-
-    /**
-     * Deletes a credential from the store.
-     */
-    suspend fun deleteCredential(id: Long)
-    suspend fun getInvalidCredentials(): List<Pair<Long, SubjectCredentialStore.StoreEntry>>
 }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
@@ -54,6 +54,11 @@ interface Holder {
     suspend fun storeCredential(credential: StoreCredentialInput, refreshTokenInfo: CredentialRenewalInfo? = null): KmmResult<SubjectCredentialStore.StoreEntry>
 
     /**
+     * Deletes a credential from the store.
+     */
+    suspend fun deleteCredential(credential: SubjectCredentialStore.StoreEntry)
+
+    /**
      * Gets a list of all stored credentials, with a revocation status.
      */
     suspend fun getCredentials(): Collection<SubjectCredentialStore.StoreEntry>?

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
@@ -51,7 +51,7 @@ interface Holder {
      * Stores the verifiable credential in [credential] if it parses and validates,
      * and returns it for future reference.
      */
-    suspend fun storeCredential(credential: StoreCredentialInput): KmmResult<SubjectCredentialStore.StoreEntry>
+    suspend fun storeCredential(credential: StoreCredentialInput, refreshTokenInfo: RefreshTokenInfo? = null): KmmResult<SubjectCredentialStore.StoreEntry>
 
     /**
      * Gets a list of all stored credentials, with a revocation status.

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Holder.kt
@@ -51,7 +51,7 @@ interface Holder {
      * Stores the verifiable credential in [credential] if it parses and validates,
      * and returns it for future reference.
      */
-    suspend fun storeCredential(credential: StoreCredentialInput, refreshTokenInfo: CredentialRenewalInfo? = null): KmmResult<SubjectCredentialStore.StoreEntry>
+    suspend fun storeCredential(credential: StoreCredentialInput, renewalInfo: CredentialRenewalInfo? = null): KmmResult<SubjectCredentialStore.StoreEntry>
 
     /**
      * Gets a list of all stored credentials, with a revocation status.

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -58,7 +58,7 @@ class HolderAgent(
      * Stores the verifiable credential in [credential] if it parses and validates,
      * and returns it for future reference.
      */
-    override suspend fun storeCredential(credential: Holder.StoreCredentialInput, refreshTokenInfo: RefreshTokenInfo?) = catching {
+    override suspend fun storeCredential(credential: Holder.StoreCredentialInput, refreshTokenInfo: CredentialRenewalInfo?) = catching {
         when (credential) {
             is Holder.StoreCredentialInput.Vc -> {
                 val validated = validatorVcJws.verifyVcJws(credential.signedVcJws, keyMaterial.publicKey)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -58,7 +58,7 @@ class HolderAgent(
      * Stores the verifiable credential in [credential] if it parses and validates,
      * and returns it for future reference.
      */
-    override suspend fun storeCredential(credential: Holder.StoreCredentialInput, refreshTokenInfo: CredentialRenewalInfo?) = catching {
+    override suspend fun storeCredential(credential: Holder.StoreCredentialInput, renewalInfo: CredentialRenewalInfo?) = catching {
         when (credential) {
             is Holder.StoreCredentialInput.Vc -> {
                 val validated = validatorVcJws.verifyVcJws(credential.signedVcJws, keyMaterial.publicKey)
@@ -71,7 +71,7 @@ class HolderAgent(
                     vc = validated.jws,
                     vcSerialized = credential.vcJws,
                     scheme = credential.scheme,
-                    refreshToken = refreshTokenInfo
+                    renewalInfo = renewalInfo
                 )
             }
 
@@ -88,7 +88,7 @@ class HolderAgent(
                     vcSerialized = credential.vcSdJwt,
                     disclosures = validated.disclosures,
                     scheme = credential.scheme,
-                    refreshToken = refreshTokenInfo
+                    renewalInfo = renewalInfo
                 )
             }
 
@@ -102,7 +102,7 @@ class HolderAgent(
                 subjectCredentialStore.storeCredential(
                     issuerSigned = validated.issuerSigned,
                     scheme = credential.scheme,
-                    refreshToken = refreshTokenInfo
+                    renewalInfo = renewalInfo
                 )
             }
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -108,10 +108,6 @@ class HolderAgent(
         }
     }
 
-    override suspend fun deleteCredential(id: Long) {
-        subjectCredentialStore.removeStoreEntryById(id)
-    }
-
     private fun Holder.StoreCredentialInput.Iso.extractIssuerKey(): CoseKey? =
         issuerSigned.issuerAuth.unprotectedHeader?.certificateChain?.firstOrNull()?.let {
             catchingUnwrapped { X509Certificate.decodeFromDer(it) }.getOrNull()?.decodedPublicKey?.getOrNull()
@@ -148,11 +144,6 @@ class HolderAgent(
         return withRevocationStatusAvailable.sortedBy {
             if (it.second.isFresh) 0 else 1
         }.map { it.first }
-    }
-
-    /** Gets a list of all stored credentials that are no longer valid, possibly filtered by [filterById]. */
-    override suspend fun getInvalidCredentials(): List<Pair<Long, StoreEntry>> {
-        return subjectCredentialStore.getInvalidCredentials()
     }
 
     /** Prefer credentials with support for selective disclosure. */

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -58,7 +58,7 @@ class HolderAgent(
      * Stores the verifiable credential in [credential] if it parses and validates,
      * and returns it for future reference.
      */
-    override suspend fun storeCredential(credential: Holder.StoreCredentialInput) = catching {
+    override suspend fun storeCredential(credential: Holder.StoreCredentialInput, refreshTokenInfo: RefreshTokenInfo?) = catching {
         when (credential) {
             is Holder.StoreCredentialInput.Vc -> {
                 val validated = validatorVcJws.verifyVcJws(credential.signedVcJws, keyMaterial.publicKey)
@@ -71,6 +71,7 @@ class HolderAgent(
                     vc = validated.jws,
                     vcSerialized = credential.vcJws,
                     scheme = credential.scheme,
+                    refreshToken = refreshTokenInfo
                 )
             }
 
@@ -87,6 +88,7 @@ class HolderAgent(
                     vcSerialized = credential.vcSdJwt,
                     disclosures = validated.disclosures,
                     scheme = credential.scheme,
+                    refreshToken = refreshTokenInfo
                 )
             }
 
@@ -99,7 +101,8 @@ class HolderAgent(
                 }
                 subjectCredentialStore.storeCredential(
                     issuerSigned = validated.issuerSigned,
-                    scheme = credential.scheme
+                    scheme = credential.scheme,
+                    refreshToken = refreshTokenInfo
                 )
             }
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -108,6 +108,10 @@ class HolderAgent(
         }
     }
 
+    override suspend fun deleteCredential(credential: StoreEntry) {
+        subjectCredentialStore.deleteCredential(credential)
+    }
+
     private fun Holder.StoreCredentialInput.Iso.extractIssuerKey(): CoseKey? =
         issuerSigned.issuerAuth.unprotectedHeader?.certificateChain?.firstOrNull()?.let {
             catchingUnwrapped { X509Certificate.decodeFromDer(it) }.getOrNull()?.decodedPublicKey?.getOrNull()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -146,6 +146,30 @@ class HolderAgent(
         }.map { it.first }
     }
 
+    /** Gets a list of all stored credentials that are no longer valid, possibly filtered by [filterById]. */
+    override suspend fun getInvalidCredentials(filterById: String?): List<StoreEntry>? {
+        val availableCredentials = getCredentials() ?: return null
+
+        val presortedCredentials = availableCredentials
+            .filter { filterById == null || it.getDcApiId() == filterById }
+            .sortedBy { it.sortKey() }
+
+        val withRevocationStatusQueryIssued = presortedCredentials.map {
+            it to coroutineScope {
+                async {
+                    validator.checkCredentialFreshness(it)
+                }
+            }
+        }
+        withRevocationStatusQueryIssued.map { it.second }.joinAll()
+        val withRevocationStatusAvailable = withRevocationStatusQueryIssued.map {
+            it.first to it.second.await()
+        }
+        return withRevocationStatusAvailable
+            .filter { !it.second.isFresh }
+            .map { it.first }
+    }
+
     /** Prefer credentials with support for selective disclosure. */
     private fun StoreEntry.sortKey(): Int = when (this) {
         is StoreEntry.Vc -> 2

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -108,8 +108,8 @@ class HolderAgent(
         }
     }
 
-    override suspend fun deleteCredential(credential: StoreEntry) {
-        subjectCredentialStore.deleteCredential(credential)
+    override suspend fun deleteCredential(id: Long) {
+        subjectCredentialStore.removeStoreEntryById(id)
     }
 
     private fun Holder.StoreCredentialInput.Iso.extractIssuerKey(): CoseKey? =
@@ -151,27 +151,8 @@ class HolderAgent(
     }
 
     /** Gets a list of all stored credentials that are no longer valid, possibly filtered by [filterById]. */
-    override suspend fun getInvalidCredentials(filterById: String?): List<StoreEntry>? {
-        val availableCredentials = getCredentials() ?: return null
-
-        val presortedCredentials = availableCredentials
-            .filter { filterById == null || it.getDcApiId() == filterById }
-            .sortedBy { it.sortKey() }
-
-        val withRevocationStatusQueryIssued = presortedCredentials.map {
-            it to coroutineScope {
-                async {
-                    validator.checkCredentialFreshness(it)
-                }
-            }
-        }
-        withRevocationStatusQueryIssued.map { it.second }.joinAll()
-        val withRevocationStatusAvailable = withRevocationStatusQueryIssued.map {
-            it.first to it.second.await()
-        }
-        return withRevocationStatusAvailable
-            .filter { !it.second.isFresh }
-            .map { it.first }
+    override suspend fun getInvalidCredentials(): List<Pair<Long, StoreEntry>> {
+        return subjectCredentialStore.getInvalidCredentials()
     }
 
     /** Prefer credentials with support for selective disclosure. */

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
@@ -50,7 +50,9 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
         } ?: credentials
     }
 
-    override suspend fun deleteCredential(credential: SubjectCredentialStore.StoreEntry) {
-        credentials.removeAll { it.getDcApiId() == credential.getDcApiId() }
+    override suspend fun removeStoreEntryById(storeEntryId: Long) {
+        // No-op: This functionality is not required for this store implementation
     }
+
+    override suspend fun getInvalidCredentials(): List<Pair<Long, SubjectCredentialStore.StoreEntry>> = emptyList()
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
@@ -16,7 +16,7 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
         vc: VerifiableCredentialJws,
         vcSerialized: String,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: RefreshTokenInfo?,
+        refreshToken: CredentialRenewalInfo?,
     ) = SubjectCredentialStore.StoreEntry.Vc(vcSerialized, vc, scheme.schemaUri)
         .also { credentials += it }
 
@@ -25,14 +25,14 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
         vcSerialized: String,
         disclosures: Map<String, SelectiveDisclosureItem?>,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: RefreshTokenInfo?,
+        refreshToken: CredentialRenewalInfo?,
     ) = SubjectCredentialStore.StoreEntry.SdJwt(vcSerialized, vc, disclosures, scheme.schemaUri)
         .also { credentials += it }
 
     override suspend fun storeCredential(
         issuerSigned: IssuerSigned,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: RefreshTokenInfo?,
+        refreshToken: CredentialRenewalInfo?,
     ) = SubjectCredentialStore.StoreEntry.Iso(issuerSigned, scheme.schemaUri)
         .also { credentials += it }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
@@ -15,7 +15,8 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
     override suspend fun storeCredential(
         vc: VerifiableCredentialJws,
         vcSerialized: String,
-        scheme: ConstantIndex.CredentialScheme
+        scheme: ConstantIndex.CredentialScheme,
+        refreshToken: RefreshTokenInfo?,
     ) = SubjectCredentialStore.StoreEntry.Vc(vcSerialized, vc, scheme.schemaUri)
         .also { credentials += it }
 
@@ -23,13 +24,15 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
         vc: VerifiableCredentialSdJwt,
         vcSerialized: String,
         disclosures: Map<String, SelectiveDisclosureItem?>,
-        scheme: ConstantIndex.CredentialScheme
+        scheme: ConstantIndex.CredentialScheme,
+        refreshToken: RefreshTokenInfo?,
     ) = SubjectCredentialStore.StoreEntry.SdJwt(vcSerialized, vc, disclosures, scheme.schemaUri)
         .also { credentials += it }
 
     override suspend fun storeCredential(
         issuerSigned: IssuerSigned,
-        scheme: ConstantIndex.CredentialScheme
+        scheme: ConstantIndex.CredentialScheme,
+        refreshToken: RefreshTokenInfo?,
     ) = SubjectCredentialStore.StoreEntry.Iso(issuerSigned, scheme.schemaUri)
         .also { credentials += it }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
@@ -49,10 +49,4 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
             }.toList()
         } ?: credentials
     }
-
-    override suspend fun removeStoreEntryById(storeEntryId: Long) {
-        // No-op: This functionality is not required for this store implementation
-    }
-
-    override suspend fun getInvalidCredentials(): List<Pair<Long, SubjectCredentialStore.StoreEntry>> = emptyList()
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
@@ -49,4 +49,8 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
             }.toList()
         } ?: credentials
     }
+
+    override suspend fun deleteCredential(credential: SubjectCredentialStore.StoreEntry) {
+        credentials.removeAll { it.getDcApiId() == credential.getDcApiId() }
+    }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
@@ -16,8 +16,8 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
         vc: VerifiableCredentialJws,
         vcSerialized: String,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: CredentialRenewalInfo?,
-    ) = SubjectCredentialStore.StoreEntry.Vc(vcSerialized, vc, scheme.schemaUri, refreshToken)
+        renewalInfo: CredentialRenewalInfo?,
+    ) = SubjectCredentialStore.StoreEntry.Vc(vcSerialized, vc, scheme.schemaUri, renewalInfo)
         .also { credentials += it }
 
     override suspend fun storeCredential(
@@ -25,15 +25,15 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
         vcSerialized: String,
         disclosures: Map<String, SelectiveDisclosureItem?>,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: CredentialRenewalInfo?,
-    ) = SubjectCredentialStore.StoreEntry.SdJwt(vcSerialized, vc, disclosures, scheme.schemaUri, refreshToken)
+        renewalInfo: CredentialRenewalInfo?,
+    ) = SubjectCredentialStore.StoreEntry.SdJwt(vcSerialized, vc, disclosures, scheme.schemaUri, renewalInfo)
         .also { credentials += it }
 
     override suspend fun storeCredential(
         issuerSigned: IssuerSigned,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: CredentialRenewalInfo?,
-    ) = SubjectCredentialStore.StoreEntry.Iso(issuerSigned, scheme.schemaUri, refreshToken)
+        renewalInfo: CredentialRenewalInfo?,
+    ) = SubjectCredentialStore.StoreEntry.Iso(issuerSigned, scheme.schemaUri, renewalInfo)
         .also { credentials += it }
 
     override suspend fun getCredentials(

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemorySubjectCredentialStore.kt
@@ -17,7 +17,7 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
         vcSerialized: String,
         scheme: ConstantIndex.CredentialScheme,
         refreshToken: CredentialRenewalInfo?,
-    ) = SubjectCredentialStore.StoreEntry.Vc(vcSerialized, vc, scheme.schemaUri)
+    ) = SubjectCredentialStore.StoreEntry.Vc(vcSerialized, vc, scheme.schemaUri, refreshToken)
         .also { credentials += it }
 
     override suspend fun storeCredential(
@@ -26,14 +26,14 @@ class InMemorySubjectCredentialStore : SubjectCredentialStore {
         disclosures: Map<String, SelectiveDisclosureItem?>,
         scheme: ConstantIndex.CredentialScheme,
         refreshToken: CredentialRenewalInfo?,
-    ) = SubjectCredentialStore.StoreEntry.SdJwt(vcSerialized, vc, disclosures, scheme.schemaUri)
+    ) = SubjectCredentialStore.StoreEntry.SdJwt(vcSerialized, vc, disclosures, scheme.schemaUri, refreshToken)
         .also { credentials += it }
 
     override suspend fun storeCredential(
         issuerSigned: IssuerSigned,
         scheme: ConstantIndex.CredentialScheme,
         refreshToken: CredentialRenewalInfo?,
-    ) = SubjectCredentialStore.StoreEntry.Iso(issuerSigned, scheme.schemaUri)
+    ) = SubjectCredentialStore.StoreEntry.Iso(issuerSigned, scheme.schemaUri, refreshToken)
         .also { credentials += it }
 
     override suspend fun getCredentials(

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -79,7 +79,9 @@ interface SubjectCredentialStore {
     suspend fun getCredentials(credentialSchemes: Collection<ConstantIndex.CredentialScheme>? = null)
             : KmmResult<List<StoreEntry>>
 
-    suspend fun deleteCredential(credential: StoreEntry)
+    suspend fun removeStoreEntryById(storeEntryId: Long)
+
+    suspend fun getInvalidCredentials() : List<Pair<Long, StoreEntry>>
 
     @Serializable
     sealed interface StoreEntry {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -42,7 +42,7 @@ interface SubjectCredentialStore {
         vc: VerifiableCredentialJws,
         vcSerialized: String,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: CredentialRenewalInfo? = null,
+        renewalInfo: CredentialRenewalInfo? = null,
     ): StoreEntry
 
     /**
@@ -57,7 +57,7 @@ interface SubjectCredentialStore {
         vcSerialized: String,
         disclosures: Map<String, SelectiveDisclosureItem?>,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: CredentialRenewalInfo? = null,
+        renewalInfo: CredentialRenewalInfo? = null,
     ): StoreEntry
 
     /**
@@ -69,7 +69,7 @@ interface SubjectCredentialStore {
     suspend fun storeCredential(
         issuerSigned: IssuerSigned,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: CredentialRenewalInfo? = null,
+        renewalInfo: CredentialRenewalInfo? = null,
     ): StoreEntry
 
     /**
@@ -86,7 +86,7 @@ interface SubjectCredentialStore {
             get() = AttributeIndex.resolveSchemaUri(schemaUri) ?: getFallbackScheme()
         val credentialFormat: CredentialFormatEnum
         val claimFormat: ClaimFormat
-        val refreshToken: CredentialRenewalInfo?
+        val renewalInfo: CredentialRenewalInfo?
 
         fun getFallbackScheme(): ConstantIndex.CredentialScheme?
 
@@ -99,7 +99,7 @@ interface SubjectCredentialStore {
             @SerialName("schema-uri")
             override val schemaUri: String,
             @SerialName("credential-renewal-info")
-            override val refreshToken: CredentialRenewalInfo? = null,
+            override val renewalInfo: CredentialRenewalInfo? = null,
         ) : StoreEntry {
             override fun getFallbackScheme(): ConstantIndex.CredentialScheme =
                 VcFallbackCredentialScheme(vc.vc.type.first { it != VERIFIABLE_CREDENTIAL })
@@ -120,7 +120,7 @@ interface SubjectCredentialStore {
             @SerialName("schema-uri")
             override val schemaUri: String,
             @SerialName("credential-renewal-info")
-            override val refreshToken: CredentialRenewalInfo? = null,
+            override val renewalInfo: CredentialRenewalInfo? = null,
         ) : StoreEntry {
             override fun getFallbackScheme(): ConstantIndex.CredentialScheme =
                 SdJwtFallbackCredentialScheme(sdJwt.verifiableCredentialType)
@@ -136,7 +136,7 @@ interface SubjectCredentialStore {
             @SerialName("schema-uri")
             override val schemaUri: String,
             @SerialName("credential-renewal-info")
-            override val refreshToken: CredentialRenewalInfo? = null,
+            override val renewalInfo: CredentialRenewalInfo? = null,
         ) : StoreEntry {
             override fun getFallbackScheme(): ConstantIndex.CredentialScheme? = catchingUnwrapped {
                 IsoMdocFallbackCredentialScheme(issuerSigned.issuerAuth.payload?.docType!!)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -21,7 +21,6 @@ import at.asitplus.wallet.lib.data.VcFallbackCredentialScheme
 import at.asitplus.wallet.lib.data.VerifiableCredential
 import at.asitplus.wallet.lib.data.VerifiableCredentialJws
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
-import at.asitplus.wallet.lib.data.vckJsonSerializer
 import io.ktor.utils.io.core.toByteArray
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -43,7 +42,7 @@ interface SubjectCredentialStore {
         vc: VerifiableCredentialJws,
         vcSerialized: String,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: RefreshTokenInfo? = null,
+        refreshToken: CredentialRenewalInfo? = null,
     ): StoreEntry
 
     /**
@@ -58,7 +57,7 @@ interface SubjectCredentialStore {
         vcSerialized: String,
         disclosures: Map<String, SelectiveDisclosureItem?>,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: RefreshTokenInfo? = null,
+        refreshToken: CredentialRenewalInfo? = null,
     ): StoreEntry
 
     /**
@@ -70,7 +69,7 @@ interface SubjectCredentialStore {
     suspend fun storeCredential(
         issuerSigned: IssuerSigned,
         scheme: ConstantIndex.CredentialScheme,
-        refreshToken: RefreshTokenInfo? = null,
+        refreshToken: CredentialRenewalInfo? = null,
     ): StoreEntry
 
     /**
@@ -87,7 +86,7 @@ interface SubjectCredentialStore {
             get() = AttributeIndex.resolveSchemaUri(schemaUri) ?: getFallbackScheme()
         val credentialFormat: CredentialFormatEnum
         val claimFormat: ClaimFormat
-        val refreshToken: RefreshTokenInfo?
+        val refreshToken: CredentialRenewalInfo?
 
         fun getFallbackScheme(): ConstantIndex.CredentialScheme?
 
@@ -99,8 +98,8 @@ interface SubjectCredentialStore {
             val vc: VerifiableCredentialJws,
             @SerialName("schema-uri")
             override val schemaUri: String,
-            @SerialName("refresh-token-info")
-            override val refreshToken: RefreshTokenInfo? = null,
+            @SerialName("credential-renewal-info")
+            override val refreshToken: CredentialRenewalInfo? = null,
         ) : StoreEntry {
             override fun getFallbackScheme(): ConstantIndex.CredentialScheme =
                 VcFallbackCredentialScheme(vc.vc.type.first { it != VERIFIABLE_CREDENTIAL })
@@ -120,8 +119,8 @@ interface SubjectCredentialStore {
             val disclosures: Map<String, SelectiveDisclosureItem?>,
             @SerialName("schema-uri")
             override val schemaUri: String,
-            @SerialName("refresh-token-info")
-            override val refreshToken: RefreshTokenInfo? = null,
+            @SerialName("credential-renewal-info")
+            override val refreshToken: CredentialRenewalInfo? = null,
         ) : StoreEntry {
             override fun getFallbackScheme(): ConstantIndex.CredentialScheme =
                 SdJwtFallbackCredentialScheme(sdJwt.verifiableCredentialType)
@@ -136,8 +135,8 @@ interface SubjectCredentialStore {
             val issuerSigned: IssuerSigned,
             @SerialName("schema-uri")
             override val schemaUri: String,
-            @SerialName("refresh-token-info")
-            override val refreshToken: RefreshTokenInfo? = null,
+            @SerialName("credential-renewal-info")
+            override val refreshToken: CredentialRenewalInfo? = null,
         ) : StoreEntry {
             override fun getFallbackScheme(): ConstantIndex.CredentialScheme? = catchingUnwrapped {
                 IsoMdocFallbackCredentialScheme(issuerSigned.issuerAuth.payload?.docType!!)
@@ -165,7 +164,7 @@ interface SubjectCredentialStore {
  * Holds all information needed to refresh a credential, pass it to [OpenId4VciClient.refreshCredential].
  */
 @Serializable
-data class RefreshTokenInfo(
+data class CredentialRenewalInfo(
     /** Even if refresh token is not returned, other properties are used to initiate full re-issuance process */
     val refreshToken: String?,
     val issuerMetadata: IssuerMetadata,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -6,6 +6,9 @@ import at.asitplus.dif.ClaimFormat
 import at.asitplus.iso.IssuerSigned
 import at.asitplus.iso.sha256
 import at.asitplus.openid.CredentialFormatEnum
+import at.asitplus.openid.IssuerMetadata
+import at.asitplus.openid.OAuth2AuthorizationServerMetadata
+import at.asitplus.openid.SupportedCredentialFormat
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.wallet.lib.data.AttributeIndex
@@ -40,6 +43,7 @@ interface SubjectCredentialStore {
         vc: VerifiableCredentialJws,
         vcSerialized: String,
         scheme: ConstantIndex.CredentialScheme,
+        refreshToken: RefreshTokenInfo? = null,
     ): StoreEntry
 
     /**
@@ -54,6 +58,7 @@ interface SubjectCredentialStore {
         vcSerialized: String,
         disclosures: Map<String, SelectiveDisclosureItem?>,
         scheme: ConstantIndex.CredentialScheme,
+        refreshToken: RefreshTokenInfo? = null,
     ): StoreEntry
 
     /**
@@ -65,6 +70,7 @@ interface SubjectCredentialStore {
     suspend fun storeCredential(
         issuerSigned: IssuerSigned,
         scheme: ConstantIndex.CredentialScheme,
+        refreshToken: RefreshTokenInfo? = null,
     ): StoreEntry
 
     /**
@@ -81,6 +87,7 @@ interface SubjectCredentialStore {
             get() = AttributeIndex.resolveSchemaUri(schemaUri) ?: getFallbackScheme()
         val credentialFormat: CredentialFormatEnum
         val claimFormat: ClaimFormat
+        val refreshToken: RefreshTokenInfo?
 
         fun getFallbackScheme(): ConstantIndex.CredentialScheme?
 
@@ -92,6 +99,8 @@ interface SubjectCredentialStore {
             val vc: VerifiableCredentialJws,
             @SerialName("schema-uri")
             override val schemaUri: String,
+            @SerialName("refresh-token-info")
+            override val refreshToken: RefreshTokenInfo? = null,
         ) : StoreEntry {
             override fun getFallbackScheme(): ConstantIndex.CredentialScheme =
                 VcFallbackCredentialScheme(vc.vc.type.first { it != VERIFIABLE_CREDENTIAL })
@@ -111,6 +120,8 @@ interface SubjectCredentialStore {
             val disclosures: Map<String, SelectiveDisclosureItem?>,
             @SerialName("schema-uri")
             override val schemaUri: String,
+            @SerialName("refresh-token-info")
+            override val refreshToken: RefreshTokenInfo? = null,
         ) : StoreEntry {
             override fun getFallbackScheme(): ConstantIndex.CredentialScheme =
                 SdJwtFallbackCredentialScheme(sdJwt.verifiableCredentialType)
@@ -125,6 +136,8 @@ interface SubjectCredentialStore {
             val issuerSigned: IssuerSigned,
             @SerialName("schema-uri")
             override val schemaUri: String,
+            @SerialName("refresh-token-info")
+            override val refreshToken: RefreshTokenInfo? = null,
         ) : StoreEntry {
             override fun getFallbackScheme(): ConstantIndex.CredentialScheme? = catchingUnwrapped {
                 IsoMdocFallbackCredentialScheme(issuerSigned.issuerAuth.payload?.docType!!)
@@ -147,3 +160,16 @@ interface SubjectCredentialStore {
 
     }
 }
+
+/**
+ * Holds all information needed to refresh a credential, pass it to [OpenId4VciClient.refreshCredential].
+ */
+@Serializable
+data class RefreshTokenInfo(
+    /** Even if refresh token is not returned, other properties are used to initiate full re-issuance process */
+    val refreshToken: String?,
+    val issuerMetadata: IssuerMetadata,
+    val oauthMetadata: OAuth2AuthorizationServerMetadata,
+    val credentialFormat: SupportedCredentialFormat,
+    val credentialIdentifier: String,
+)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -79,6 +79,8 @@ interface SubjectCredentialStore {
     suspend fun getCredentials(credentialSchemes: Collection<ConstantIndex.CredentialScheme>? = null)
             : KmmResult<List<StoreEntry>>
 
+    suspend fun deleteCredential(credential: StoreEntry)
+
     @Serializable
     sealed interface StoreEntry {
         val schemaUri: String

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -79,10 +79,6 @@ interface SubjectCredentialStore {
     suspend fun getCredentials(credentialSchemes: Collection<ConstantIndex.CredentialScheme>? = null)
             : KmmResult<List<StoreEntry>>
 
-    suspend fun removeStoreEntryById(storeEntryId: Long)
-
-    suspend fun getInvalidCredentials() : List<Pair<Long, StoreEntry>>
-
     @Serializable
     sealed interface StoreEntry {
         val schemaUri: String


### PR DESCRIPTION
Added necessary changes for refresh token feature 
- Added `CredentialRenewalInfo` to `SubjectCredentialStore.StoreEntry`
- Moved the class `RefreshTokenInfo` from `OpenId4VciClient` to `SubjectCredentialStore.kt` and renamed it to `CredentialRenewalInfo` to better describe its role in the renewal process.
- Kept `RefreshTokenInfo` as a typealias in the original package for backward compatibility
-  Added support for refresh tokens in `BearerTokenService`