### PR TITLE
Change: Matching unsatisfiable DCQL query no longer throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Release 5.12.0 (unreleased):
  - Remove code elements deprecated in 5.11.0
  - ISO mdoc:
    - Preserve `Document.errors` in parsed ISO document results instead of failing validation
+ - Change: Executing unsatisfiable DCQL queries no longer throws on matching, only on submission.
 
 Release 5.11.0:
  - Digital Credentials API:

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
@@ -285,30 +285,20 @@ sealed interface DCQLCredentialQuery {
             mdocCredentialDoctypeExtractor: (Credential) -> String,
             sdJwtCredentialTypeExtractor: (Credential) -> String,
             jwtVcCredentialTypeExtractor: (Credential) -> List<String>,
-        ): KmmResult<Unit> = catching {
-            when (credentialMetadataAndValidityConstraints) {
-                DCQLEmptyCredentialMetadataAndValidityConstraints -> {
-                    // noop
-                }
+        ): KmmResult<Unit> = when (credentialMetadataAndValidityConstraints) {
+            DCQLEmptyCredentialMetadataAndValidityConstraints -> KmmResult.success(Unit)
 
-                is DCQLIsoMdocCredentialMetadataAndValidityConstraints -> {
-                    credentialMetadataAndValidityConstraints.validate(
-                        mdocCredentialDoctypeExtractor(credential)
-                    ).getOrThrow()
-                }
+            is DCQLIsoMdocCredentialMetadataAndValidityConstraints -> credentialMetadataAndValidityConstraints.validate(
+                mdocCredentialDoctypeExtractor(credential)
+            )
 
-                is DCQLSdJwtCredentialMetadataAndValidityConstraints -> {
-                    credentialMetadataAndValidityConstraints.validate(
-                        sdJwtCredentialTypeExtractor(credential)
-                    ).getOrThrow()
-                }
+            is DCQLSdJwtCredentialMetadataAndValidityConstraints -> credentialMetadataAndValidityConstraints.validate(
+                sdJwtCredentialTypeExtractor(credential)
+            )
 
-                is DCQLJwtVcCredentialMetadataAndValidityConstraints -> {
-                    credentialMetadataAndValidityConstraints.validate(
-                        jwtVcCredentialTypeExtractor(credential)
-                    ).getOrThrow()
-                }
-            }
+            is DCQLJwtVcCredentialMetadataAndValidityConstraints -> credentialMetadataAndValidityConstraints.validate(
+                jwtVcCredentialTypeExtractor(credential)
+            )
         }
     }
 }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
@@ -16,7 +16,6 @@ import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.data.NonEmptyList
 import at.asitplus.data.NonEmptyList.Companion.nonEmptyListOf
-import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.openid.CredentialFormatEnum
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -131,17 +130,8 @@ data class DCQLQuery(
                 authorityKeyIdentifiers = authorityKeyIdentifiers,
             )
 
-            val satisfiableCredentialSetQueryOptions = findSatisfactoryCredentialSetQueryOptions(
-                credentialQueryMatches = credentialQueryMatches,
-                requestedCredentialSetQueries = requestedCredentialSetQueries,
-                credentialQueries
-            ).getOrElse {
-                throw IllegalArgumentException("Submission requirements cannot be satisfied.", it)
-            }
-
             DCQLQueryResult(
-                credentialQueryMatches = credentialQueryMatches,
-                satisfiableCredentialSetQueries = satisfiableCredentialSetQueryOptions
+                credentialQueryMatches = credentialQueryMatches
             )
         }
 
@@ -173,35 +163,6 @@ data class DCQLQuery(
                             matchingResult = it
                         )
                     }
-                }
-            }
-        }
-
-        fun <Credential : Any> findSatisfactoryCredentialSetQueryOptions(
-            credentialQueryMatches: Map<DCQLCredentialQueryIdentifier, List<DCQLCredentialSubmissionOption<Credential>>>,
-            requestedCredentialSetQueries: List<DCQLCredentialSetQuery>,
-            credentialQueries: List<DCQLCredentialQuery>,
-        ): KmmResult<List<DCQLCredentialSetQuery>> = catching {
-            requestedCredentialSetQueries.mapNotNull { credentialSetQuery ->
-                catching<DCQLCredentialSetQuery?> {
-                    credentialSetQuery.copy(
-                        options = credentialSetQuery.options.filter { option ->
-                            option.all {
-                                credentialQueryMatches[it]?.isNotEmpty() == true
-                            }
-                        }.toNonEmptyList()
-                    )
-                }.getOrElse {
-                    if (credentialSetQuery.required) {
-                        val failedQuery = credentialQueries.find {
-                            it.id.string in credentialSetQuery.options.list.flatten().map { it.string }
-                        }
-                        throw IllegalArgumentException(
-                            "Required credential set query is not satisfiable: $credentialSetQuery and $failedQuery}",
-                            it
-                        )
-                    }
-                    null
                 }
             }
         }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQuery.kt
