### PR TITLE
Fix issuer_state handling for PAR request_uri flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+Release 5.11.1:
+ - OAuth 2.0:
+   - Fix bug in `SimpleAuthorizationRequest` validating `issuer_state` on pushed authorization requests twice (and failing on the second time)
+
 Release 5.11.0:
  - Digital Credentials API:
    - Add request/response models for OpenID4VP and ISO 18013-7 Annex C flows, including protocol identifiers, wallet/verifier request options, and typed responses

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -269,7 +269,9 @@ class SimpleAuthorizationService(
         val actualRequest = request.extractPushedRequestParams()
         Napier.i("par called with $actualRequest")
         clientAuthenticationService.authenticateClient(httpRequest, actualRequest.clientId)
-        actualRequest.validate()
+        // PAR stores the request for later authorization. issuer_state is single-use and must only be consumed
+        // when /authorize is executed with the referenced request_uri.
+        actualRequest.validate(validateIssuerState = false)
         val requestUri = "urn:ietf:params:oauth:request_uri:${uuid4()}".also {
             requestUriToPushedAuthorizationRequest.put(it, actualRequest)
         }
@@ -375,7 +377,9 @@ class SimpleAuthorizationService(
      *  * [AuthenticationRequestParameters.scope] is validated by [strategy]
      *  * [AuthenticationRequestParameters.authorizationDetails] are validated by [strategy]
      */
-    private suspend fun AuthenticationRequestParameters.validate(): AuthenticationRequestParameters {
+    private suspend fun AuthenticationRequestParameters.validate(
+        validateIssuerState: Boolean = true,
+    ): AuthenticationRequestParameters {
         require(redirectUrl != null) { "redirect_uri not set" }
         scope?.let {
             strategy.filterScope(it)
@@ -384,7 +388,7 @@ class SimpleAuthorizationService(
         authorizationDetails?.let {
             strategy.validateAuthorizationDetails(it)
         }
-        if (issuerState != null) {
+        if (validateIssuerState && issuerState != null) {
             // The wallet could have started an auth code flow without any credential offer,
             // so the issuerState may be in fact null.
             if (!codeService.verifyAndRemove(issuerState!!))

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/OidvciOfferCodeTest.kt
@@ -181,6 +181,32 @@ val OidvciOfferCodeTest by testSuite {
             }
         }
 
+        test("process with code after credential offer over par and request_uri") {
+            val credentialOffer = it.authorizationService.credentialOfferWithAuthorizationCode(
+                credentialIssuer = it.issuer.publicContext,
+                configurationIds = listOf(),
+            )
+            val credentialIdToRequest = credentialOffer.configurationIds.first()
+            val credentialFormat = it.issuer.metadata.supportedCredentialConfigurations
+                ?.get(credentialIdToRequest)
+                .shouldNotBeNull()
+            val authnRequest = it.oauth2Client.createAuthRequest(
+                state = it.state,
+                scope = credentialFormat.scope.shouldNotBeNull(),
+                resource = it.issuer.metadata.credentialIssuer,
+                issuerState = credentialOffer.grants?.authorizationCode?.issuerState,
+            )
+            val parResponse = it.authorizationService.par(
+                request = authnRequest,
+                httpRequest = null
+            ).getOrThrow()
+            val authnResponse = it.authorizationService.authorize(
+                input = it.oauth2Client.createAuthRequestAfterPar(parResponse),
+                loadUserFun = { catching { DummyUserProvider.user } }
+            ).getOrThrow().shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+            authnResponse.params?.code.shouldNotBeNull()
+        }
+
         test("process with code after credential offer, and authorization details for one credential") {
             val credentialOffer = it.authorizationService.credentialOfferWithAuthorizationCode(
                 credentialIssuer = it.issuer.publicContext,


### PR DESCRIPTION
Do not consume issuer_state during PAR validation so it remains available for authorize(). Add a regression test for auth code issuance over PAR + request_uri.