### PR TITLE
Remove Status Agents Generics

### DIFF
--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListIssuer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListIssuer.kt
@@ -1,10 +1,6 @@
 package at.asitplus.wallet.lib.agent
 
-import at.asitplus.signum.indispensable.cosef.CoseSigned
-import at.asitplus.signum.indispensable.josef.JwsSigned
-import at.asitplus.wallet.lib.data.StatusListToken
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationList
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListTokenPayload
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.StatusIssuer
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.StatusProvider
 
@@ -13,16 +9,17 @@ import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.StatusProvider
  *
  * It can issue Verifiable Credentials, revoke credentials and build a revocation list.
  */
-interface StatusListIssuer :
-    StatusIssuer<JwsSigned<StatusListTokenPayload>, CoseSigned<ByteArray>>,
-    StatusProvider<StatusListToken> {
+interface StatusListIssuer : StatusIssuer, StatusProvider {
 
     /**
      * Returns a revocation list which can either be
      * status list as defined in [TokenListStatus](https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-06.html)
      * or an identifier list as defined in ISO18013-5
      */
-    fun buildRevocationList(timePeriod: Int? = null, kind: RevocationList.Kind = RevocationList.Kind.STATUS_LIST): RevocationList?
+    fun buildRevocationList(
+        timePeriod: Int? = null,
+        kind: RevocationList.Kind = RevocationList.Kind.STATUS_LIST
+    ): RevocationList?
 
     /**
      * Sets the status of one specific credential to [at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus.Invalid].

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/agents/StatusIssuer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/agents/StatusIssuer.kt
@@ -1,21 +1,24 @@
 package at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents
 
+import at.asitplus.signum.indispensable.cosef.CoseSigned
+import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationList
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationList.Kind.STATUS_LIST
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListTokenPayload
 import kotlin.time.Instant
 
 /**
  * The Issuer gives updated status information to the Status Issuer, who creates a Status List
  * Token. The Status Issuer provides the Status List Token to the Status Provider
  */
-interface StatusIssuer<JsonSerialized: Any, CborSerialized: Any> {
+interface StatusIssuer {
     /**
      * @return a status list jwt.
      */
-    suspend fun issueStatusListJwt(time: Instant? = null, kind: RevocationList.Kind = STATUS_LIST): JsonSerialized
+    suspend fun issueStatusListJwt(time: Instant? = null, kind: RevocationList.Kind = STATUS_LIST): JwsSigned<StatusListTokenPayload>
 
     /**
      * @return a status list cwt.
      */
-    suspend fun issueStatusListCwt(time: Instant? = null, kind: RevocationList.Kind = STATUS_LIST): CborSerialized
+    suspend fun issueStatusListCwt(time: Instant? = null, kind: RevocationList.Kind = STATUS_LIST): CoseSigned<ByteArray>
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/agents/StatusProvider.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/agents/StatusProvider.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents
 
+import at.asitplus.wallet.lib.data.StatusListToken
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationList
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListAggregation
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.communication.primitives.StatusListTokenMediaType
@@ -9,7 +10,7 @@ import kotlin.time.Instant
  * The Status Issuer provides the Status List Token to the Status Provider, who serves the Status
  * List Token on a public, resolvable endpoint.
  */
-interface StatusProvider<StatusListToken : Any> {
+interface StatusProvider {
     /**
      * @return a status list based on the accepted and available types.
      */


### PR DESCRIPTION
Generics are unused in the current implementations and can be replaced with static types