@@ -13,7 +13,6 @@ package at.asitplus.openid.dcql
  */
 
 import at.asitplus.KmmResult
-import at.asitplus.catching
 import at.asitplus.data.NonEmptyList
 import at.asitplus.data.NonEmptyList.Companion.nonEmptyListOf
 import at.asitplus.openid.CredentialFormatEnum
@@ -75,9 +74,8 @@ data class DCQLQuery(
         credentialClaimStructureExtractor: (Credential) -> DCQLCredentialClaimStructure,
         satisfiesCryptographicHolderBinding: (Credential) -> Boolean,
         authorityKeyIdentifiers: (Credential) -> Collection<DCQLAuthorityKeyIdentifier>,
-    ): KmmResult<DCQLQueryResult<Credential>> = Procedures.executeQuery(
+    ): DCQLQueryResult<Credential> = Procedures.executeQuery(
         credentialQueries = credentials,
-        requestedCredentialSetQueries = requestedCredentialSetQueries,
         availableCredentials = availableCredentials,
         credentialFormatExtractor = credentialFormatExtractor,
         mdocCredentialDoctypeExtractor = mdocCredentialDoctypeExtractor,
@@ -86,6 +84,13 @@ data class DCQLQuery(
         credentialClaimStructureExtractor = credentialClaimStructureExtractor,
         satisfiesCryptographicHolderBinding = satisfiesCryptographicHolderBinding,
         authorityKeyIdentifiers = authorityKeyIdentifiers,
+    )
+
+    fun isSatisfiedWith(
+        credentialSubmissions: Set<DCQLCredentialQueryIdentifier>,
+    ) = Procedures.isSatisfactoryCredentialSubmission(
+        credentialSubmissions = credentialSubmissions,
+        requestedCredentialSetQueries = requestedCredentialSetQueries,
     )
 
     object Procedures {
@@ -108,7 +113,6 @@ data class DCQLQuery(
          */
         fun <Credential : Any> executeQuery(
             credentialQueries: List<DCQLCredentialQuery>,
-            requestedCredentialSetQueries: List<DCQLCredentialSetQuery>,
             availableCredentials: List<Credential>,
             credentialFormatExtractor: (Credential) -> CredentialFormatEnum,
             mdocCredentialDoctypeExtractor: (Credential) -> String,
@@ -117,8 +121,8 @@ data class DCQLQuery(
             credentialClaimStructureExtractor: (Credential) -> DCQLCredentialClaimStructure,
             satisfiesCryptographicHolderBinding: (Credential) -> Boolean,
             authorityKeyIdentifiers: (Credential) -> Collection<DCQLAuthorityKeyIdentifier>,
-        ): KmmResult<DCQLQueryResult<Credential>> = catching {
-            val credentialQueryMatches = findCredentialQueryMatches(
+        ): DCQLQueryResult<Credential> = DCQLQueryResult(
+            credentialQueryMatches = findCredentialQueryMatches(
                 credentialQueries = credentialQueries,
                 availableCredentials = availableCredentials,
                 credentialFormatExtractor = credentialFormatExtractor,
@@ -129,11 +133,7 @@ data class DCQLQuery(
                 satisfiesCryptographicHolderBinding = satisfiesCryptographicHolderBinding,
                 authorityKeyIdentifiers = authorityKeyIdentifiers,
             )
-
-            DCQLQueryResult(
-                credentialQueryMatches = credentialQueryMatches
-            )
-        }
+        )
 
         fun <Credential : Any> findCredentialQueryMatches(
             credentialQueries: List<DCQLCredentialQuery>,

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQueryResult.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQueryResult.kt
@@ -1,8 +1,7 @@
 package at.asitplus.openid.dcql
 
 data class DCQLQueryResult<Credential: Any>(
-    val credentialQueryMatches: Map<DCQLCredentialQueryIdentifier, List<DCQLCredentialSubmissionOption<Credential>>>,
-    val satisfiableCredentialSetQueries: List<DCQLCredentialSetQuery>
+    val credentialQueryMatches: Map<DCQLCredentialQueryIdentifier, List<DCQLCredentialSubmissionOption<Credential>>>
 )
 
 

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLQueryTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLQueryTest.kt
@@ -1,5 +1,6 @@
 package at.asitplus.openid.dcql
 
+import at.asitplus.csc.or
 import at.asitplus.data.NonEmptyList.Companion.nonEmptyListOf
 import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.openid.CredentialFormatEnum
@@ -132,9 +133,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     ),
                 ) {
-                    shouldThrowAny {
-                        TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe false
                 }
             }
 
@@ -219,7 +218,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     )
                 ) {
-                    val result = TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
+                    val result = TestCredentialQueryAdapter(dcqlQuery).execute(it)
                     result.credentialQueryMatches shouldHaveSize 1
                     result.credentialQueryMatches.values.first() shouldHaveSize 1
                 }
@@ -304,9 +303,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     ),
                 ) {
-                    shouldThrowAny {
-                        TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe false
                 }
             }
 
