### PR TITLE
Refactor issuer credential store

### DIFF
--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
@@ -28,37 +28,24 @@ class InMemoryIssuerCredentialStore(
     private val credentialMap = mutableMapOf<Int, MutableList<Credential>>()
 
     override suspend fun createStatusListIndex(
-        credential: CredentialToBeIssued,
         timePeriod: Int,
-    ): KmmResult<IssuerCredentialStore.StoredCredentialReference> = catching {
-        val list = credentialMap.getOrPut(timePeriod) { mutableListOf() }
-        val newIndex: ULong = (list.maxOfOrNull { it.statusListIndex } ?: 0U) + 1U
-        val vcId = uuid4().toString()
-        list += Credential(
-            vcId = vcId,
-            statusListIndex = newIndex,
-            status = TokenStatus.Valid,
-            expirationDate = credential.expiration,
-            scheme = credential.scheme,
-        )
-        IssuerCredentialStore.StoredCredentialReference(vcId, timePeriod, newIndex)
-    }
+    ): ULong = credentialMap.getOrPut(timePeriod) { mutableListOf() }.maxOfOrNull { it.statusListIndex + 1U } ?: 0U
 
-    override suspend fun updateStoredCredential(
-        reference: IssuerCredentialStore.StoredCredentialReference,
-        credential: Issuer.IssuedCredential,
-    ): KmmResult<IssuerCredentialStore.StoredCredentialReference> = catching {
-        val list = credentialMap.getOrPut(reference.timePeriod) { mutableListOf() }
-        if (list.find { it.vcId == reference.id } == null) {
+    override suspend fun storeCredential(
+        timePeriod: Int,
+        reference: ULong,
+        validUntil: Instant,
+        scheme: ConstantIndex.CredentialScheme
+    ): KmmResult<Boolean> = catching {
+        val list = credentialMap.getOrElse(timePeriod) { throw Exception("Credential $timePeriod not found") }
             list += Credential(
-                vcId = reference.id,
-                statusListIndex = reference.statusListIndex,
+                vcId = uuid4().toString(),
+                statusListIndex = reference,
                 status = TokenStatus.Valid,
-                expirationDate = credential.validUntil,
-                scheme = credential.scheme
+                expirationDate = validUntil,
+                scheme = scheme
             )
-        }
-        reference
+        true
     }
 
     override fun getStatusListView(timePeriod: Int): StatusListView {
@@ -100,9 +87,11 @@ class InMemoryIssuerCredentialStore(
     }
 }
 
-private val Issuer.IssuedCredential.validUntil: Instant
+val Issuer.IssuedCredential.validUntil: Instant
     get() = when (this) {
-        is Issuer.IssuedCredential.Iso -> this.issuerSigned.issuerAuth.payload?.validityInfo?.validUntil ?: Instant.DISTANT_PAST
-        is Issuer.IssuedCredential.VcJwt -> this.vc.expirationDate?: Instant.DISTANT_PAST
+        is Issuer.IssuedCredential.Iso -> this.issuerSigned.issuerAuth.payload?.validityInfo?.validUntil
+            ?: Instant.DISTANT_PAST
+
+        is Issuer.IssuedCredential.VcJwt -> this.vc.expirationDate ?: Instant.DISTANT_PAST
         is Issuer.IssuedCredential.VcSdJwt -> this.sdJwtVc.expiration ?: Instant.DISTANT_PAST
     }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
@@ -14,7 +14,6 @@ import kotlin.time.Instant
 class InMemoryIssuerCredentialStore(
     val tokenStatusBitSize: TokenStatusBitSize = TokenStatusBitSize.ONE,
 ) : IssuerCredentialStore, ReferencedTokenStore {
-    private val indexMutex = Mutex()
 
     data class Credential(
         val vcId: String,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
@@ -10,7 +10,6 @@ import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusBit
 import com.benasher44.uuid.uuid4
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlin.let
 import kotlin.time.Instant
 
 class InMemoryIssuerCredentialStore(
@@ -42,8 +41,7 @@ class InMemoryIssuerCredentialStore(
     override suspend fun storeCredential(
         timePeriod: Int,
         reference: ULong,
-        validUntil: Instant,
-        scheme: ConstantIndex.CredentialScheme
+        credential: Issuer.IssuedCredential
     ): KmmResult<Boolean> = catching {
         require(reference <= indexMap[timePeriod]!!) { "Invalid reference!" }
         val list = credentialMap.getOrPut(timePeriod) { mutableListOf() }
@@ -52,8 +50,8 @@ class InMemoryIssuerCredentialStore(
             vcId = uuid4().toString(),
             statusListIndex = reference,
             status = TokenStatus.Valid,
-            expirationDate = validUntil,
-            scheme = scheme
+            expirationDate = credential.validUntil,
+            scheme = credential.scheme
         )
         true
     }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
@@ -26,10 +26,11 @@ class InMemoryIssuerCredentialStore(
 
     /** Maps timePeriod to credentials */
     private val credentialMap = mutableMapOf<Int, MutableList<Credential>>()
+    private val indexMap = mutableMapOf<Int, MutableList<ULong>>()
 
     override suspend fun createStatusListIndex(
         timePeriod: Int,
-    ): ULong = credentialMap.getOrPut(timePeriod) { mutableListOf() }.maxOfOrNull { it.statusListIndex + 1U } ?: 0U
+    ): ULong = indexMap.getOrPut(timePeriod) { mutableListOf() }.maxOfOrNull { it + 1U } ?: 0U
 
     override suspend fun storeCredential(
         timePeriod: Int,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
@@ -10,6 +10,7 @@ import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusBit
 import com.benasher44.uuid.uuid4
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.let
 import kotlin.time.Instant
 
 class InMemoryIssuerCredentialStore(
@@ -31,13 +32,12 @@ class InMemoryIssuerCredentialStore(
     private val indexMap = mutableMapOf<Int, ULong>()
     private val indexMutex = Mutex()
 
-    override suspend fun createStatusListIndex(
-        timePeriod: Int,
-    ): ULong = indexMutex.withLock {
-        val next = (indexMap[timePeriod] ?: 0U) + 1U
-        indexMap[timePeriod] = next
-        next
-    }
+    override suspend fun createStatusListIndex(timePeriod: Int): ULong =
+        indexMutex.withLock {
+            indexMap.getOrPut(timePeriod) { 0u }.also { index ->
+                indexMap[timePeriod] = index + 1u
+            }
+        }
 
     override suspend fun storeCredential(
         timePeriod: Int,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
@@ -9,6 +9,7 @@ import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusBitSize
 import com.benasher44.uuid.uuid4
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.time.Instant
 
 class InMemoryIssuerCredentialStore(
@@ -25,11 +26,18 @@ class InMemoryIssuerCredentialStore(
 
     /** Maps timePeriod to credentials */
     private val credentialMap = mutableMapOf<Int, MutableList<Credential>>()
-    private val indexMap = mutableMapOf<Int, MutableList<ULong>>()
+
+    /** Index is map of timePeriod to counter */
+    private val indexMap = mutableMapOf<Int, ULong>()
+    private val indexMutex = Mutex()
 
     override suspend fun createStatusListIndex(
         timePeriod: Int,
-    ): ULong = indexMap.getOrPut(timePeriod) { mutableListOf() }.maxOfOrNull { it + 1U } ?: 0U
+    ): ULong = indexMutex.withLock {
+        val next = (indexMap[timePeriod] ?: 0U) + 1U
+        indexMap[timePeriod] = next
+        next
+    }
 
     override suspend fun storeCredential(
         timePeriod: Int,
@@ -37,14 +45,16 @@ class InMemoryIssuerCredentialStore(
         validUntil: Instant,
         scheme: ConstantIndex.CredentialScheme
     ): KmmResult<Boolean> = catching {
-        val list = credentialMap.getOrElse(timePeriod) { throw Exception("Credential $timePeriod not found") }
-            list += Credential(
-                vcId = uuid4().toString(),
-                statusListIndex = reference,
-                status = TokenStatus.Valid,
-                expirationDate = validUntil,
-                scheme = scheme
-            )
+        require(reference <= indexMap[timePeriod]!!) { "Invalid reference!" }
+        val list = credentialMap.getOrPut(timePeriod) { mutableListOf() }
+        require(list.find { it.statusListIndex == reference } == null) { "Reference already used!" }
+        list += Credential(
+            vcId = uuid4().toString(),
+            statusListIndex = reference,
+            status = TokenStatus.Valid,
+            expirationDate = validUntil,
+            scheme = scheme
+        )
         true
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -18,7 +18,6 @@ import at.asitplus.wallet.lib.cbor.CoseHeaderCertificate
 import at.asitplus.wallet.lib.cbor.CoseHeaderNone
 import at.asitplus.wallet.lib.cbor.SignCose
 import at.asitplus.wallet.lib.cbor.SignCoseFun
-import at.asitplus.wallet.lib.data.Status
 import at.asitplus.wallet.lib.data.VerifiableCredential
 import at.asitplus.wallet.lib.data.VerifiableCredentialJws
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
@@ -87,14 +86,14 @@ class IssuerAgent(
     ): Issuer.IssuedCredential {
         val expirationDate = credential.expiration
         val timePeriod = timePeriodProvider.getTimePeriodFor(issuanceDate)
-        val reference = issuerCredentialStore.createStatusListIndex(credential, timePeriod).getOrThrow()
+        val reference = issuerCredentialStore.createStatusListIndex(timePeriod)
         val coseKey = credential.subjectPublicKey.toCoseKey()
             .getOrElse { throw IllegalStateException("Could not create subject COSE key", it) }
         val deviceKeyInfo = DeviceKeyInfo(coseKey)
 
         //TODO add IdentifierListInfo option
         val credentialStatus = StatusListInfo(
-            index = reference.statusListIndex,
+            index = reference,
             uri = UniformResourceIdentifier(getRevocationListUrlFor(timePeriod)),
         )
         val mso = MobileSecurityObject(
@@ -130,7 +129,7 @@ class IssuerAgent(
             subjectPublicKey = credential.subjectPublicKey,
             userInfo = credential.userInfo
         ).also {
-            issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
+            issuerCredentialStore.storeCredential(timePeriod, reference, it.validUntil, it.scheme).getOrThrow()
         }
     }
 
@@ -141,9 +140,9 @@ class IssuerAgent(
         val vcId = "urn:uuid:${uuid4()}"
         val expirationDate = credential.expiration
         val timePeriod = timePeriodProvider.getTimePeriodFor(issuanceDate)
-        val reference = issuerCredentialStore.createStatusListIndex(credential, timePeriod).getOrThrow()
+        val reference = issuerCredentialStore.createStatusListIndex(timePeriod)
         val credentialStatus = StatusListInfo(
-            index = reference.statusListIndex,
+            index = reference,
             uri = UniformResourceIdentifier(getRevocationListUrlFor(timePeriod)),
         )
         val vc = VerifiableCredential(
@@ -171,7 +170,7 @@ class IssuerAgent(
             subjectPublicKey = credential.subjectPublicKey,
             userInfo = credential.userInfo,
         ).also {
-            issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
+            issuerCredentialStore.storeCredential(timePeriod, reference, it.validUntil, it.scheme).getOrThrow()
         }
     }
 
@@ -182,9 +181,9 @@ class IssuerAgent(
         val expirationDate = credential.expiration
         val timePeriod = timePeriodProvider.getTimePeriodFor(issuanceDate)
         val subjectId = credential.subjectPublicKey.didEncoded // TODO not necessarily!
-        val reference = issuerCredentialStore.createStatusListIndex(credential, timePeriod).getOrThrow()
+        val reference = issuerCredentialStore.createStatusListIndex(timePeriod)
         val credentialStatus = StatusListInfo(
-            index = reference.statusListIndex,
+            index = reference,
             uri = UniformResourceIdentifier(getRevocationListUrlFor(timePeriod)),
         )
         val (sdJwt, disclosures) = credential.claims.toSdJsonObject(randomSource, credential.sdAlgorithm)
@@ -226,7 +225,7 @@ class IssuerAgent(
             subjectPublicKey = credential.subjectPublicKey,
             userInfo = credential.userInfo,
         ).also {
-            issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
+            issuerCredentialStore.storeCredential(timePeriod, reference, it.validUntil, it.scheme).getOrThrow()
         }
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -129,7 +129,7 @@ class IssuerAgent(
             subjectPublicKey = credential.subjectPublicKey,
             userInfo = credential.userInfo
         ).also {
-            issuerCredentialStore.storeCredential(timePeriod, reference, it.validUntil, it.scheme).getOrThrow()
+            issuerCredentialStore.storeCredential(timePeriod, reference, it).getOrThrow()
         }
     }
 
@@ -170,7 +170,7 @@ class IssuerAgent(
             subjectPublicKey = credential.subjectPublicKey,
             userInfo = credential.userInfo,
         ).also {
-            issuerCredentialStore.storeCredential(timePeriod, reference, it.validUntil, it.scheme).getOrThrow()
+            issuerCredentialStore.storeCredential(timePeriod, reference, it).getOrThrow()
         }
     }
 
@@ -225,7 +225,7 @@ class IssuerAgent(
             subjectPublicKey = credential.subjectPublicKey,
             userInfo = credential.userInfo,
         ).also {
-            issuerCredentialStore.storeCredential(timePeriod, reference, it.validUntil, it.scheme).getOrThrow()
+            issuerCredentialStore.storeCredential(timePeriod, reference, it).getOrThrow()
         }
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerCredentialStore.kt
@@ -1,8 +1,6 @@
 package at.asitplus.wallet.lib.agent
 
 import at.asitplus.KmmResult
-import at.asitplus.wallet.lib.data.ConstantIndex
-import kotlin.time.Instant
 
 /**
  * Stores all issued credentials, keeps track of the index for the revocation list
@@ -23,7 +21,6 @@ interface IssuerCredentialStore {
     suspend fun storeCredential(
         timePeriod: Int,
         reference: ULong,
-        validUntil: Instant,
-        scheme: ConstantIndex.CredentialScheme
+        credential: Issuer.IssuedCredential
     ): KmmResult<Boolean>
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerCredentialStore.kt
@@ -1,34 +1,29 @@
 package at.asitplus.wallet.lib.agent
 
 import at.asitplus.KmmResult
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListView
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
+import at.asitplus.wallet.lib.data.ConstantIndex
+import kotlin.time.Instant
 
 /**
  * Stores all issued credentials, keeps track of the index for the revocation list
  */
 interface IssuerCredentialStore {
 
-    data class StoredCredentialReference(
-        val id: String,
-        val timePeriod: Int,
-        val statusListIndex: ULong,
-    )
-
     /**
      * Called by an [Issuer] when creating a new credential to get a `statusListIndex` first.
-     * [Issuer] will call [updateStoredCredential] with the issued credential afterwards.
+     * [Issuer] will call [storeCredential] with the issued credential afterwards.
      */
     suspend fun createStatusListIndex(
-        credential: CredentialToBeIssued,
         timePeriod: Int,
-    ): KmmResult<StoredCredentialReference>
+    ): ULong
 
     /**
      * Called by an [Issuer] when the credential has been signed and delivered to the holder.
      */
-    suspend fun updateStoredCredential(
-        reference: StoredCredentialReference,
-        credential: Issuer.IssuedCredential,
-    ): KmmResult<StoredCredentialReference>
+    suspend fun storeCredential(
+        timePeriod: Int,
+        reference: ULong,
+        validUntil: Instant,
+        scheme: ConstantIndex.CredentialScheme
+    ): KmmResult<Boolean>
 }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -5,7 +5,6 @@ import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.withFixtureGenerator
 import at.asitplus.wallet.lib.agent.FixedTimePeriodProvider.timePeriod
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignature
-import at.asitplus.wallet.lib.data.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
 import at.asitplus.wallet.lib.data.StatusListCwt
@@ -189,12 +188,16 @@ private fun verifyStatusList(statusList: StatusList, expectedRevokedIndexes: Lis
 }
 
 private suspend fun InMemoryIssuerCredentialStore.revokeCredentialsWithIndexes(revokedIndexes: List<ULong>) {
-    val cred = AtomicAttribute2023("sub", "name", "value", "text")
     val issuanceDate = Clock.System.now()
-    val expirationDate = issuanceDate + 60.seconds
-    for (i in 1..16) {
+    (1..16).forEach { _ ->
         val reference = createStatusListIndex(
             timePeriod
+        )
+        storeCredential(
+            timePeriod = timePeriod,
+            reference = reference,
+            validUntil = issuanceDate + 60.seconds,
+            scheme = ConstantIndex.AtomicAttribute2023,
         )
         if (revokedIndexes.contains(reference)) {
             setStatus(timePeriod, reference, TokenStatus.Invalid)
@@ -204,15 +207,13 @@ private suspend fun InMemoryIssuerCredentialStore.revokeCredentialsWithIndexes(r
 
 private suspend fun InMemoryIssuerCredentialStore.revokeRandomCredentials(): List<ULong> {
     val expectedRevocationList = mutableListOf<ULong>()
-    val cred = AtomicAttribute2023("sub", "name", "value", "text")
     val issuanceDate = Clock.System.now()
-    val expirationDate = issuanceDate + 60.seconds
-    for (i in 1..256) {
+    (1..256).forEach { _ ->
         val revListIndex = createStatusListIndex(timePeriod)
         storeCredential(
             timePeriod = timePeriod,
             reference = revListIndex,
-            validUntil = issuanceDate + 6000.seconds,
+            validUntil = issuanceDate + 60.seconds,
             scheme = ConstantIndex.AtomicAttribute2023,
         )
         if (Random.nextBoolean()) {

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.cosef.io.Base16Strict
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.withFixtureGenerator
@@ -28,28 +29,30 @@ import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.random.Random
 import kotlin.time.Clock
-import kotlin.time.Duration.Companion.seconds
 
 val AgentRevocationTest by testSuite {
 
     withFixtureGenerator(suspend {
         val issuerCredentialStore = InMemoryIssuerCredentialStore()
-        val expectedRevokedIndexes = issuerCredentialStore.revokeRandomCredentials()
-        object {
-            val issuerCredentialStore = issuerCredentialStore
-            val expectedRevokedIndexes = expectedRevokedIndexes
-            val issuer = IssuerAgent(
-                issuerCredentialStore = issuerCredentialStore,
-                identifier = "https://issuer.example.com/".toUri(),
-                randomSource = RandomSource.Default
-            )
-            val statusListIssuer = StatusListAgent(issuerCredentialStore = issuerCredentialStore)
-            val verifierKeyMaterial = EphemeralKeyWithoutCert()
+        val issuer = IssuerAgent(
+            issuerCredentialStore = issuerCredentialStore,
+            identifier = "https://issuer.example.com/".toUri(),
+            randomSource = RandomSource.Default
+        )
+        val verifierKeyMaterial = EphemeralKeyWithoutCert()
 
+        object {
+            val expectedRevokedIndexes: List<ULong> = listOf(1U, 2U, 4U, 6U, 7U, 9U, 10U, 12U, 13U, 14U)
+            val issuer = issuer
+            val issuerCredentialStore = issuerCredentialStore
+            val statusListIssuer = StatusListAgent(issuerCredentialStore = issuerCredentialStore)
+            val verifierKeyMaterial = verifierKeyMaterial
         }
     }) - {
 
         "revocation list should contain indices of revoked credential" {
+            batchIssueCredentials(15, it.issuer, it.verifierKeyMaterial.publicKey)
+            it.issuerCredentialStore.revokeCredentialsWithIndexes(it.expectedRevokedIndexes)
             val statusList = it.statusListIssuer.issueStatusListJwt()
                 .shouldNotBeNull().payload.revocationList.shouldBeInstanceOf<StatusList>()
 
@@ -57,15 +60,7 @@ val AgentRevocationTest by testSuite {
         }
 
         "aggregation should contain links if statuses have been set" {
-            it.issuer.issueCredential(
-                DummyCredentialDataProvider.getCredential(
-                    it.verifierKeyMaterial.publicKey,
-                    ConstantIndex.AtomicAttribute2023,
-                    PLAIN_JWT,
-                ).getOrThrow()
-            ).getOrElse {
-                fail("no issued credentials")
-            }
+            issueCredential(it.issuer, it.verifierKeyMaterial.publicKey)
             it.issuerCredentialStore.revokeCredentialsWithIndexes(listOf(0U))
 
             val statusListAggregation = it.statusListIssuer.provideStatusListAggregation()
@@ -73,15 +68,7 @@ val AgentRevocationTest by testSuite {
         }
 
         "issued jwt should have same status list as provided token when asking for jwt" {
-            it.issuer.issueCredential(
-                DummyCredentialDataProvider.getCredential(
-                    it.verifierKeyMaterial.publicKey,
-                    ConstantIndex.AtomicAttribute2023,
-                    PLAIN_JWT,
-                ).getOrThrow()
-            ).getOrElse {
-                fail("no issued credentials")
-            }
+            issueCredential(it.issuer, it.verifierKeyMaterial.publicKey)
             it.issuerCredentialStore.revokeCredentialsWithIndexes(listOf(0U))
 
             val timestamp = Clock.System.now()
@@ -97,15 +84,7 @@ val AgentRevocationTest by testSuite {
         }
 
         "issued cwt should have same status list as provided token when asking for cwt" {
-            it.issuer.issueCredential(
-                DummyCredentialDataProvider.getCredential(
-                    it.verifierKeyMaterial.publicKey,
-                    ConstantIndex.AtomicAttribute2023,
-                    PLAIN_JWT,
-                ).getOrThrow()
-            ).getOrElse {
-                fail("no issued credentials")
-            }
+            issueCredential(it.issuer, it.verifierKeyMaterial.publicKey)
             it.issuerCredentialStore.revokeCredentialsWithIndexes(listOf(0U))
 
             val timestamp = Clock.System.now()
@@ -135,15 +114,10 @@ val AgentRevocationTest by testSuite {
         }
 
         "credentials should contain status information" {
-            val result = it.issuer.issueCredential(
-                DummyCredentialDataProvider.getCredential(
-                    it.verifierKeyMaterial.publicKey,
-                    ConstantIndex.AtomicAttribute2023,
-                    PLAIN_JWT,
-                ).getOrThrow()
-            ).getOrElse {
-                fail("no issued credentials")
-            }.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
+            val result = issueCredential(
+                it.issuer,
+                it.verifierKeyMaterial.publicKey
+            ).shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
             ValidatorVcJws().verifyVcJws(result.signedVcJws, it.verifierKeyMaterial.publicKey)
                 .shouldBeInstanceOf<Verifier.VerifyCredentialResult.SuccessJwt>()
@@ -154,26 +128,37 @@ val AgentRevocationTest by testSuite {
         }
 
         "encoding to a known value works" {
-            val issuerCredentialStore = InMemoryIssuerCredentialStore()
-            val statusListIssuer = StatusListAgent(issuerCredentialStore = issuerCredentialStore)
             val expectedRevokedIndexes: List<ULong> = listOf(1U, 2U, 4U, 6U, 7U, 9U, 10U, 12U, 13U, 14U)
-            issuerCredentialStore.revokeCredentialsWithIndexes(expectedRevokedIndexes)
+            batchIssueCredentials(15, it.issuer, it.verifierKeyMaterial.publicKey)
+            it.issuerCredentialStore.revokeCredentialsWithIndexes(expectedRevokedIndexes)
 
-            val revocationList = statusListIssuer.buildRevocationList(timePeriod).shouldNotBeNull()
+            val revocationList = it.statusListIssuer.buildRevocationList(timePeriod).shouldNotBeNull()
 
             verifyStatusList(revocationList.shouldBeInstanceOf<StatusList>(), expectedRevokedIndexes)
         }
 
         "decoding a known value works" {
-            val expectedRevokedIndexes: List<ULong> = listOf(1U, 2U, 4U, 6U, 7U, 9U, 10U, 12U, 13U, 14U)
-
             val revocationList =
                 Json.decodeFromString<StatusList>("""{"lst": "eJy7VgYAAiQBTQ==", "bits": 1}""")
 
-            verifyStatusList(revocationList, expectedRevokedIndexes)
+            verifyStatusList(revocationList, it.expectedRevokedIndexes)
         }
     }
 }
+
+private suspend fun issueCredential(issuer: Issuer, publicKey: CryptoPublicKey) =
+    issuer.issueCredential(
+        DummyCredentialDataProvider.getCredential(
+            publicKey,
+            ConstantIndex.AtomicAttribute2023,
+            PLAIN_JWT,
+        ).getOrThrow()
+    ).getOrElse {
+        fail("no issued credentials")
+    }
+
+private suspend fun batchIssueCredentials(numCred: Int, issuer: Issuer, publicKey: CryptoPublicKey) =
+    (0..<numCred).forEach { _ -> issueCredential(issuer, publicKey) }
 
 private fun verifyStatusList(statusList: StatusList, expectedRevokedIndexes: List<ULong>) {
     val expectedRevocationStatuses = MutableList(expectedRevokedIndexes.max().toInt() + 1) {
@@ -188,38 +173,7 @@ private fun verifyStatusList(statusList: StatusList, expectedRevokedIndexes: Lis
 }
 
 private suspend fun InMemoryIssuerCredentialStore.revokeCredentialsWithIndexes(revokedIndexes: List<ULong>) {
-    val issuanceDate = Clock.System.now()
-    (1..16).forEach { _ ->
-        val reference = createStatusListIndex(
-            timePeriod
-        )
-        storeCredential(
-            timePeriod = timePeriod,
-            reference = reference,
-            validUntil = issuanceDate + 60.seconds,
-            scheme = ConstantIndex.AtomicAttribute2023,
-        )
-        if (revokedIndexes.contains(reference)) {
-            setStatus(timePeriod, reference, TokenStatus.Invalid)
-        }
+    revokedIndexes.forEach { id ->
+        setStatus(timePeriod, id, TokenStatus.Invalid)
     }
-}
-
-private suspend fun InMemoryIssuerCredentialStore.revokeRandomCredentials(): List<ULong> {
-    val expectedRevocationList = mutableListOf<ULong>()
-    val issuanceDate = Clock.System.now()
-    (1..256).forEach { _ ->
-        val revListIndex = createStatusListIndex(timePeriod)
-        storeCredential(
-            timePeriod = timePeriod,
-            reference = revListIndex,
-            validUntil = issuanceDate + 60.seconds,
-            scheme = ConstantIndex.AtomicAttribute2023,
-        )
-        if (Random.nextBoolean()) {
-            expectedRevocationList += revListIndex
-            setStatus(timePeriod, revListIndex, TokenStatus.Invalid)
-        }
-    }
-    return expectedRevocationList.toList()
 }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -1,7 +1,5 @@
 package at.asitplus.wallet.lib.agent
 
-import at.asitplus.openid.OidcUserInfo
-import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.signum.indispensable.cosef.io.Base16Strict
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.withFixtureGenerator
@@ -196,18 +194,10 @@ private suspend fun InMemoryIssuerCredentialStore.revokeCredentialsWithIndexes(r
     val expirationDate = issuanceDate + 60.seconds
     for (i in 1..16) {
         val reference = createStatusListIndex(
-            CredentialToBeIssued.VcJwt(
-                subject = cred,
-                expiration = expirationDate,
-                scheme = ConstantIndex.AtomicAttribute2023,
-                subjectPublicKey = EphemeralKeyWithoutCert().publicKey,
-                userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
-            ),
             timePeriod
-        ).getOrThrow()
-        val revListIndex = reference.statusListIndex
-        if (revokedIndexes.contains(revListIndex)) {
-            setStatus(timePeriod, revListIndex, TokenStatus.Invalid)
+        )
+        if (revokedIndexes.contains(reference)) {
+            setStatus(timePeriod, reference, TokenStatus.Invalid)
         }
     }
 }
@@ -218,16 +208,13 @@ private suspend fun InMemoryIssuerCredentialStore.revokeRandomCredentials(): Lis
     val issuanceDate = Clock.System.now()
     val expirationDate = issuanceDate + 60.seconds
     for (i in 1..256) {
-        val revListIndex = createStatusListIndex(
-            CredentialToBeIssued.VcJwt(
-                subject = cred,
-                expiration = expirationDate,
-                scheme = ConstantIndex.AtomicAttribute2023,
-                subjectPublicKey = EphemeralKeyWithoutCert().publicKey,
-                userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
-            ),
-            timePeriod
-        ).getOrThrow().statusListIndex
+        val revListIndex = createStatusListIndex(timePeriod)
+        storeCredential(
+            timePeriod = timePeriod,
+            reference = revListIndex,
+            validUntil = issuanceDate + 6000.seconds,
+            scheme = ConstantIndex.AtomicAttribute2023,
+        )
         if (Random.nextBoolean()) {
             expectedRevocationList += revListIndex
             setStatus(timePeriod, revListIndex, TokenStatus.Invalid)

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
@@ -1,7 +1,5 @@
 package at.asitplus.wallet.lib.agent
 
-import at.asitplus.openid.OidcUserInfo
-import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.signum.indispensable.josef.JwsHeader
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.withFixtureGenerator
@@ -24,7 +22,6 @@ import com.benasher44.uuid.uuid4
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.comparables.shouldNotBeGreaterThan
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlin.time.Clock
@@ -69,15 +66,8 @@ val ValidatorVcTest by testSuite {
                 val vcId = "urn:uuid:${uuid4()}"
                 val exp = expirationDate ?: (Clock.System.now() + 60.seconds)
                 val statusListIndex = issuerCredentialStore.createStatusListIndex(
-                    CredentialToBeIssued.VcJwt(
-                        subject = sub,
-                        expiration = exp,
-                        scheme = ConstantIndex.AtomicAttribute2023,
-                        subjectPublicKey = issuerKeyMaterial.publicKey,
-                        userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
-                    ),
                     FixedTimePeriodProvider.timePeriod
-                ).getOrThrow().statusListIndex
+                )
                 val credentialStatus = StatusListInfo(
                     index = statusListIndex,
                     uri = UniformResourceIdentifier(revocationListUrl),


### PR DESCRIPTION
Currently IssuerCredentialStore contains a function called `createStatusListIndex` which has a scope which is bigger than just providing an index and `updateStoredCredential` which at least in `InMemoryIssuerCredentialStore` does not update the credential under normal circumstances.

If I haven't misunderstood the current flow in `IssuerAgent` in conjunction with `InMemoryIssuerCredentialStore`
 + `createStatusListIndex` saves `StoredCredentialReference`
 + `updateStoredCredential` does nothing

If no real implementations of the interface block this I would propose the following:
 + `createStatusListIndex` purely returns the next free index which `InMemoryIssuerCredentialStore` tracks via a new `MutableMap`
 + `updateStoredCredential` renamed to `storeCredential` now saves to `storedCredentials`/Memory

In a future PR the `StatusListIndex` management will then be handled by a new class/interface in order to allow `Identifier`/`IdentifierList` tracking as well