@@ -387,7 +384,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     )
                 ) {
-                    val result = TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
+                    val result = TestCredentialQueryAdapter(dcqlQuery).execute(it)
                     result.credentialQueryMatches shouldHaveSize 1
                     result.credentialQueryMatches.values.first() shouldHaveSize 1
                 }
@@ -466,9 +463,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     ),
                 ) {
-                    shouldThrowAny {
-                        TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe false
                 }
             }
 
@@ -502,7 +497,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     )
                 ) {
-                    val result = TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
+                    val result = TestCredentialQueryAdapter(dcqlQuery).execute(it)
                     result.credentialQueryMatches shouldHaveSize 2
                     result.credentialQueryMatches.values.first() shouldHaveSize 1
                 }
@@ -658,9 +653,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     ),
                 ) {
-                    shouldThrowAny {
-                        TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe false
                 }
             }
 
@@ -692,7 +685,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     )
                 ) {
-                    TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe true
                 }
             }
         }
@@ -887,9 +880,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     ),
                 ) {
-                    shouldThrowAny {
-                        TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe false
                 }
             }
 
@@ -964,7 +955,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     )
                 ) {
-                    TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe true
                 }
             }
         }
@@ -1103,9 +1094,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     ),
                 ) {
-                    shouldThrowAny {
-                        TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe false
                 }
             }
 
@@ -1131,7 +1120,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     )
                 ) {
-                    TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe true
                 }
             }
         }
@@ -1285,9 +1274,7 @@ val DCQLQueryTest by testSuite {
                         ),
                     ),
                 ) {
-                    shouldThrowAny {
-                        TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe false
                 }
             }
 
@@ -1298,7 +1285,7 @@ val DCQLQueryTest by testSuite {
                         "valid2" to listOf(valid2),
                     )
                 ) {
-                    TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
+                    TestCredentialQueryAdapter(dcqlQuery).isSatisfiable(it) shouldBe true
                 }
             }
         }
@@ -1442,32 +1429,24 @@ val DCQLQueryTest by testSuite {
 
                 withData(testVector.second) {
                     val test = buildSdJwtValueCredential(it)
-                    shouldNotThrowAny {
-                        TestCredentialQueryAdapter(sdJwtDcqlQuery).execute(
-                            listOf(test)
-                        ).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(sdJwtDcqlQuery).isSatisfiable(
+                        listOf(test)
+                    ) shouldBe true
                 }
                 withData(testVector.second) {
-                    shouldNotThrowAny {
-                        TestCredentialQueryAdapter(mdocDcqlQuery).execute(
-                            listOf(buildMdocValueCredential(it))
-                        ).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(mdocDcqlQuery).isSatisfiable(
+                        listOf(buildMdocValueCredential(it))
+                    ) shouldBe true
                 }
                 withData(testVector.third) {
-                    shouldThrowAny {
-                        TestCredentialQueryAdapter(sdJwtDcqlQuery).execute(
-                            listOf(buildSdJwtValueCredential(it))
-                        ).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(sdJwtDcqlQuery).isSatisfiable(
+                        listOf(buildSdJwtValueCredential(it))
+                    ) shouldBe false
                 }
                 withData(testVector.third) {
-                    shouldThrowAny {
-                        TestCredentialQueryAdapter(mdocDcqlQuery).execute(
-                            listOf(buildMdocValueCredential(it))
-                        ).getOrThrow()
-                    }
+                    TestCredentialQueryAdapter(mdocDcqlQuery).isSatisfiable(
+                        listOf(buildMdocValueCredential(it))
+                    ) shouldBe false
                 }
             }
         }
@@ -1494,10 +1473,9 @@ val DCQLQueryTest by testSuite {
                         satisfiesCryptographicHolderBinding = it,
                     ),
                 )
-                val executionResult = TestCredentialQueryAdapter(sdJwtDcqlQuery).execute(
+                TestCredentialQueryAdapter(sdJwtDcqlQuery).isSatisfiable(
                     credentials
-                )
-                executionResult.isSuccess shouldBe it
+                ) shouldBe it
             }
         }
         "mdoc credential" - {
@@ -1521,10 +1499,9 @@ val DCQLQueryTest by testSuite {
                         satisfiesCryptographicHolderBinding = it
                     ),
                 )
-                val executionResult = TestCredentialQueryAdapter(mdocDcqlQuery).execute(
+                TestCredentialQueryAdapter(mdocDcqlQuery).isSatisfiable(
                     credentials
-                )
-                executionResult.isSuccess shouldBe it
+                ) shouldBe it
             }
         }
     }
@@ -1564,8 +1541,7 @@ val DCQLQueryTest by testSuite {
                         satisfiesCryptographicHolderBinding = true,
                     ),
                 )
-                val executionResult = TestCredentialQueryAdapter(sdJwtDcqlQuery).execute(credentials)
-                executionResult.isSuccess shouldBe it.isNotEmpty()
+                TestCredentialQueryAdapter(sdJwtDcqlQuery).isSatisfiable(credentials) shouldBe it.isNotEmpty()
             }
         }
         "authority key identifiers in mdoc credential" - {
@@ -1603,8 +1579,7 @@ val DCQLQueryTest by testSuite {
                         satisfiesCryptographicHolderBinding = true,
                     ),
                 )
-                val executionResult = TestCredentialQueryAdapter(mdocDcqlQuery).execute(credentials)
-                executionResult.isSuccess shouldBe it.isNotEmpty()
+                TestCredentialQueryAdapter(mdocDcqlQuery).isSatisfiable(credentials) shouldBe it.isNotEmpty()
             }
         }
     }

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLQueryTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLQueryTest.kt
@@ -220,7 +220,6 @@ val DCQLQueryTest by testSuite {
                     )
                 ) {
                     val result = TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
-                    result.satisfiableCredentialSetQueries shouldHaveSize 1
                     result.credentialQueryMatches shouldHaveSize 1
                     result.credentialQueryMatches.values.first() shouldHaveSize 1
                 }
@@ -389,7 +388,6 @@ val DCQLQueryTest by testSuite {
                     )
                 ) {
                     val result = TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
-                    result.satisfiableCredentialSetQueries shouldHaveSize 1
                     result.credentialQueryMatches shouldHaveSize 1
                     result.credentialQueryMatches.values.first() shouldHaveSize 1
                 }
@@ -505,7 +503,6 @@ val DCQLQueryTest by testSuite {
                     )
                 ) {
                     val result = TestCredentialQueryAdapter(dcqlQuery).execute(it).getOrThrow()
-                    result.satisfiableCredentialSetQueries shouldHaveSize 1
                     result.credentialQueryMatches shouldHaveSize 2
                     result.credentialQueryMatches.values.first() shouldHaveSize 1
                 }

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredentialQueryAdapter.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/TestCredentialQueryAdapter.kt
@@ -12,6 +12,7 @@ package at.asitplus.openid.dcql
  * see the "LICENSE" file for more details
  */
 
+import io.kotest.matchers.shouldBe
 import kotlin.jvm.JvmInline
 
 @JvmInline
@@ -57,4 +58,13 @@ value class TestCredentialQueryAdapter(val dcqlQuery: DCQLQuery) {
             it.authorityKeyIdentifiers
         }
     )
+
+    fun isSatisfiable(availableCredentials: List<TestCredential>): Boolean {
+        val matching = execute(availableCredentials)
+        return dcqlQuery.isSatisfiedWith(
+            matching.credentialQueryMatches.filter {
+                it.value.isNotEmpty()
+            }.keys
+        )
+    }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -323,10 +323,12 @@ class HolderAgent(
     override suspend fun matchDCQLQueryAgainstCredentialStore(
         dcqlQuery: DCQLQuery,
         filterById: String?,
-    ): KmmResult<DCQLQueryResult<StoreEntry>> = DCQLQueryAdapter(dcqlQuery).select(
-        credentials = getValidCredentialsByPriority(filterById)
-            ?: throw PresentationException("Credentials could not be retrieved from the store"),
-    )
+    ): KmmResult<DCQLQueryResult<StoreEntry>> = catching {
+        DCQLQueryAdapter(dcqlQuery).select(
+            credentials = getValidCredentialsByPriority(filterById)
+                ?: throw PresentationException("Credentials could not be retrieved from the store"),
+        )
+    }
 
     private fun PresentationSubmission.Companion.fromMatches(
         presentationId: String?,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -229,10 +229,9 @@ class HolderAgent(
 
         val requestedCredentialSetQueries =
             credentialPresentation.presentationRequest.dcqlQuery.requestedCredentialSetQueries
-        val allowsMultiple = dcqlQuery.credentials.filter { it.multiple ?: false }.map { it.id }.toSet()
         val credentialSubmissions = credentialPresentation.credentialQuerySubmissions
             ?: matchDCQLQueryAgainstCredentialStore(dcqlQuery).getOrThrow()
-                .toDefaultSubmission(allowsMultiple).getOrThrow()
+                .toDefaultSubmission(dcqlQuery).getOrThrow()
 
         DCQLQuery.Procedures.isSatisfactoryCredentialSubmission(
             credentialSubmissions = credentialSubmissions.keys,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/extensions/DCQLQueryResult.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/extensions/DCQLQueryResult.kt
@@ -4,19 +4,25 @@ import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
 import at.asitplus.openid.dcql.DCQLCredentialSubmissionOption
+import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.openid.dcql.DCQLQueryResult
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import io.github.aakira.napier.Napier
 
 fun DCQLQueryResult<SubjectCredentialStore.StoreEntry>.toDefaultSubmission(
-    allowsMultiple: Collection<DCQLCredentialQueryIdentifier> = listOf()
+    dcqlQuery: DCQLQuery,
 ): KmmResult<Map<DCQLCredentialQueryIdentifier, List<DCQLCredentialSubmissionOption<SubjectCredentialStore.StoreEntry>>>> =
     catching {
+        val allowsMultiple = dcqlQuery.credentials.filter { it.multiple ?: false }.map { it.id }.toSet()
         // submit the first options of the required queries by default
-        val queriesToBePresented = satisfiableCredentialSetQueries.filter {
+        val queriesToBePresented = dcqlQuery.requestedCredentialSetQueries.filter {
             it.required
         }.map {
-            it.options.first()
+            it.options.first {
+                it.all {
+                    it in this@toDefaultSubmission.credentialQueryMatches
+                }
+            }
         }.flatten()
 
         queriesToBePresented.associateWith { queryId ->

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/dcql/DCQLQueryProcedureAdapter.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/dcql/DCQLQueryProcedureAdapter.kt
@@ -45,7 +45,7 @@ import kotlin.jvm.JvmInline
 value class DCQLQueryAdapter(val dcqlQuery: DCQLQuery) {
     fun select(
         credentials: List<SubjectCredentialStore.StoreEntry>
-    ): KmmResult<DCQLQueryResult<SubjectCredentialStore.StoreEntry>> = dcqlQuery.execute(
+    ): DCQLQueryResult<SubjectCredentialStore.StoreEntry> = dcqlQuery.execute(
         availableCredentials = credentials,
         credentialFormatExtractor = { it.credentialFormat },
         mdocCredentialDoctypeExtractor = {

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/openid/dcql/DCQLQueryProcedureAdapterTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/openid/dcql/DCQLQueryProcedureAdapterTest.kt
@@ -88,43 +88,46 @@ val DCQLQueryProcedureAdapterTest by testSuite {
             )
         ).select(
             credentials = listOf(credential)
-        ).getOrThrow().credentialQueryMatches shouldHaveSize 1
+        ).credentialQueryMatches shouldHaveSize 1
 
-        DCQLQueryAdapter(
-            Json.decodeFromString<DCQLQuery>(
-                """
+        val dcqlQuery = Json.decodeFromString<DCQLQuery>(
+            """
+              {
+                "credential_sets": [
                   {
-                    "credential_sets": [
+                    "options": [
+                      ["pid_sd_jwt"]
+                    ]
+                  }
+                ],
+                "credentials": [
+                  {
+                    "id": "pid_sd_jwt",
+                    "format": "dc+sd-jwt",
+                    "meta": {
+                      "vct_values": ["AtomicAttribute2023"]
+                    },
+                    "claims": [
                       {
-                        "options": [
-                          ["pid_sd_jwt"]
-                        ]
-                      }
-                    ],
-                    "credentials": [
+                        "path": ["${ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME}"]
+                      },
                       {
-                        "id": "pid_sd_jwt",
-                        "format": "dc+sd-jwt",
-                        "meta": {
-                          "vct_values": ["AtomicAttribute2023"]
-                        },
-                        "claims": [
-                          {
-                            "path": ["${ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME}"]
-                          },
-                          {
-                            "path": ["iss"],
-                            "values": ["${issuerIdentifier.reversed()}"]
-                          }
-                        ]
+                        "path": ["iss"],
+                        "values": ["${issuerIdentifier.reversed()}"]
                       }
                     ]
                   }
-                """.trimIndent()
-            )
-        ).select(
+                ]
+              }
+            """.trimIndent()
+        )
+        DCQLQueryAdapter(dcqlQuery).select(
             credentials = listOf(credential)
-        ).isFailure shouldBe true
+        ).let {
+            dcqlQuery.isSatisfiedWith(it.credentialQueryMatches.filter {
+                it.value.isNotEmpty()
+            }.keys) shouldBe false
+        }
     }
 
     "Match authority key identifier" {
@@ -192,44 +195,47 @@ val DCQLQueryProcedureAdapterTest by testSuite {
             )
         ).select(
             credentials = listOf(credential)
-        ).getOrThrow().credentialQueryMatches shouldHaveSize 1
+        ).credentialQueryMatches shouldHaveSize 1
 
-        DCQLQueryAdapter(
-            Json.decodeFromString<DCQLQuery>(
-                """
+        val dcqlQuery = Json.decodeFromString<DCQLQuery>(
+            """
+              {
+                "credential_sets": [
                   {
-                    "credential_sets": [
+                    "options": [
+                      ["pid_sd_jwt"]
+                    ]
+                  }
+                ],
+                "credentials": [
+                  {
+                    "id": "pid_sd_jwt",
+                    "format": "dc+sd-jwt",
+                    "meta": {
+                      "vct_values": ["AtomicAttribute2023"]
+                    },
+                    "trusted_authorities": [
                       {
-                        "options": [
-                          ["pid_sd_jwt"]
-                        ]
+                        "type": "aki",
+                        "values": ["${aki.encodeToString(Base64UrlStrict).reversed()}"]
                       }
                     ],
-                    "credentials": [
+                    "claims": [
                       {
-                        "id": "pid_sd_jwt",
-                        "format": "dc+sd-jwt",
-                        "meta": {
-                          "vct_values": ["AtomicAttribute2023"]
-                        },
-                        "trusted_authorities": [
-                          {
-                            "type": "aki",
-                            "values": ["${aki.encodeToString(Base64UrlStrict).reversed()}"]
-                          }
-                        ],
-                        "claims": [
-                          {
-                            "path": ["${ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME}"]
-                          }
-                        ]
+                        "path": ["${ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME}"]
                       }
                     ]
                   }
-                """.trimIndent()
-            )
-        ).select(
+                ]
+              }
+            """.trimIndent()
+        )
+        DCQLQueryAdapter(dcqlQuery).select(
             credentials = listOf(credential)
-        ).isFailure shouldBe true
+        ).let {
+            dcqlQuery.isSatisfiedWith(it.credentialQueryMatches.filter {
+                it.value.isNotEmpty()
+            }.keys) shouldBe false
+        }
     }
 }


### PR DESCRIPTION
This allows us to see which credential sets are not satisfiable in the app.

Submitting an invalid presentation still throws.

This is a step towards more detailed failure information in the app