### PR TITLE
DCQL send raw VcJws when not requiring cryptographic holder binding 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,24 @@ Release 5.12.0 (unreleased):
      Kept `RefreshTokenInfo` in the original package for backward compatibility
    - Added `CredentialRenewalInfo` to `SubjectCredentialStore.StoreEntry`
    - Added support for refresh tokens in BearerTokenService
+   - Change: When no cryptographic holder binding is required, present raw W3C Verifiable Credentials
+   - Change: OpenId4VPRequestOptions now transports a presentation request directly instead of credentials and presentation mechanism
+   - Change: Return type of `Verifier.verifyPresentationSdJwt` from `VerifyPresentationResult` to `KmmResult<VerifyPresentationResult.SuccessSdJwt>`
+   - Change: Return type of `Verifier.verifyPresentationVcJwt` from `VerifyPresentationResult` to `KmmResult<VerifyPresentationResult.Success>`
+   - Change: Return type of `Verifier.verifyPresentationIsoMdoc` from `VerifyPresentationResult` to `KmmResult<VerifyPresentationResult.SuccessIso>`
+   - Add: `Verifier.verifyUnsignedVcJws`
+   - Add: `AuthnResponseResult.SuccessUnsigned`
+   - Add: `CreatePresentationResult.VcJws`
+   - Rename: `CreatePresentationResult.Signed` to `CreatePresentationResult.VpJws`
  - OAuth 2.0:
    - In `SimpleAuthorizationService` implement [JWT Response for OAuth Token Introspection](https://datatracker.ietf.org/doc/html/rfc9701/)
+- ISO MDOC:
+    - Change: Return type of `Iso180137AnnexCVerifier.validateResponse` from `Iso180137AnnexCResponseResult` to `KmmResult<Iso180137AnnexCResponseResult>`
 
 Release 5.11.1:
  - OAuth 2.0:
    - Fix bug in `SimpleAuthorizationRequest` validating `issuer_state` on pushed authorization requests twice (and failing on the second time)
+
 
 Release 5.11.0:
  - Digital Credentials API:

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
@@ -41,7 +41,7 @@ sealed interface DCQLCredentialQuery {
      *  OID4VP 1.0: multiple: OPTIONAL. A boolean which indicates whether multiple Credentials can be returned
      *  for this Credential Query. If omitted, the default value is false.
      */
-    val multiple: Boolean?
+    val multiple: Boolean
 
     /**
      * OID4VP 1.0: meta: REQUIRED. An object defining additional properties requested by the
@@ -68,7 +68,7 @@ sealed interface DCQLCredentialQuery {
      *  with Cryptographic Holder Binding is required. If set to false, the Verifier accepts a Credential without
      *  Cryptographic Holder Binding proof.
      */
-    val requireCryptographicHolderBinding: Boolean?
+    val requireCryptographicHolderBinding: Boolean
 
     /**
      * OID4VP 1.0: claims: OPTIONAL. A non-empty array of objects as defined in Section 6.3
@@ -95,9 +95,9 @@ sealed interface DCQLCredentialQuery {
             meta: DCQLCredentialMetadataAndValidityConstraints,
             claims: DCQLClaimsQueryList<DCQLClaimsQuery>? = null,
             claimSets: NonEmptyList<List<DCQLClaimsQueryIdentifier>>? = null,
-            multiple: Boolean? = false,
+            multiple: Boolean? = null,
             trustedAuthorities: NonEmptyList<DCQLTrustedAuthorityQueryEntry>? = null,
-            requireCryptographicHolderBinding: Boolean? = true,
+            requireCryptographicHolderBinding: Boolean? = null,
         ): DCQLCredentialQuery = when (format) {
             CredentialFormatEnum.JWT_VC -> DCQLJwtVcCredentialQuery(
                 id = id,
@@ -107,9 +107,9 @@ sealed interface DCQLCredentialQuery {
                     it as DCQLJsonClaimsQuery
                 }?.toNonEmptyList()?.let(::DCQLClaimsQueryList),
                 claimSets = claimSets,
-                multiple = multiple,
+                multiple = multiple ?: Defaults.MULTIPLE,
                 trustedAuthorities = trustedAuthorities,
-                requireCryptographicHolderBinding = requireCryptographicHolderBinding,
+                requireCryptographicHolderBinding = requireCryptographicHolderBinding ?: Defaults.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING,
             )
 
             CredentialFormatEnum.DC_SD_JWT -> DCQLSdJwtCredentialQuery(
@@ -120,9 +120,9 @@ sealed interface DCQLCredentialQuery {
                     it as DCQLJsonClaimsQuery
                 }?.toNonEmptyList()?.let(::DCQLClaimsQueryList),
                 claimSets = claimSets,
-                multiple = multiple,
+                multiple = multiple ?: Defaults.MULTIPLE,
                 trustedAuthorities = trustedAuthorities,
-                requireCryptographicHolderBinding = requireCryptographicHolderBinding,
+                requireCryptographicHolderBinding = requireCryptographicHolderBinding ?: Defaults.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING,
             )
 
             CredentialFormatEnum.MSO_MDOC -> DCQLIsoMdocCredentialQuery(
@@ -133,13 +133,18 @@ sealed interface DCQLCredentialQuery {
                     it as DCQLIsoMdocClaimsQuery
                 }?.toNonEmptyList()?.let(::DCQLClaimsQueryList),
                 claimSets = claimSets,
-                multiple = multiple,
+                multiple = multiple ?: Defaults.MULTIPLE,
                 trustedAuthorities = trustedAuthorities,
-                requireCryptographicHolderBinding = requireCryptographicHolderBinding,
+                requireCryptographicHolderBinding = requireCryptographicHolderBinding ?: Defaults.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING,
             )
 
             else -> throw IllegalArgumentException("Unsupported credential format: ${format}")
         }
+    }
+
+    object Defaults {
+        const val MULTIPLE = false
+        const val REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING = true
     }
 
     object SerialNames {

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocCredentialQuery.kt
@@ -17,11 +17,11 @@ data class DCQLIsoMdocCredentialQuery(
     @SerialName(DCQLCredentialQuery.SerialNames.CLAIM_SETS)
     override val claimSets: NonEmptyList<List<DCQLClaimsQueryIdentifier>>? = null,
     @SerialName(DCQLCredentialQuery.SerialNames.MULTIPLE)
-    override val multiple: Boolean? = null,
+    override val multiple: Boolean = DCQLCredentialQuery.Defaults.MULTIPLE,
     @SerialName(DCQLCredentialQuery.SerialNames.TRUSTED_AUTHORITIES)
     override val trustedAuthorities: NonEmptyList<DCQLTrustedAuthorityQueryEntry>? = null,
     @SerialName(DCQLCredentialQuery.SerialNames.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING)
-    override val requireCryptographicHolderBinding: Boolean? = null,
+    override val requireCryptographicHolderBinding: Boolean = DCQLCredentialQuery.Defaults.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING,
     @SerialName(DCQLCredentialQuery.SerialNames.FORMAT)
     @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     override val format: CredentialFormatEnum = CREDENTIAL_FORMAT,

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLJwtVcCredentialQuery.kt
@@ -32,11 +32,11 @@ data class DCQLJwtVcCredentialQuery(
     @SerialName(DCQLCredentialQuery.SerialNames.CLAIM_SETS)
     override val claimSets: NonEmptyList<List<DCQLClaimsQueryIdentifier>>? = null,
     @SerialName(DCQLCredentialQuery.SerialNames.MULTIPLE)
-    override val multiple: Boolean? = false,
+    override val multiple: Boolean = DCQLCredentialQuery.Defaults.MULTIPLE,
     @SerialName(DCQLCredentialQuery.SerialNames.TRUSTED_AUTHORITIES)
     override val trustedAuthorities: NonEmptyList<DCQLTrustedAuthorityQueryEntry>? = null,
     @SerialName(DCQLCredentialQuery.SerialNames.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING)
-    override val requireCryptographicHolderBinding: Boolean? = true,
+    override val requireCryptographicHolderBinding: Boolean = DCQLCredentialQuery.Defaults.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING,
     @SerialName(DCQLCredentialQuery.SerialNames.FORMAT)
     @EncodeDefault(mode = EncodeDefault.Mode.ALWAYS)
     override val format: CredentialFormatEnum = CREDENTIAL_FORMAT,

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLSdJwtCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLSdJwtCredentialQuery.kt
@@ -23,11 +23,11 @@ data class DCQLSdJwtCredentialQuery(
     @SerialName(DCQLCredentialQuery.SerialNames.CLAIM_SETS)
     override val claimSets: NonEmptyList<List<DCQLClaimsQueryIdentifier>>? = null,
     @SerialName(DCQLCredentialQuery.SerialNames.MULTIPLE)
-    override val multiple: Boolean? = false,
+    override val multiple: Boolean = DCQLCredentialQuery.Defaults.MULTIPLE,
     @SerialName(DCQLCredentialQuery.SerialNames.TRUSTED_AUTHORITIES)
     override val trustedAuthorities: NonEmptyList<DCQLTrustedAuthorityQueryEntry>? = null,
     @SerialName(DCQLCredentialQuery.SerialNames.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING)
-    override val requireCryptographicHolderBinding: Boolean? = true,
+    override val requireCryptographicHolderBinding: Boolean = DCQLCredentialQuery.Defaults.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING,
     @SerialName(DCQLCredentialQuery.SerialNames.FORMAT)
     @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     override val format: CredentialFormatEnum = CREDENTIAL_FORMAT,

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
@@ -33,11 +33,14 @@ import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.agent.toStoreCredentialInput
+import at.asitplus.wallet.lib.data.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.CredentialPresentation.DCQLPresentation
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
+import at.asitplus.wallet.lib.data.CredentialSubject
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.data.vckJsonSerializer
@@ -49,7 +52,7 @@ import at.asitplus.wallet.lib.openid.AuthnResponseResult
 import at.asitplus.wallet.lib.openid.AuthnResponseResult.SuccessIso
 import at.asitplus.wallet.lib.openid.AuthnResponseResult.SuccessSdJwt
 import at.asitplus.wallet.lib.openid.ClientIdScheme
-import at.asitplus.wallet.lib.openid.DCQLMatchingResult
+import at.asitplus.wallet.lib.openid.CredentialPresentationRequestBuilder
 import at.asitplus.wallet.lib.openid.OpenId4VpVerifier
 import at.asitplus.wallet.lib.openid.OpenId4VpVerifier.CreationOptions
 import at.asitplus.wallet.lib.openid.OpenId4VpRequestOptions
@@ -101,17 +104,20 @@ val OpenId4VpWalletTest by testSuite {
                 storeCredentials: Boolean = true,
             ) {
                 val requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(
-                            credentialScheme = scheme,
-                            representation = representation,
-                            requestedAttributes = attributes.keys
-                        )
-                    ),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(
+                                credentialScheme = scheme,
+                                representation = representation,
+                                requestedAttributes = attributes.keys
+                            )
+                        ),
+                    ).toPresentationExchangeRequest(),
                     responseMode = responseMode,
                 )
-                if (storeCredentials)
+                if (storeCredentials) {
                     storeMockCredentials(scheme, representation, attributes)
+                }
                 setupRelyingPartyService(clientId, requestOptions) {
                     verifyReceivedAttributes(it, attributes)
                 }
@@ -151,6 +157,14 @@ val OpenId4VpWalletTest by testSuite {
                 scheme: ConstantIndex.CredentialScheme,
                 attributes: Map<String, Any>,
             ): CredentialToBeIssued = when (this) {
+                ConstantIndex.CredentialRepresentation.PLAIN_JWT -> CredentialToBeIssued.VcJwt(
+                    subject = AtomicAttribute2023("sub", "name", "value", "text"),
+                    expiration = Clock.System.now().plus(1.minutes),
+                    scheme = scheme,
+                    subjectPublicKey = keyMaterial.publicKey,
+                    userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
+                )
+
                 SD_JWT -> CredentialToBeIssued.VcSd(
                     claims = attributes.map { it.toClaimToBeIssued() },
                     expiration = Clock.System.now().plus(1.minutes),
@@ -167,8 +181,6 @@ val OpenId4VpWalletTest by testSuite {
                     subjectPublicKey = keyMaterial.publicKey,
                     userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
                 )
-
-                else -> TODO()
             }
 
             /**
@@ -229,7 +241,6 @@ val OpenId4VpWalletTest by testSuite {
 
         }
     } - {
-
         test("presentEuPidCredentialSdJwtDirectPost") {
             it.setup(
                 scheme = EuPidScheme,
@@ -249,7 +260,6 @@ val OpenId4VpWalletTest by testSuite {
 
             assertPresentation(it.countdownLatch)
         }
-
 
         test("presentEuPidCredentialIsoQuery") {
             it.setup(

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
@@ -43,6 +43,7 @@ import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.CredentialSubject
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
 import at.asitplus.wallet.lib.data.rfc3986.toUri
+import at.asitplus.wallet.lib.data.toJsonElement
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
@@ -53,6 +54,7 @@ import at.asitplus.wallet.lib.openid.AuthnResponseResult.SuccessIso
 import at.asitplus.wallet.lib.openid.AuthnResponseResult.SuccessSdJwt
 import at.asitplus.wallet.lib.openid.ClientIdScheme
 import at.asitplus.wallet.lib.openid.CredentialPresentationRequestBuilder
+import at.asitplus.wallet.lib.openid.DCQLMatchingResult
 import at.asitplus.wallet.lib.openid.OpenId4VpVerifier
 import at.asitplus.wallet.lib.openid.OpenId4VpVerifier.CreationOptions
 import at.asitplus.wallet.lib.openid.OpenId4VpRequestOptions
@@ -158,7 +160,7 @@ val OpenId4VpWalletTest by testSuite {
                 attributes: Map<String, Any>,
             ): CredentialToBeIssued = when (this) {
                 ConstantIndex.CredentialRepresentation.PLAIN_JWT -> CredentialToBeIssued.VcJwt(
-                    subject = AtomicAttribute2023("sub", "name", "value", "text"),
+                    subject = AtomicAttribute2023("sub", "name", "value", "text").toJsonElement(),
                     expiration = Clock.System.now().plus(1.minutes),
                     scheme = scheme,
                     subjectPublicKey = keyMaterial.publicKey,

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/TestUtils.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/TestUtils.kt
@@ -109,8 +109,7 @@ object TestUtils {
         credentials.shouldBeSingleton().also {
             it.first().shouldBeInstanceOf<Holder.StoreCredentialInput.SdJwt>().also {
                 it.scheme shouldBe EuPidScheme
-                ValidatorSdJwt().verifySdJwt(it.signedSdJwtVc, credentialKey)
-                    .shouldBeInstanceOf<Verifier.VerifyCredentialResult.SuccessSdJwt>()
+                ValidatorSdJwt().verifySdJwt(it.signedSdJwtVc, credentialKey).getOrThrow()
                     .disclosures.values.any {
                         it.claimName == claimName &&
                                 it.claimValue.jsonPrimitive.content == expectedClaimValue

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -4,6 +4,7 @@ import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
 import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
 import at.asitplus.wallet.lib.data.IsoDocumentParsed
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
+import at.asitplus.wallet.lib.data.VcJwsVerificationResultWrapper
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.VerifiablePresentationParsed
 import at.asitplus.wallet.lib.jws.SdJwtSigned
@@ -59,6 +60,14 @@ sealed class AuthnResponseResult {
      */
     data class Success(
         val vp: VerifiablePresentationParsed,
+        val state: String? = null,
+    ) : AuthnResponseResult()
+
+    /**
+     * Successfully decoded the response from the Wallet (VC in JWT without cryptographic holder binding)
+     */
+    data class SuccessUnsigned(
+        val vc: VcJwsVerificationResultWrapper,
         val state: String? = null,
     ) : AuthnResponseResult()
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CredentialMatchingResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CredentialMatchingResult.kt
@@ -5,6 +5,10 @@ import at.asitplus.wallet.lib.agent.HolderPresentationExchangeQueryMatchingResul
 import at.asitplus.wallet.lib.agent.HolderPresentationRequestMatchingResult
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 
+/**
+ * This interface represents the result of matching a [CredentialPresentationRequest]
+ * against a list of available credentials
+ */
 sealed interface CredentialMatchingResult<Credential: Any> {
     val presentationRequest: CredentialPresentationRequest
     val matchingResult: HolderPresentationRequestMatchingResult<Credential>

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CredentialPresentationRequestBuilder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CredentialPresentationRequestBuilder.kt
@@ -149,8 +149,6 @@ data class CredentialPresentationRequestBuilder(
                 .takeIf { it.isNotEmpty() } // requesting all claims if none are specified
                 ?.map { (attribute, _) ->
                     DCQLIsoMdocClaimsQuery(
-                        namespace = credentialScheme.isoNamespace!!,
-                        claimName = attribute,
                         path = DCQLClaimsPathPointer(credentialScheme.isoNamespace!!, attribute)
                     )
                 }?.toNonEmptyList()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CredentialPresentationRequestBuilder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CredentialPresentationRequestBuilder.kt
@@ -1,0 +1,169 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.data.NonEmptyList.Companion.nonEmptyListOf
+import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
+import at.asitplus.dif.DifInputDescriptor
+import at.asitplus.dif.FormatContainerJwt
+import at.asitplus.dif.FormatContainerSdJwt
+import at.asitplus.dif.FormatHolder
+import at.asitplus.dif.InputDescriptor
+import at.asitplus.dif.PresentationDefinition
+import at.asitplus.iso.DeviceRequest
+import at.asitplus.iso.DocRequest
+import at.asitplus.iso.ItemsRequest
+import at.asitplus.iso.ItemsRequestList
+import at.asitplus.iso.SingleItemsRequest
+import at.asitplus.openid.dcql.DCQLClaimsPathPointer
+import at.asitplus.openid.dcql.DCQLClaimsPathPointerSegment
+import at.asitplus.openid.dcql.DCQLClaimsQueryList
+import at.asitplus.openid.dcql.DCQLCredentialQuery
+import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
+import at.asitplus.openid.dcql.DCQLCredentialQueryList
+import at.asitplus.openid.dcql.DCQLIsoMdocClaimsQuery
+import at.asitplus.openid.dcql.DCQLIsoMdocCredentialMetadataAndValidityConstraints
+import at.asitplus.openid.dcql.DCQLIsoMdocCredentialQuery
+import at.asitplus.openid.dcql.DCQLJsonClaimsQuery
+import at.asitplus.openid.dcql.DCQLJwtVcCredentialMetadataAndValidityConstraints
+import at.asitplus.openid.dcql.DCQLJwtVcCredentialQuery
+import at.asitplus.openid.dcql.DCQLQuery
+import at.asitplus.openid.dcql.DCQLSdJwtCredentialMetadataAndValidityConstraints
+import at.asitplus.openid.dcql.DCQLSdJwtCredentialQuery
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
+import at.asitplus.wallet.lib.RequestOptionsCredential
+import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest
+import com.benasher44.uuid.uuid4
+
+/**
+ * This is a helper class to build a [CredentialPresentationRequest] from a collection of [RequestOptionsCredential]
+ * to be used in [OpenId4VpRequestOptions].
+ */
+data class CredentialPresentationRequestBuilder(
+    /** Requested credentials, should be at least one. */
+    val credentials: Collection<RequestOptionsCredential>,
+) {
+    fun toPresentationExchangeRequest() = CredentialPresentationRequest.PresentationExchangeRequest(
+        PresentationDefinition(
+            id = uuid4().toString(),
+            inputDescriptors = credentials.map {
+                it.toInputDescriptor()
+            }
+        )
+    )
+
+    private fun RequestOptionsCredential.toInputDescriptor(): InputDescriptor = DifInputDescriptor(
+        id = buildId(),
+        format = toFormatHolder(),
+        constraints = toConstraint(),
+    )
+
+    private fun RequestOptionsCredential.toFormatHolder() = when (this.representation) {
+        ConstantIndex.CredentialRepresentation.PLAIN_JWT -> FormatHolder(
+            jwtVp = FormatContainerJwt()
+        )
+
+        ConstantIndex.CredentialRepresentation.SD_JWT -> FormatHolder(
+            sdJwt = FormatContainerSdJwt()
+        )
+
+        ConstantIndex.CredentialRepresentation.ISO_MDOC -> FormatHolder(
+            msoMdoc = FormatContainerJwt()
+        )
+    }
+
+    fun toDCQLRequest(): CredentialPresentationRequest.DCQLRequest? {
+        return CredentialPresentationRequest.DCQLRequest(
+            DCQLQuery(
+                credentials = DCQLCredentialQueryList(
+                    credentials.mapNotNull {
+                        it.toQuery()
+                    }.takeIf {
+                        it.isNotEmpty()
+                    }?.toNonEmptyList() ?: return null
+                ),
+            )
+        )
+    }
+
+    fun toIso180137AnnexCDeviceRequest() = credentials.map {
+        if (it.representation != CredentialRepresentation.ISO_MDOC) {
+            throw UnsupportedOperationException("Wrong representation: Only ISO MDoc is supported")
+        }
+        val namespace = it.credentialScheme.isoNamespace ?: throw IllegalStateException("Missing namespace")
+        val docType = it.credentialScheme.isoDocType ?: throw IllegalStateException("Missing doc type")
+        val itemsRequestsListEntries = it.requestedAttributes?.map { reqAttr ->
+            SingleItemsRequest(reqAttr, false)
+        } ?: listOf()
+        val itemsRequestList = mapOf(namespace to ItemsRequestList(itemsRequestsListEntries))
+        DocRequest(ByteStringWrapper(ItemsRequest(docType, itemsRequestList)))
+    }.toTypedArray().let {
+        DeviceRequest("1.0", it)
+    }
+
+    private fun RequestOptionsCredential.toQuery(): DCQLCredentialQuery? = when (representation) {
+        CredentialRepresentation.PLAIN_JWT -> toJwtVcQuery()
+        CredentialRepresentation.SD_JWT -> toSdJwtQuery()
+        CredentialRepresentation.ISO_MDOC -> toIsoMdocQuery()
+    }
+
+    private fun RequestOptionsCredential.toJwtVcQuery() = credentialScheme.vcType?.let { vcType ->
+        DCQLJwtVcCredentialQuery(
+            id = DCQLCredentialQueryIdentifier(id),
+            meta = DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                typeValues = nonEmptyListOf(
+                    listOfNotNull(vcType)
+                )
+            ),
+            claims = nonOptionalAndOptionalRequestedAttributes()
+                .takeIf { it.isNotEmpty() } // requesting all claims if none are specified
+                ?.map { (attribute, _) ->
+                    DCQLJsonClaimsQuery(path = attribute.splitByDotToDcqlPath())
+                }?.toNonEmptyList()
+                ?.let { DCQLClaimsQueryList(it) }
+        )
+    }
+
+    private fun RequestOptionsCredential.toSdJwtQuery() = credentialScheme.sdJwtType?.let { sdJwtType ->
+        DCQLSdJwtCredentialQuery(
+            id = DCQLCredentialQueryIdentifier(id),
+            meta = DCQLSdJwtCredentialMetadataAndValidityConstraints(
+                vctValues = listOf(sdJwtType)
+            ),
+            claims = nonOptionalAndOptionalRequestedAttributes()
+                .takeIf { it.isNotEmpty() } // requesting all claims if none are specified
+                ?.map { (attribute, _) ->
+                    DCQLJsonClaimsQuery(path = attribute.splitByDotToDcqlPath())
+                }?.toNonEmptyList()
+                ?.let { DCQLClaimsQueryList(it) }
+        )
+    }
+
+    private fun RequestOptionsCredential.toIsoMdocQuery() = credentialScheme.isoDocType?.let { isoDocType ->
+        DCQLIsoMdocCredentialQuery(
+            id = DCQLCredentialQueryIdentifier(id),
+            meta = DCQLIsoMdocCredentialMetadataAndValidityConstraints(
+                doctypeValue = isoDocType
+            ),
+            claims = nonOptionalAndOptionalRequestedAttributes()
+                .takeIf { it.isNotEmpty() } // requesting all claims if none are specified
+                ?.map { (attribute, _) ->
+                    DCQLIsoMdocClaimsQuery(
+                        namespace = credentialScheme.isoNamespace!!,
+                        claimName = attribute,
+                        path = DCQLClaimsPathPointer(credentialScheme.isoNamespace!!, attribute)
+                    )
+                }?.toNonEmptyList()
+                ?.let { DCQLClaimsQueryList(it) }
+        )
+    }
+
+    // TODO: how to properly handle non-required claims?
+    private fun RequestOptionsCredential.nonOptionalAndOptionalRequestedAttributes(): List<Pair<String, Boolean>> =
+        (requestedAttributes?.map { it to true } ?: listOf()) +
+                (requestedOptionalAttributes?.map { it to false } ?: listOf())
+
+    private fun String.splitByDotToDcqlPath() = DCQLClaimsPathPointer(
+        split(".").map { DCQLClaimsPathPointerSegment.NameSegment(it) }.toNonEmptyList()
+    )
+}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -405,14 +405,14 @@ class OpenId4VpHolder(
         ?: throw InvalidRequest("could not parse audience")
 
     private fun RequestParametersFrom<AuthenticationRequestParameters>.callingOrigin() = when (this) {
-        is RequestParametersFrom.DcApiSigned<*> -> dcApiRequest.callingOrigin
-        is RequestParametersFrom.DcApiUnsigned<*> -> dcApiRequest.callingOrigin
+        is RequestParametersFrom.DcApiSigned -> dcApiRequest.callingOrigin
+        is RequestParametersFrom.DcApiUnsigned -> dcApiRequest.callingOrigin
         else -> null
     }
 
     private fun RequestParametersFrom<AuthenticationRequestParameters>.credentialId() = when (this) {
-        is RequestParametersFrom.DcApiSigned<*> -> dcApiRequest.credentialId
-        is RequestParametersFrom.DcApiUnsigned<*> -> dcApiRequest.credentialId
+        is RequestParametersFrom.DcApiSigned -> dcApiRequest.credentialId
+        is RequestParametersFrom.DcApiUnsigned -> dcApiRequest.credentialId
         else -> null
     }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestOptions.kt
@@ -1,44 +1,22 @@
 package at.asitplus.wallet.lib.openid
 
-import at.asitplus.data.NonEmptyList.Companion.nonEmptyListOf
-import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
-import at.asitplus.dif.DifInputDescriptor
-import at.asitplus.dif.FormatContainerJwt
-import at.asitplus.dif.FormatContainerSdJwt
-import at.asitplus.dif.InputDescriptor
-import at.asitplus.dif.PresentationDefinition
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.OpenIdConstants.ResponseMode
 import at.asitplus.openid.OpenIdConstants.SCOPE_OPENID
 import at.asitplus.openid.OpenIdConstants.SCOPE_PROFILE
 import at.asitplus.openid.OpenIdConstants.VP_TOKEN
 import at.asitplus.openid.TransactionData
-import at.asitplus.openid.dcql.DCQLClaimsPathPointer
-import at.asitplus.openid.dcql.DCQLClaimsPathPointerSegment
-import at.asitplus.openid.dcql.DCQLClaimsQueryList
-import at.asitplus.openid.dcql.DCQLCredentialQuery
-import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
-import at.asitplus.openid.dcql.DCQLCredentialQueryList
-import at.asitplus.openid.dcql.DCQLIsoMdocClaimsQuery
-import at.asitplus.openid.dcql.DCQLIsoMdocCredentialMetadataAndValidityConstraints
-import at.asitplus.openid.dcql.DCQLIsoMdocCredentialQuery
-import at.asitplus.openid.dcql.DCQLJsonClaimsQuery
-import at.asitplus.openid.dcql.DCQLJwtVcCredentialMetadataAndValidityConstraints
-import at.asitplus.openid.dcql.DCQLJwtVcCredentialQuery
-import at.asitplus.openid.dcql.DCQLQuery
-import at.asitplus.openid.dcql.DCQLSdJwtCredentialMetadataAndValidityConstraints
-import at.asitplus.openid.dcql.DCQLSdJwtCredentialQuery
 import at.asitplus.wallet.lib.RequestOptions
 import at.asitplus.wallet.lib.RequestOptionsCredential
-import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import com.benasher44.uuid.uuid4
 
 data class OpenId4VpRequestOptions(
-    /** Requested credentials, should be at least one. */
-    override val credentials: Set<RequestOptionsCredential>,
-
-    /** Presentation mechanism to be used for requesting credentials. */
-    val presentationMechanism: PresentationMechanismEnum = PresentationMechanismEnum.PresentationExchange,
+    /**
+     * Presentation mechanism to be used for requesting credentials.
+     * Use [CredentialPresentationRequestBuilder] for simple requests.
+     */
+    val presentationRequest: CredentialPresentationRequest?,
 
     /**
      * Response mode to request, see [OpenIdConstants.ResponseMode],
@@ -89,10 +67,49 @@ data class OpenId4VpRequestOptions(
      */
     val populateClientId: Boolean = true,
 ) : RequestOptions {
+    @Deprecated("Replace with primary constructor, building a presentation request using [CredentialPresentationRequestBuilder]")
+    constructor(
+        credentials: Set<RequestOptionsCredential>,
+        presentationMechanism: PresentationMechanismEnum = PresentationMechanismEnum.PresentationExchange,
+        responseMode: ResponseMode = ResponseMode.Fragment,
+        responseUrl: String? = null,
+        responseType: String = VP_TOKEN,
+        state: String = uuid4().toString(),
+        transactionData: List<TransactionData>? = null,
+        expectedOrigins: List<String>? = null,
+        populateClientId: Boolean = true,
+    ) : this(
+        presentationRequest = CredentialPresentationRequestBuilder(
+            credentials = credentials
+        ).let {
+            when(presentationMechanism) {
+                PresentationMechanismEnum.PresentationExchange -> it.toPresentationExchangeRequest()
+                PresentationMechanismEnum.DCQL -> it.toDCQLRequest()
+                PresentationMechanismEnum.DeviceRequest -> throw IllegalArgumentException("Invalid presentation mechanism for OpenId4VP: $presentationMechanism")
+            }
+        },
+        responseMode = responseMode,
+        responseUrl = responseUrl,
+        responseType = responseType,
+        state = state,
+        transactionData = transactionData,
+        expectedOrigins = expectedOrigins,
+        populateClientId = populateClientId,
+    )
+
     init {
         if (!transactionData.isNullOrEmpty()) {
-            val transactionIds = transactionData.map { it.credentialIds.toList() }.flatten().sorted().distinct()
-            val credentialIds = credentials.map { it.id }.sorted().distinct()
+            val transactionIds = transactionData.map { it.credentialIds.toList() }.flatten().toSet()
+            val credentialIds = when(presentationRequest) {
+                is CredentialPresentationRequest.DCQLRequest -> presentationRequest.dcqlQuery.credentials.map {
+                    it.id.string
+                }
+                is CredentialPresentationRequest.PresentationExchangeRequest -> presentationRequest.presentationDefinition.inputDescriptors.map {
+                    it.id
+                }
+
+                null -> setOf()
+            }.toSet()
             require(transactionIds == credentialIds) { "OpenId4VP defines that the credential_ids that must be part of a transaction_data element have to be an ID from InputDescriptor" }
         }
         if (isAnyDcApi) {
@@ -104,10 +121,7 @@ data class OpenId4VpRequestOptions(
     }
 
     val isDcql: Boolean
-        get() = presentationMechanism == PresentationMechanismEnum.DCQL
-
-    val isPresentationExchange
-        get() = presentationMechanism == PresentationMechanismEnum.PresentationExchange
+        get() = presentationRequest is CredentialPresentationRequest.DCQLRequest
 
     val isAnyDirectPost: Boolean
         get() = (responseMode == ResponseMode.DirectPost) ||
@@ -120,97 +134,5 @@ data class OpenId4VpRequestOptions(
         get() = responseType.contains(OpenIdConstants.ID_TOKEN)
 
     fun buildScope(): String = listOf(SCOPE_OPENID, SCOPE_PROFILE).joinToString(" ")
-
-    fun toDCQLQuery(): DCQLQuery? =
-        if (credentials.isEmpty()) null
-        else DCQLQuery(
-            credentials = DCQLCredentialQueryList(
-                credentials.mapNotNull { it.toQuery() }.takeIf { it.isNotEmpty() }?.toNonEmptyList()
-                    ?: return null
-            ),
-        )
-
-    private fun RequestOptionsCredential.toQuery(): DCQLCredentialQuery? = when (representation) {
-        CredentialRepresentation.PLAIN_JWT -> toJwtVcQuery()
-        CredentialRepresentation.SD_JWT -> toSdJwtQuery()
-        CredentialRepresentation.ISO_MDOC -> toIsoMdocQuery()
-    }
-
-    // TODO: how to properly handle non-required claims?
-    private fun RequestOptionsCredential.nonOptionalAndOptionalRequestedAttributes(): List<Pair<String, Boolean>> =
-        (requestedAttributes?.map { it to true } ?: listOf()) +
-                (requestedOptionalAttributes?.map { it to false } ?: listOf())
-
-    private fun RequestOptionsCredential.toJwtVcQuery() = credentialScheme.vcType?.let { vcType ->
-        DCQLJwtVcCredentialQuery(
-            id = DCQLCredentialQueryIdentifier(id),
-            meta = DCQLJwtVcCredentialMetadataAndValidityConstraints(
-                typeValues = nonEmptyListOf(
-                    listOfNotNull(vcType)
-                )
-            ),
-            claims = nonOptionalAndOptionalRequestedAttributes()
-                .takeIf { it.isNotEmpty() } // requesting all claims if none are specified
-                ?.map { (attribute, _) ->
-                    DCQLJsonClaimsQuery(path = attribute.splitByDotToDcqlPath())
-                }?.toNonEmptyList()
-                ?.let { DCQLClaimsQueryList(it) }
-        )
-    }
-
-    private fun RequestOptionsCredential.toSdJwtQuery() = credentialScheme.sdJwtType?.let { sdJwtType ->
-        DCQLSdJwtCredentialQuery(
-            id = DCQLCredentialQueryIdentifier(id),
-            meta = DCQLSdJwtCredentialMetadataAndValidityConstraints(
-                vctValues = listOf(sdJwtType)
-            ),
-            claims = nonOptionalAndOptionalRequestedAttributes()
-                .takeIf { it.isNotEmpty() } // requesting all claims if none are specified
-                ?.map { (attribute, _) ->
-                    DCQLJsonClaimsQuery(path = attribute.splitByDotToDcqlPath())
-                }?.toNonEmptyList()
-                ?.let { DCQLClaimsQueryList(it) }
-        )
-    }
-
-    private fun RequestOptionsCredential.toIsoMdocQuery() = credentialScheme.isoDocType?.let { isoDocType ->
-        DCQLIsoMdocCredentialQuery(
-            id = DCQLCredentialQueryIdentifier(id),
-            meta = DCQLIsoMdocCredentialMetadataAndValidityConstraints(
-                doctypeValue = isoDocType
-            ),
-            claims = nonOptionalAndOptionalRequestedAttributes()
-                .takeIf { it.isNotEmpty() } // requesting all claims if none are specified
-                ?.map { (attribute, _) ->
-                    DCQLIsoMdocClaimsQuery(
-                        path = DCQLClaimsPathPointer(credentialScheme.isoNamespace!!, attribute)
-                    )
-                }?.toNonEmptyList()
-                ?.let { DCQLClaimsQueryList(it) }
-        )
-    }
-
-    private fun String.splitByDotToDcqlPath() = DCQLClaimsPathPointer(
-        split(".").map { DCQLClaimsPathPointerSegment.NameSegment(it) }.toNonEmptyList()
-    )
-
-    fun toPresentationDefinition(
-        containerJwt: FormatContainerJwt,
-        containerSdJwt: FormatContainerSdJwt,
-    ): PresentationDefinition = PresentationDefinition(
-        id = uuid4().toString(),
-        inputDescriptors = toInputDescriptor(containerJwt, containerSdJwt)
-    )
-
-    fun toInputDescriptor(
-        containerJwt: FormatContainerJwt,
-        containerSdJwt: FormatContainerSdJwt,
-    ): List<InputDescriptor> = credentials.map {
-        DifInputDescriptor(
-            id = it.buildId(),
-            format = it.toFormatHolder(containerJwt, containerSdJwt),
-            constraints = it.toConstraint(),
-        )
-    }
 }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -8,6 +8,7 @@ import at.asitplus.dcapi.OpenID4VPDCAPIHandoverInfo
 import at.asitplus.dcapi.OpenId4VpResponse
 import at.asitplus.dcapi.SessionTranscriptContentHashable
 import at.asitplus.dif.ClaimFormat
+import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.dif.FormatContainerJwt
 import at.asitplus.dif.FormatContainerSdJwt
 import at.asitplus.dif.PresentationSubmissionDescriptor
@@ -57,6 +58,7 @@ import at.asitplus.wallet.lib.agent.Verifier.VerifyPresentationResult
 import at.asitplus.wallet.lib.agent.VerifierAgent
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
 import at.asitplus.wallet.lib.data.toBase64UrlJsonString
 import at.asitplus.wallet.lib.data.vckJsonSerializer
@@ -74,7 +76,7 @@ import at.asitplus.wallet.lib.oidvci.encodeToParameters
 import at.asitplus.wallet.lib.utils.DefaultMapStore
 import at.asitplus.wallet.lib.utils.MapStore
 import io.github.aakira.napier.Napier
-import io.ktor.http.*
+import io.ktor.http.URLBuilder
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
@@ -366,11 +368,36 @@ class OpenId4VpVerifier(
         idTokenType = if (isSiop) IdTokenType.SUBJECT_SIGNED.text else null,
         responseMode = responseMode,
         state = if (!isAnyDcApi) state else null,
-        dcqlQuery = if (isDcql) toDCQLQuery() else null,
-        presentationDefinition = if (isPresentationExchange)
-            toPresentationDefinition(containerJwt, containerSdJwt) else null,
+        dcqlQuery = (presentationRequest as? CredentialPresentationRequest.DCQLRequest)?.dcqlQuery,
+        presentationDefinition = (presentationRequest as? CredentialPresentationRequest.PresentationExchangeRequest)?.presentationDefinition?.run {
+            copy(
+                inputDescriptors = inputDescriptors.map {
+                    when (val inputDescriptor = it) {
+                        is DifInputDescriptor -> inputDescriptor.replaceAvailableFormatHolders()
+                    }
+                }
+            )
+        },
         transactionData = transactionData?.map { it.toBase64UrlJsonString() },
         expectedOrigins = expectedOrigins,
+    )
+
+    /**
+     * Defining *some* non-null format container is our way of specifying the allowed credential representations,
+     * but provided values are overridden here
+     */
+    private fun DifInputDescriptor.replaceAvailableFormatHolders() = copy(
+        format = format?.copy(
+            jwtVp = format?.jwtVp?.let {
+                containerJwt
+            },
+            sdJwt = format?.sdJwt?.let {
+                containerSdJwt
+            },
+            msoMdoc = format?.msoMdoc?.let {
+                containerJwt
+            },
+        )
     )
 
     /**
@@ -613,6 +640,7 @@ class OpenId4VpVerifier(
                             transactionData = authnRequest.transactionData,
                             clientIdRequired = clientIdRequired,
                             origin = (originalResponseParameters as? ResponseParametersFrom.DcApi)?.origin,
+                            requireCryptographicHolderBinding = query.credentialQuery(credentialQueryId)?.requireCryptographicHolderBinding,
                         )
                     }.map {
                         it.mapToAuthnResponseResult(responseParameters.parameters.state)
@@ -668,6 +696,7 @@ class OpenId4VpVerifier(
         transactionData: List<TransactionDataBase64Url>?,
         clientIdRequired: Boolean,
         origin: String?,
+        requireCryptographicHolderBinding: Boolean? = null,
     ) = when (claimFormat) {
         ClaimFormat.SD_JWT -> verifier.verifyPresentationSdJwt(
             input = SdJwtSigned.parseCatching(relatedPresentation.extractContent()).getOrElse {
@@ -677,14 +706,22 @@ class OpenId4VpVerifier(
             transactionData = transactionData
         )
 
-        ClaimFormat.JWT_VP -> verifier.verifyPresentationVcJwt(
-            input = JwsSigned.deserialize(
-                VerifiablePresentationJws.serializer(),
-                relatedPresentation.extractContent(),
-                vckJsonSerializer
-            ).getOrThrow(),
-            challenge = expectedNonce
-        )
+        ClaimFormat.JWT_VP -> if (requireCryptographicHolderBinding != false) {
+            verifier.verifyPresentationVcJwt(
+                input = JwsSigned.deserialize(
+                    VerifiablePresentationJws.serializer(),
+                    relatedPresentation.extractContent(),
+                    vckJsonSerializer
+                ).getOrThrow(),
+                challenge = expectedNonce
+            )
+        } else {
+            verifier.verifyUnsignedVcJws(
+                input = relatedPresentation.extractContent()
+            ).map {
+                VerifyPresentationResult.SuccessUnsignedVcJws(it.vc)
+            }
+        }
 
         ClaimFormat.MSO_MDOC -> verifier.verifyPresentationIsoMdoc(
             input = relatedPresentation.extractContent().decodeToByteArray(Base64UrlStrict)
@@ -780,16 +817,28 @@ class OpenId4VpVerifier(
     )
 
 
-    private fun VerifyPresentationResult.mapToAuthnResponseResult(state: String?) = when (this) {
-        is VerifyPresentationResult.ValidationError -> AuthnResponseResult.ValidationError("vpToken", state, cause)
-        is VerifyPresentationResult.Success -> AuthnResponseResult.Success(vp, state)
-        is VerifyPresentationResult.SuccessIso -> AuthnResponseResult.SuccessIso(documents, state)
-        is VerifyPresentationResult.SuccessSdJwt -> AuthnResponseResult.SuccessSdJwt(
-            sdJwtSigned = sdJwtSigned,
-            verifiableCredentialSdJwt = verifiableCredentialSdJwt,
-            reconstructed = reconstructedJsonObject,
-            disclosures = disclosures,
-            freshnessSummary = freshnessSummary,
+    private fun KmmResult<VerifyPresentationResult>.mapToAuthnResponseResult(state: String?) = map {
+        when (it) {
+            is VerifyPresentationResult.Success -> AuthnResponseResult.Success(it.vp, state)
+            is VerifyPresentationResult.SuccessIso -> AuthnResponseResult.SuccessIso(it.documents, state)
+            is VerifyPresentationResult.SuccessSdJwt -> AuthnResponseResult.SuccessSdJwt(
+                sdJwtSigned = it.sdJwtSigned,
+                verifiableCredentialSdJwt = it.verifiableCredentialSdJwt,
+                reconstructed = it.reconstructedJsonObject,
+                disclosures = it.disclosures,
+                freshnessSummary = it.freshnessSummary,
+            )
+
+            is VerifyPresentationResult.SuccessUnsignedVcJws -> AuthnResponseResult.SuccessUnsigned(
+                vc = it.vc,
+                state = state,
+            )
+        }
+    }.getOrElse {
+        AuthnResponseResult.ValidationError(
+            "vpToken",
+            state = state,
+            cause = it,
         )
     }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/PresentationFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/PresentationFactory.kt
@@ -256,7 +256,7 @@ internal class PresentationFactory(
     private fun CreatePresentationResult.toFormat(): ClaimFormat = when (this) {
         is CreatePresentationResult.DeviceResponse -> ClaimFormat.MSO_MDOC
         is CreatePresentationResult.SdJwt -> ClaimFormat.SD_JWT
-        is CreatePresentationResult.Signed -> ClaimFormat.JWT_VP
+        is CreatePresentationResult.VcJwsPresentationData -> ClaimFormat.JWT_VP
     }
 
 }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -43,7 +43,9 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
 
     representations.forEach { representation ->
         val reqOptions = OpenId4VpRequestOptions(
-            credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, representation))
+            presentationRequest = CredentialPresentationRequestBuilder(
+                credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, representation))
+            ).toPresentationExchangeRequest(),
         )
 
         "URL test $representation" {

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/CredentialPresentationRequestBuilderTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/CredentialPresentationRequestBuilderTest.kt
@@ -1,0 +1,115 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.openid.OpenIdConstants
+import at.asitplus.openid.QCertCreationAcceptance
+import at.asitplus.openid.dcql.DCQLClaimsPathPointerSegment
+import at.asitplus.openid.dcql.DCQLIsoMdocClaimsQuery
+import at.asitplus.openid.dcql.DCQLIsoMdocCredentialMetadataAndValidityConstraints
+import at.asitplus.openid.dcql.DCQLIsoMdocCredentialQuery
+import at.asitplus.openid.dcql.DCQLJsonClaimsQuery
+import at.asitplus.openid.dcql.DCQLSdJwtCredentialMetadataAndValidityConstraints
+import at.asitplus.openid.dcql.DCQLSdJwtCredentialQuery
+import at.asitplus.signum.indispensable.asn1.ObjectIdentifier
+import at.asitplus.wallet.lib.RequestOptionsCredential
+import at.asitplus.wallet.lib.data.ConstantIndex
+import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+
+val CredentialPresentationRequestBuilderTest by testSuite {
+    test("invalid credential scheme for SD-JWT should not throw when creating query") {
+        val credential = RequestOptionsCredential(
+            credentialScheme = object : ConstantIndex.CredentialScheme {
+                override val schemaUri: String = "https://example.com"
+            },
+            representation = ConstantIndex.CredentialRepresentation.SD_JWT
+        )
+
+        CredentialPresentationRequestBuilder(
+            setOf(credential)
+        ).apply {
+            toDCQLRequest()
+            toPresentationExchangeRequest()
+        }
+    }
+
+    test("invalid credential scheme for ISO should not throw when creating query") {
+        val credential = RequestOptionsCredential(
+            credentialScheme = object : ConstantIndex.CredentialScheme {
+                override val schemaUri: String = "https://example.com"
+            },
+            representation = ConstantIndex.CredentialRepresentation.ISO_MDOC
+        )
+        CredentialPresentationRequestBuilder(setOf(credential)).apply {
+            toDCQLRequest()
+            toPresentationExchangeRequest()
+        }
+    }
+
+    test("sd-jwt dcql mapping includes metadata and claims") {
+        val presentationRequest = CredentialPresentationRequestBuilder(
+            credentials = setOf(
+                RequestOptionsCredential(
+                    credentialScheme = ConstantIndex.AtomicAttribute2023,
+                    representation = ConstantIndex.CredentialRepresentation.SD_JWT,
+                    requestedAttributes = setOf(ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME),
+                    requestedOptionalAttributes = setOf(ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME),
+                    id = "cred-1"
+                )
+            ),
+        ).toDCQLRequest()
+
+        val credentialQuery = presentationRequest.shouldNotBeNull().dcqlQuery
+            .credentials.shouldBeSingleton().first()
+            .shouldBeInstanceOf<DCQLSdJwtCredentialQuery>()
+
+        credentialQuery.meta.shouldBeInstanceOf<DCQLSdJwtCredentialMetadataAndValidityConstraints>()
+            .vctValues shouldContain ConstantIndex.AtomicAttribute2023.sdJwtType
+
+        val claims = credentialQuery.claims.shouldNotBeNull().toList().apply {
+            size shouldBe 2
+        }
+        val claimNames = claims.map {
+            it.shouldBeInstanceOf<DCQLJsonClaimsQuery>().path.segments.first()
+                .shouldBeInstanceOf<DCQLClaimsPathPointerSegment.NameSegment>()
+                .name
+        }.toSet()
+
+        claimNames shouldBe setOf(
+            ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME,
+            ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
+        )
+    }
+
+
+    test("iso mdoc dcql mapping includes namespace and doctype") {
+        val presentationRequest = CredentialPresentationRequestBuilder(
+            credentials = setOf(
+                RequestOptionsCredential(
+                    credentialScheme = ConstantIndex.AtomicAttribute2023,
+                    representation = ConstantIndex.CredentialRepresentation.ISO_MDOC,
+                    requestedAttributes = setOf(ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME),
+                    id = "cred-1"
+                )
+            ),
+        ).toDCQLRequest()
+
+        val credentialQuery = presentationRequest.shouldNotBeNull().dcqlQuery.shouldNotBeNull()
+            .credentials.shouldBeSingleton().first()
+            .shouldBeInstanceOf<DCQLIsoMdocCredentialQuery>()
+
+        credentialQuery.meta.shouldBeInstanceOf<DCQLIsoMdocCredentialMetadataAndValidityConstraints>()
+            .doctypeValue shouldBe ConstantIndex.AtomicAttribute2023.isoDocType
+
+        val claim = credentialQuery.claims.shouldNotBeNull().shouldBeSingleton().first()
+            .shouldBeInstanceOf<DCQLIsoMdocClaimsQuery>()
+        claim.namespace shouldBe ConstantIndex.AtomicAttribute2023.isoNamespace
+        claim.claimName shouldBe ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
+    }
+}

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
@@ -10,6 +10,7 @@ import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.agent.toStoreCredentialInput
+import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.rfc3986.toUri
@@ -59,13 +60,15 @@ val JarmTest by testSuite {
         "DirectPostJwt must either be signed or encrypted" {
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(
-                            AtomicAttribute2023,
-                            SD_JWT,
-                            setOf(AtomicAttribute2023.CLAIM_GIVEN_NAME)
-                        )
-                    ),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(
+                                AtomicAttribute2023,
+                                SD_JWT,
+                                setOf(AtomicAttribute2023.CLAIM_GIVEN_NAME)
+                            )
+                        ),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = "https://example.com/${uuid4()}"
                 )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
@@ -52,6 +52,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 
 private fun AuthenticationRequestParameters.serialize(): String = vckJsonSerializer.encodeToString(this)
 
@@ -156,16 +157,15 @@ val OpenId4VpCombinedProtocolTest by testSuite {
                 )
             )
 
-            val authnResponse =
-                it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
-                    .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
 
             val vcFreshnessSummary = it.verifierOid4vp.validateAuthnResponse(authnResponse.url)
                 .shouldBeInstanceOf<AuthnResponseResult.VerifiableDCQLPresentationValidationResults>()
                 .allValidationResults.entries.shouldBeSingleton().first().value.shouldBeSingleton().first()
                 .shouldBeInstanceOf<AuthnResponseResult.SuccessUnsigned>()
                 .vc
-            vcFreshnessSummary.vcJws.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
+            vcFreshnessSummary.vcJws.vc.credentialSubject.shouldBeInstanceOf<JsonObject>()
             vcFreshnessSummary.freshnessSummary.isFresh.shouldBeTrue()
         }
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
@@ -12,7 +12,12 @@ package at.asitplus.wallet.lib.openid
  * see the "LICENSE" file for more details
  */
 
+import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.dcql.DCQLCredentialQueryList
+import at.asitplus.openid.dcql.DCQLIsoMdocCredentialQuery
+import at.asitplus.openid.dcql.DCQLJwtVcCredentialQuery
+import at.asitplus.openid.dcql.DCQLSdJwtCredentialQuery
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.withFixtureGenerator
 import at.asitplus.wallet.eupid.EuPidScheme
@@ -27,6 +32,8 @@ import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.agent.toStoreCredentialInput
 import at.asitplus.wallet.lib.data.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
@@ -36,6 +43,7 @@ import at.asitplus.wallet.mdl.MobileDrivingLicenceScheme
 import com.benasher44.uuid.uuid4
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.assertions.AssertionErrorBuilder.Companion.fail
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldNotBeEmpty
@@ -74,9 +82,11 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
+                        ),
+                    ).toPresentationExchangeRequest()
                 )
             )
             it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
@@ -92,9 +102,11 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
+                        )
+                    ).toPresentationExchangeRequest(),
                 )
             )
 
@@ -114,6 +126,49 @@ val OpenId4VpCombinedProtocolTest by testSuite {
                 }
         }
 
+        test("plain jwt: send plain if no cryptographic holder binding") {
+            it.holderAgent.storeJwtCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
+            it.holderAgent.storeJwtCredential(it.holderKeyMaterial, MobileDrivingLicenceScheme)
+            it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
+            it.holderAgent.storeIsoCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
+
+            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+                requestOptions = OpenId4VpRequestOptions(
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
+                        )
+                    ).toDCQLRequest()?.let {
+                        CredentialPresentationRequest.DCQLRequest(
+                            it.dcqlQuery.copy(
+                                credentials = DCQLCredentialQueryList(
+                                    it.dcqlQuery.credentials.map {
+                                        it as DCQLJwtVcCredentialQuery
+                                    }.map {
+                                        it.copy(
+                                            requireCryptographicHolderBinding = false
+                                        )
+                                    }.toNonEmptyList()
+                                )
+                            )
+                        )
+                    },
+                )
+            )
+
+            val authnResponse =
+                it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+                    .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+
+            val vcFreshnessSummary = it.verifierOid4vp.validateAuthnResponse(authnResponse.url)
+                .shouldBeInstanceOf<AuthnResponseResult.VerifiableDCQLPresentationValidationResults>()
+                .allValidationResults.entries.shouldBeSingleton().first().value.shouldBeSingleton().first()
+                .shouldBeInstanceOf<AuthnResponseResult.SuccessUnsigned>()
+                .vc
+            vcFreshnessSummary.vcJws.vc.credentialSubject.shouldBeInstanceOf<AtomicAttribute2023>()
+            vcFreshnessSummary.freshnessSummary.isFresh.shouldBeTrue()
+        }
+
         test("sd-jwt presex: if not available despite others with correct format or correct attribute, but not both") {
             it.holderAgent.storeJwtCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, MobileDrivingLicenceScheme)
@@ -121,9 +176,11 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
+                        )
+                    ).toPresentationExchangeRequest(),
                 )
             )
             it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
@@ -139,9 +196,11 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
+                        )
+                    ).toPresentationExchangeRequest(),
                 ),
             )
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
@@ -159,10 +218,11 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.prepareAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
-                    ),
-                    presentationMechanism = PresentationMechanismEnum.DCQL,
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
+                        ),
+                    ).toDCQLRequest(),
                 ),
             )
 
@@ -179,10 +239,11 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
-                    ),
-                    presentationMechanism = PresentationMechanismEnum.DCQL
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
+                        ),
+                    ).toDCQLRequest(),
                 ),
             )
 
@@ -204,9 +265,11 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
+                        )
+                    ).toPresentationExchangeRequest(),
                 ),
             )
             it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
@@ -222,9 +285,11 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
+                        )
+                    ).toPresentationExchangeRequest(),
                 ),
             )
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
@@ -241,10 +306,11 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
-                    ),
-                    presentationMechanism = PresentationMechanismEnum.DCQL,
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
+                        ),
+                    ).toDCQLRequest(),
                 ),
             )
 
@@ -261,10 +327,11 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
-                    ),
-                    presentationMechanism = PresentationMechanismEnum.DCQL
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
+                        ),
+                    ).toDCQLRequest(),
                 ),
             )
 
@@ -282,10 +349,12 @@ val OpenId4VpCombinedProtocolTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT),
-                        RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT),
+                            RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC)
+                        )
+                    ).toPresentationExchangeRequest(),
                 ),
             )
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
@@ -301,21 +370,23 @@ val OpenId4VpCombinedProtocolTest by testSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(
-                        credentialScheme = ConstantIndex.AtomicAttribute2023,
-                        representation = SD_JWT,
-                        requestedAttributes = setOf(ConstantIndex.AtomicAttribute2023.CLAIM_DATE_OF_BIRTH),
-                    ),
-                    RequestOptionsCredential(
-                        credentialScheme = EuPidScheme,
-                        representation = SD_JWT,
-                        requestedAttributes = setOf(
-                            EuPidScheme.Attributes.FAMILY_NAME,
-                            EuPidScheme.Attributes.GIVEN_NAME
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(
+                        RequestOptionsCredential(
+                            credentialScheme = ConstantIndex.AtomicAttribute2023,
+                            representation = SD_JWT,
+                            requestedAttributes = setOf(ConstantIndex.AtomicAttribute2023.CLAIM_DATE_OF_BIRTH),
                         ),
+                        RequestOptionsCredential(
+                            credentialScheme = EuPidScheme,
+                            representation = SD_JWT,
+                            requestedAttributes = setOf(
+                                EuPidScheme.Attributes.FAMILY_NAME,
+                                EuPidScheme.Attributes.GIVEN_NAME
+                            ),
+                        )
                     )
-                )
+                ).toPresentationExchangeRequest(),
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(requestOptions)
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTwoStepTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTwoStepTest.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.testballoon.withFixtureGenerator
+import at.asitplus.wallet.eupid.EuPidScheme
 import at.asitplus.wallet.lib.RequestOptionsCredential
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
@@ -57,9 +58,11 @@ val OpenId4VpCombinedProtocolTwoStepTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
+                        )
+                    ).toPresentationExchangeRequest(),
                 )
             )
             val preparationState = it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize())
@@ -90,9 +93,11 @@ val OpenId4VpCombinedProtocolTwoStepTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
+                        )
+                    ).toPresentationExchangeRequest(),
                 )
             )
 
@@ -143,16 +148,18 @@ val OpenId4VpCombinedProtocolTwoStepTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(
-                            credentialScheme = AtomicAttribute2023,
-                            representation = ISO_MDOC,
-                            requestedOptionalAttributes = setOf(
-                                AtomicAttribute2023.CLAIM_FAMILY_NAME,
-                                AtomicAttribute2023.CLAIM_GIVEN_NAME
-                            )
-                        ),
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(
+                                credentialScheme = AtomicAttribute2023,
+                                representation = ISO_MDOC,
+                                requestedOptionalAttributes = setOf(
+                                    AtomicAttribute2023.CLAIM_FAMILY_NAME,
+                                    AtomicAttribute2023.CLAIM_GIVEN_NAME
+                                )
+                            ),
+                        )
+                    ).toPresentationExchangeRequest(),
                 )
             )
 
@@ -205,9 +212,11 @@ val OpenId4VpCombinedProtocolTwoStepTest by testSuite {
             val sdJwtMatches = run {
                 val authnRequestSdJwt = it.verifierOid4vp.createAuthnRequest(
                     requestOptions = OpenId4VpRequestOptions(
-                        credentials = setOf(
-                            RequestOptionsCredential(AtomicAttribute2023, SD_JWT)
-                        )
+                        presentationRequest = CredentialPresentationRequestBuilder(
+                            credentials = setOf(
+                                RequestOptionsCredential(AtomicAttribute2023, SD_JWT)
+                            )
+                        ).toPresentationExchangeRequest(),
                     )
                 )
 
@@ -238,9 +247,11 @@ val OpenId4VpCombinedProtocolTwoStepTest by testSuite {
 
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions = OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
+                        )
+                    ).toPresentationExchangeRequest(),
                 )
             )
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpComplexSdJwtProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpComplexSdJwtProtocolTest.kt
@@ -15,6 +15,7 @@ import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.agent.toStoreCredentialInput
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.extensions.supportedSdAlgorithms
 import com.benasher44.uuid.uuid4
@@ -85,24 +86,26 @@ val OpenId4VpComplexSdJwtProtocolTest by testSuite {
                 "$CLAIM_ADDRESS.$CLAIM_ADDRESS_REGION",
                 "$CLAIM_ADDRESS.$CLAIM_ADDRESS_COUNTRY"
             )
+
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(AtomicAttribute2023, SD_JWT, requestedClaims)
-                ),
-                presentationMechanism = PresentationMechanismEnum.PresentationExchange
-            ).apply {
-                toInputDescriptor(FormatContainerJwt(), FormatContainerSdJwt()).shouldBeSingleton().first().apply {
-                    constraints.shouldNotBeNull().apply {
-                        fields.shouldNotBeNull().forEach {
-                            it.path.shouldBeSingleton().first().apply {
-                                JsonPath(this)
-                                if (!this.contains("vct"))
-                                    split(".").shouldHaveSize(3) // "$", first segment, second segment
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    setOf(
+                        RequestOptionsCredential(AtomicAttribute2023, SD_JWT, requestedClaims)
+                    )
+                ).toPresentationExchangeRequest().apply {
+                    presentationDefinition.inputDescriptors.shouldBeSingleton().first().apply {
+                        constraints.shouldNotBeNull().apply {
+                            fields.shouldNotBeNull().forEach {
+                                it.path.shouldBeSingleton().first().apply {
+                                    JsonPath(this)
+                                    if (!this.contains("vct"))
+                                        split(".").shouldHaveSize(3) // "$", first segment, second segment
+                                }
                             }
                         }
                     }
                 }
-            }
+            )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions,
                 OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
@@ -129,12 +132,13 @@ val OpenId4VpComplexSdJwtProtocolTest by testSuite {
                 "$CLAIM_ADDRESS.$CLAIM_ADDRESS_COUNTRY"
             )
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(AtomicAttribute2023, SD_JWT, requestedClaims)
-                ),
-                presentationMechanism = PresentationMechanismEnum.DCQL
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    setOf(
+                        RequestOptionsCredential(AtomicAttribute2023, SD_JWT, requestedClaims)
+                    )
+                ).toDCQLRequest()
             ).apply {
-                toDCQLQuery().shouldNotBeNull().apply {
+                (presentationRequest as? CredentialPresentationRequest.DCQLRequest)?.dcqlQuery.shouldNotBeNull().apply {
                     credentials.shouldBeSingleton().first().apply {
                         claims.shouldNotBeNull().forEach {
                             it.path.shouldNotBeNull().shouldHaveSize(2)

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEuRefInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEuRefInteropTest.kt
@@ -24,8 +24,10 @@ import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.agent.toStoreCredentialInput
 import at.asitplus.wallet.lib.data.ConstantIndex
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
@@ -349,15 +351,17 @@ val OpenId4VpEuRefInteropTest by testSuite {
             val requestUrl = "https://example.com/request/$nonce"
             val (walletUrl, jar) = verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(
+                                ConstantIndex.AtomicAttribute2023,
+                                ConstantIndex.CredentialRepresentation.SD_JWT,
+                                setOf(CLAIM_FAMILY_NAME, CLAIM_GIVEN_NAME)
+                            )
+                        )
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPost,
                     responseUrl = "https://example.com/response",
-                    credentials = setOf(
-                        RequestOptionsCredential(
-                            ConstantIndex.AtomicAttribute2023,
-                            ConstantIndex.CredentialRepresentation.SD_JWT,
-                            setOf(CLAIM_FAMILY_NAME, CLAIM_GIVEN_NAME)
-                        )
-                    )
                 ),
                 OpenId4VpVerifier.CreationOptions.SignedRequestByReference("https://wallet.a-sit.at/mobile", requestUrl)
             ).getOrThrow()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpInteropTest.kt
@@ -115,15 +115,17 @@ val OpenId4VpInteropTest by testSuite {
             val requestUrl = "https://verifier.example.com/request/$requestNonce"
             val (requestUrlForWallet, requestObject) = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(
+                                ConstantIndex.AtomicAttribute2023,
+                                ConstantIndex.CredentialRepresentation.SD_JWT,
+                                setOf(CLAIM_FAMILY_NAME, CLAIM_GIVEN_NAME)
+                            )
+                        )
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPost,
                     responseUrl = "https://verifier.example.com/response/$responseNonce",
-                    credentials = setOf(
-                        RequestOptionsCredential(
-                            ConstantIndex.AtomicAttribute2023,
-                            ConstantIndex.CredentialRepresentation.SD_JWT,
-                            setOf(CLAIM_FAMILY_NAME, CLAIM_GIVEN_NAME)
-                        )
-                    )
                 ),
                 OpenId4VpVerifier.CreationOptions.SignedRequestByReference("haip://", requestUrl)
             ).getOrThrow()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpIsoProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpIsoProtocolTest.kt
@@ -11,7 +11,9 @@ import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.IssuerAgent
 import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.agent.toStoreCredentialInput
+import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.rfc3986.toUri
@@ -89,9 +91,11 @@ val OpenId4VpIsoProtocolTest by testSuite {
     }) - {
         "test with Fragment for mDL" {
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(GIVEN_NAME))
-                )
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(
+                        RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(GIVEN_NAME))
+                    )
+                ).toPresentationExchangeRequest(),
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(requestOptions, Query(it.walletUrl))
                 .getOrThrow().url
@@ -108,9 +112,11 @@ val OpenId4VpIsoProtocolTest by testSuite {
 
         "test with Fragment for custom attributes" {
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC, setOf(CLAIM_GIVEN_NAME))
-                )
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(
+                        RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC, setOf(CLAIM_GIVEN_NAME))
+                    )
+                ).toPresentationExchangeRequest(),
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(requestOptions, Query(it.walletUrl))
                 .getOrThrow().url
@@ -128,9 +134,11 @@ val OpenId4VpIsoProtocolTest by testSuite {
         "Selective Disclosure with mDL" {
             val requestedClaim = FAMILY_NAME
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(requestedClaim))
-                )
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(
+                        RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(requestedClaim))
+                    )
+                ).toPresentationExchangeRequest(),
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(requestOptions, Query(it.walletUrl))
                 .getOrThrow().url
@@ -148,9 +156,11 @@ val OpenId4VpIsoProtocolTest by testSuite {
         "Selective Disclosure with mDL (ISO/IEC 18013-7:2024 Annex B)" {
             val requestedClaim = FAMILY_NAME
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(requestedClaim))
-                ),
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(
+                        RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(requestedClaim))
+                    ),
+                ).toPresentationExchangeRequest(),
                 responseMode = OpenIdConstants.ResponseMode.DirectPost,
                 responseUrl = "https://example.com/response",
             )
@@ -176,9 +186,11 @@ val OpenId4VpIsoProtocolTest by testSuite {
         "Selective Disclosure with mDL and encryption (ISO/IEC 18013-7:2024 Annex B)" {
             val requestedClaim = FAMILY_NAME
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(requestedClaim))
-                ),
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(
+                        RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(requestedClaim))
+                    ),
+                ).toPresentationExchangeRequest(),
                 responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                 responseUrl = "https://example.com/response",
             )
@@ -206,13 +218,14 @@ val OpenId4VpIsoProtocolTest by testSuite {
             val mdlFamilyName = FAMILY_NAME
             val atomicGivenName = CLAIM_GIVEN_NAME
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(mdlFamilyName)),
-                    RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC, setOf(atomicGivenName))
-                ),
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(
+                        RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(mdlFamilyName)),
+                        RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC, setOf(atomicGivenName))
+                    ),
+                ).toPresentationExchangeRequest(),
                 responseMode = OpenIdConstants.ResponseMode.DirectPost,
                 responseUrl = "https://example.com/response",
-                presentationMechanism = PresentationMechanismEnum.PresentationExchange
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(requestOptions, Query(it.walletUrl))
                 .getOrThrow().url
@@ -241,13 +254,14 @@ val OpenId4VpIsoProtocolTest by testSuite {
             val mdlFamilyName = FAMILY_NAME
             val atomicGivenName = CLAIM_GIVEN_NAME
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(mdlFamilyName)),
-                    RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC, setOf(atomicGivenName))
-                ),
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(
+                        RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(mdlFamilyName)),
+                        RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC, setOf(atomicGivenName))
+                    ),
+                ).toDCQLRequest(),
                 responseMode = OpenIdConstants.ResponseMode.DirectPost,
                 responseUrl = "https://example.com/response",
-                presentationMechanism = PresentationMechanismEnum.DCQL,
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(requestOptions, Query(it.walletUrl))
                 .getOrThrow().url
@@ -276,9 +290,11 @@ val OpenId4VpIsoProtocolTest by testSuite {
 
         "Selective Disclosure with mDL JSON Path syntax" {
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(FAMILY_NAME))
-                )
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(
+                        RequestOptionsCredential(MobileDrivingLicenceScheme, ISO_MDOC, setOf(FAMILY_NAME))
+                    )
+                ).toPresentationExchangeRequest(),
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(requestOptions, Query(it.walletUrl))
                 .getOrThrow().url

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestOptionsTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpRequestOptionsTest.kt
@@ -36,43 +36,26 @@ val OpenId4VpRequestOptionsTest by testSuite {
             credentialIds = setOf("cred-2")
         )
 
-        shouldThrowAny {
-            OpenId4VpRequestOptions(
-                credentials = setOf(credential),
-                transactionData = listOf(transactionData)
-            )
+        val requestBuilder = CredentialPresentationRequestBuilder(setOf(credential))
+        listOf(
+            requestBuilder.toDCQLRequest(),
+            requestBuilder.toPresentationExchangeRequest()
+        ).forEach {
+            shouldThrowAny {
+                OpenId4VpRequestOptions(
+                    presentationRequest = it,
+                    transactionData = listOf(transactionData)
+                )
+            }
         }
-    }
-
-    test("invalid credential scheme for SD-JWT should not throw when creating query") {
-        val credential = RequestOptionsCredential(
-            credentialScheme = object : ConstantIndex.CredentialScheme {
-                override val schemaUri: String = "https://example.com"
-            },
-            representation = ConstantIndex.CredentialRepresentation.SD_JWT
-        )
-        OpenId4VpRequestOptions(credentials = setOf(credential))
-            .toDCQLQuery()
-            .shouldBeNull()
-    }
-
-    test("invalid credential scheme for ISO should not throw when creating query") {
-        val credential = RequestOptionsCredential(
-            credentialScheme = object : ConstantIndex.CredentialScheme {
-                override val schemaUri: String = "https://example.com"
-            },
-            representation = ConstantIndex.CredentialRepresentation.ISO_MDOC
-        )
-        OpenId4VpRequestOptions(credentials = setOf(credential))
-            .toDCQLQuery()
-            .shouldBeNull()
     }
 
     test("dc api requires dcql and expected origins") {
         shouldThrowAny {
             OpenId4VpRequestOptions(
-                credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
-                presentationMechanism = PresentationMechanismEnum.PresentationExchange,
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023))
+                ).toPresentationExchangeRequest(),
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf("https://wallet.example")
             )
@@ -80,8 +63,9 @@ val OpenId4VpRequestOptionsTest by testSuite {
 
         shouldThrowAny {
             OpenId4VpRequestOptions(
-                credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
-                presentationMechanism = PresentationMechanismEnum.DCQL,
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023))
+                ).toDCQLRequest(),
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = null
             )
@@ -91,72 +75,12 @@ val OpenId4VpRequestOptionsTest by testSuite {
     test("non dc api requires client id population") {
         shouldThrowAny {
             OpenId4VpRequestOptions(
-                credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023))
+                ).toPresentationExchangeRequest(),
                 responseMode = OpenIdConstants.ResponseMode.Fragment,
                 populateClientId = false
             )
         }
-    }
-
-    test("sd-jwt dcql mapping includes metadata and claims") {
-        val options = OpenId4VpRequestOptions(
-            credentials = setOf(
-                RequestOptionsCredential(
-                    credentialScheme = ConstantIndex.AtomicAttribute2023,
-                    representation = ConstantIndex.CredentialRepresentation.SD_JWT,
-                    requestedAttributes = setOf(ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME),
-                    requestedOptionalAttributes = setOf(ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME),
-                    id = "cred-1"
-                )
-            ),
-            presentationMechanism = PresentationMechanismEnum.DCQL
-        )
-
-        val credentialQuery = options.toDCQLQuery().shouldNotBeNull()
-            .credentials.shouldBeSingleton().first()
-            .shouldBeInstanceOf<DCQLSdJwtCredentialQuery>()
-
-        credentialQuery.meta.shouldBeInstanceOf<DCQLSdJwtCredentialMetadataAndValidityConstraints>()
-            .vctValues shouldContain ConstantIndex.AtomicAttribute2023.sdJwtType
-
-        val claims = credentialQuery.claims.shouldNotBeNull().toList().apply {
-            size shouldBe 2
-        }
-        val claimNames = claims.map {
-            it.shouldBeInstanceOf<DCQLJsonClaimsQuery>().path.segments.first()
-                .shouldBeInstanceOf<DCQLClaimsPathPointerSegment.NameSegment>()
-                .name
-        }.toSet()
-
-        claimNames shouldBe setOf(
-            ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME,
-            ConstantIndex.AtomicAttribute2023.CLAIM_FAMILY_NAME
-        )
-    }
-
-    test("iso mdoc dcql mapping includes namespace and doctype") {
-        val options = OpenId4VpRequestOptions(
-            credentials = setOf(
-                RequestOptionsCredential(
-                    credentialScheme = ConstantIndex.AtomicAttribute2023,
-                    representation = ConstantIndex.CredentialRepresentation.ISO_MDOC,
-                    requestedAttributes = setOf(ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME),
-                    id = "cred-1"
-                )
-            ),
-            presentationMechanism = PresentationMechanismEnum.DCQL
-        )
-
-        val credentialQuery = options.toDCQLQuery().shouldNotBeNull()
-            .credentials.shouldBeSingleton().first()
-            .shouldBeInstanceOf<DCQLIsoMdocCredentialQuery>()
-
-        credentialQuery.meta.shouldBeInstanceOf<DCQLIsoMdocCredentialMetadataAndValidityConstraints>()
-            .doctypeValue shouldBe ConstantIndex.AtomicAttribute2023.isoDocType
-
-        val claim = credentialQuery.claims.shouldNotBeNull().shouldBeSingleton().first()
-            .shouldBeInstanceOf<DCQLIsoMdocClaimsQuery>()
-        claim.namespace shouldBe ConstantIndex.AtomicAttribute2023.isoNamespace
-        claim.claimName shouldBe ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
     }
 }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpSdJwtProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpSdJwtProtocolTest.kt
@@ -68,9 +68,11 @@ val OpenId4VpSdJwtProtocolTest by testSuite {
             val requestedClaim = AtomicAttribute2023.CLAIM_GIVEN_NAME
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    setOf(
-                        RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(requestedClaim))
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        setOf(
+                            RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(requestedClaim))
+                        )
+                    ).toPresentationExchangeRequest(),
                 ),
                 OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
@@ -95,9 +97,11 @@ val OpenId4VpSdJwtProtocolTest by testSuite {
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(EuPidScheme, SD_JWT, requestedClaims)
-                    )
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(EuPidScheme, SD_JWT, requestedClaims)
+                        )
+                    ).toPresentationExchangeRequest(),
                 ),
                 OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509HashTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509HashTest.kt
@@ -65,9 +65,11 @@ val OpenId4VpX509HashTest by testSuite {
             val requestUrl = "https://example.com/request"
             val (walletUrl, jar) = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(CLAIM_GIVEN_NAME))
-                    ),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(CLAIM_GIVEN_NAME))
+                        ),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPost,
                     responseUrl = "https://example.com/response",
                 ),
@@ -97,9 +99,11 @@ val OpenId4VpX509HashTest by testSuite {
             val requestUrl = "https://example.com/request"
             val (walletUrl, jar) = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(CLAIM_GIVEN_NAME))
-                    ),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(CLAIM_GIVEN_NAME))
+                        ),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = "https://example.com/response",
                 ),

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509SanDnsTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509SanDnsTest.kt
@@ -85,9 +85,11 @@ val OpenId4VpX509SanDnsTest by testSuite {
             val requestUrl = "https://example.com/request"
             val (walletUrl, jar) = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(CLAIM_GIVEN_NAME))
-                    ),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(CLAIM_GIVEN_NAME))
+                        ),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPost,
                     responseUrl = "https://example.com/response",
                 ),
@@ -117,9 +119,11 @@ val OpenId4VpX509SanDnsTest by testSuite {
             val requestUrl = "https://example.com/request"
             val (walletUrl, jar) = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(
-                        RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(CLAIM_GIVEN_NAME))
-                    ),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(
+                            RequestOptionsCredential(AtomicAttribute2023, SD_JWT, setOf(CLAIM_GIVEN_NAME))
+                        ),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = "https://example.com/response",
                 ),

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -21,8 +21,6 @@ import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.testballoon.invoke
 import at.asitplus.testballoon.withFixtureGenerator
-import at.asitplus.wallet.lib.NonceService
-import at.asitplus.wallet.lib.RequestOptionsCredential
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.IssuerAgent
@@ -36,13 +34,10 @@ import at.asitplus.wallet.lib.jws.VerifyJwsObject
 import at.asitplus.wallet.lib.utils.MapStore
 import at.asitplus.wallet.lib.NonceService
 import at.asitplus.wallet.lib.RequestOptionsCredential
-import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
-import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
 import at.asitplus.wallet.lib.oidvci.encodeToParameters
 import at.asitplus.wallet.lib.oidvci.formUrlEncode
-import at.asitplus.wallet.lib.utils.MapStore
 import com.benasher44.uuid.uuid4
 import de.infix.testBalloon.framework.core.testSuite
 import io.kotest.assertions.throwables.shouldNotThrowAny

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -33,6 +33,11 @@ import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.data.vckJsonSerializer
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
+import at.asitplus.wallet.lib.utils.MapStore
+import at.asitplus.wallet.lib.NonceService
+import at.asitplus.wallet.lib.RequestOptionsCredential
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.oidvci.OAuth2Exception
 import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
 import at.asitplus.wallet.lib.oidvci.encodeToParameters
@@ -94,9 +99,11 @@ val PreRegisteredClientTest by testSuite {
                 decryptionKeyMaterial = decryptionKeyMaterial
             )
             val defaultRequestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(
-                    RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
-                ),
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(
+                        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
+                    ),
+                ).toPresentationExchangeRequest(),
             )
         }
     }) - {
@@ -104,7 +111,9 @@ val PreRegisteredClientTest by testSuite {
         "test with Fragment" {
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.Fragment,
                 ),
                 OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
@@ -134,7 +143,9 @@ val PreRegisteredClientTest by testSuite {
             val expectedState = uuid4().toString()
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.Query,
                     state = expectedState,
                 ),
@@ -165,7 +176,9 @@ val PreRegisteredClientTest by testSuite {
                 }
             )
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                ).toPresentationExchangeRequest(),
                 responseType = OpenIdConstants.ID_TOKEN,
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
@@ -225,7 +238,9 @@ val PreRegisteredClientTest by testSuite {
         "test with direct_post" {
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPost,
                     responseUrl = it.redirectUrl
                 ),
@@ -244,7 +259,9 @@ val PreRegisteredClientTest by testSuite {
         "test with direct_post.jwt" {
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = it.redirectUrl
                 ),
@@ -270,7 +287,9 @@ val PreRegisteredClientTest by testSuite {
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = it.redirectUrl
                 ),
@@ -438,9 +457,11 @@ val PreRegisteredClientTest by testSuite {
 }
 
 private fun requestOptionsAtomicAttribute() = OpenId4VpRequestOptions(
-    credentials = setOf(
-        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
-    ),
+    presentationRequest = CredentialPresentationRequestBuilder(
+        credentials = setOf(
+            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
+        ),
+    ).toPresentationExchangeRequest(),
 )
 
 private suspend fun verifySecondProtocolRun(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
@@ -114,7 +114,9 @@ val RedirectUriClientTest by testSuite {
                 }
             )
             val requestOptions = OpenId4VpRequestOptions(
-                credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                presentationRequest = CredentialPresentationRequestBuilder(
+                    credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                ).toPresentationExchangeRequest(),
                 responseType = OpenIdConstants.ID_TOKEN
             )
             val authnRequest = verifierOid4vp.createAuthnRequest(
@@ -171,7 +173,9 @@ val RedirectUriClientTest by testSuite {
         "test with direct_post" {
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPost,
                     responseUrl = it.clientId,
                 ),
@@ -190,7 +194,9 @@ val RedirectUriClientTest by testSuite {
         "test with direct_post.jwt" {
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = it.clientId,
                 ),
@@ -212,7 +218,9 @@ val RedirectUriClientTest by testSuite {
             val expectedState = uuid4().toString()
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 OpenId4VpRequestOptions(
-                    credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    presentationRequest = CredentialPresentationRequestBuilder(
+                        credentials = setOf(RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)),
+                    ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.Query,
                     state = expectedState
                 ),
@@ -277,9 +285,11 @@ val RedirectUriClientTest by testSuite {
 }
 
 private fun requestOptionsAtomicAttribute() = OpenId4VpRequestOptions(
-    credentials = setOf(
-        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
-    ),
+    presentationRequest = CredentialPresentationRequestBuilder(
+        credentials = setOf(
+            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
+        ),
+    ).toPresentationExchangeRequest(),
 )
 
 private suspend fun verifySecondProtocolRun(
@@ -296,7 +306,9 @@ private suspend fun verifySecondProtocolRun(
 }
 
 private val defaultRequestOptions = OpenId4VpRequestOptions(
-    credentials = setOf(
-        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
-    )
+    presentationRequest = CredentialPresentationRequestBuilder(
+        credentials = setOf(
+            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
+        )
+    ).toPresentationExchangeRequest(),
 )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/VerifierAttestationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/VerifierAttestationTest.kt
@@ -134,9 +134,11 @@ val VerifierAttestationTest by testSuite {
 
 
 private fun requestOptionsAtomicAttribute() = OpenId4VpRequestOptions(
-    credentials = setOf(
-        RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
-    ),
+    presentationRequest = CredentialPresentationRequestBuilder(
+        credentials = setOf(
+            RequestOptionsCredential(ConstantIndex.AtomicAttribute2023)
+        ),
+    ).toPresentationExchangeRequest(),
 )
 
 private suspend fun buildAttestationJwt(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptionsTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptionsTest.kt
@@ -13,10 +13,12 @@ import at.asitplus.wallet.eupid.EuPidScheme.SdJwtAttributes.FAMILY_NAME
 import at.asitplus.wallet.eupid.EuPidScheme.SdJwtAttributes.GIVEN_NAME
 import at.asitplus.wallet.lib.RequestOptionsCredential
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.SdJwtConstants
 import at.asitplus.wallet.lib.data.toTransactionData
 import at.asitplus.wallet.lib.openid.ClientIdScheme
+import at.asitplus.wallet.lib.openid.CredentialPresentationRequestBuilder
 import at.asitplus.wallet.lib.openid.OpenId4VpVerifier
 import at.asitplus.wallet.lib.openid.OpenId4VpRequestOptions
 import com.benasher44.uuid.bytes
@@ -59,14 +61,16 @@ internal fun buildRequestOptions(
         responseUrl = if (responseMode == OpenIdConstants.ResponseMode.DirectPost)
             "https://example.com/rp/${uuid4()}"
         else null,
-        credentials = setOf(
-            RequestOptionsCredential(
-                credentialScheme = EuPidScheme,
-                representation = SD_JWT,
-                requestedAttributes = setOf(FAMILY_NAME, GIVEN_NAME),
-                id = credentialId
-            )
-        ),
+        presentationRequest = CredentialPresentationRequestBuilder(
+            credentials = setOf(
+                RequestOptionsCredential(
+                    credentialScheme = EuPidScheme,
+                    representation = SD_JWT,
+                    requestedAttributes = setOf(FAMILY_NAME, GIVEN_NAME),
+                    id = credentialId
+                )
+            ),
+        ).toPresentationExchangeRequest(),
         transactionData = listOf(
             getTransactionData(setOf(credentialId), transactionDataHashAlgorithms),
             getTransactionData(setOf(credentialId), transactionDataHashAlgorithms)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/RequestOptions.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/RequestOptions.kt
@@ -22,7 +22,6 @@ import kotlin.collections.plus
 typealias RequestedAttributes = Set<String>
 
 interface RequestOptions {
-    val credentials: Set<RequestOptionsCredential>
     val state: String
 }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -10,6 +10,7 @@ import at.asitplus.dif.PresentationSubmission
 import at.asitplus.dif.PresentationSubmissionDescriptor
 import at.asitplus.jsonpath.core.NodeList
 import at.asitplus.jsonpath.core.NormalizedJsonPath
+import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult
 import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.signum.indispensable.cosef.CoseKey
 import at.asitplus.signum.indispensable.cosef.toCoseKey
@@ -59,12 +60,7 @@ class HolderAgent(
     override suspend fun storeCredential(credential: Holder.StoreCredentialInput, renewalInfo: CredentialRenewalInfo?) = catching {
         when (credential) {
             is Holder.StoreCredentialInput.Vc -> {
-                val validated = validatorVcJws.verifyVcJws(credential.signedVcJws, keyMaterial.publicKey)
-                if (validated !is Verifier.VerifyCredentialResult.SuccessJwt) {
-                    val error = (validated as? Verifier.VerifyCredentialResult.ValidationError)?.cause
-                        ?: Throwable("Invalid VC JWS")
-                    throw VerificationError(error)
-                }
+                val validated = validatorVcJws.verifyVcJws(credential.signedVcJws, keyMaterial.publicKey).getOrThrow()
                 subjectCredentialStore.storeCredential(
                     vc = validated.jws,
                     vcSerialized = credential.vcJws,
@@ -74,13 +70,10 @@ class HolderAgent(
             }
 
             is Holder.StoreCredentialInput.SdJwt -> {
-                val validated = validatorSdJwt.verifySdJwt(credential.signedSdJwtVc, keyMaterial.publicKey)
-                if (credential.signedSdJwtVc.keyBindingJws != null) Throwable("Issued SD-JWT credentials must not contain a KB")
-                if (validated !is Verifier.VerifyCredentialResult.SuccessSdJwt) {
-                    val error = (validated as? Verifier.VerifyCredentialResult.ValidationError)?.cause
-                        ?: Throwable("Invalid SD-JWT")
-                    throw VerificationError(error)
+                if (credential.signedSdJwtVc.keyBindingJws != null) {
+                    throw Throwable("Issued SD-JWT credentials must not contain a KB")
                 }
+                val validated = validatorSdJwt.verifySdJwt(credential.signedSdJwtVc, keyMaterial.publicKey).getOrThrow()
                 subjectCredentialStore.storeCredential(
                     vc = validated.verifiableCredentialSdJwt,
                     vcSerialized = credential.vcSdJwt,
@@ -91,12 +84,7 @@ class HolderAgent(
             }
 
             is Holder.StoreCredentialInput.Iso -> {
-                val validated = validatorMdoc.verifyIsoCred(credential.issuerSigned, credential.extractIssuerKey())
-                if (validated !is Verifier.VerifyCredentialResult.SuccessIso) {
-                    val error = (validated as? Verifier.VerifyCredentialResult.ValidationError)?.cause
-                        ?: Throwable("Invalid ISO MDOC")
-                    throw VerificationError(error)
-                }
+                val validated = validatorMdoc.verifyIsoCred(credential.issuerSigned, credential.extractIssuerKey()).getOrThrow()
                 subjectCredentialStore.storeCredential(
                     issuerSigned = validated.issuerSigned,
                     scheme = credential.scheme,
@@ -243,19 +231,27 @@ class HolderAgent(
             }
         }
 
-        val verifiablePresentations = credentialSubmissions.mapValues { match ->
+        val verifiablePresentations = credentialSubmissions.mapValues { (queryId, submissions) ->
             val query = credentialPresentation.presentationRequest.dcqlQuery.credentials.first {
-                it.id == match.key
+                it.id == queryId
             }
-            if (query.multiple != true && match.value.size != 1) {
-                throw IllegalArgumentException("Credential query ${query.id} does not allow multiple submission, but ${match.value.size} were provided.")
+            if(query.multiple != true && submissions.size != 1) {
+                throw IllegalArgumentException("Credential query ${query.id} does not allow multiple submission, but ${submissions.size} were provided.")
             }
-            match.value.map {
-                verifiablePresentationFactory.createVerifiablePresentation(
-                    request = request,
-                    credential = it.credential,
-                    disclosedAttributes = it.matchingResult,
-                ).getOrThrow()
+            submissions.map {
+                val credential = it.credential
+                if(credential is StoreEntry.Vc && !query.requireCryptographicHolderBinding) {
+                    if(it.matchingResult !is DCQLCredentialQueryMatchingResult.AllClaimsMatchingResult) {
+                        throw IllegalArgumentException("Credential type only allows disclosure of all attributes.")
+                    }
+                    CreatePresentationResult.VcJws(credential.vcSerialized)
+                } else {
+                    verifiablePresentationFactory.createVerifiablePresentation(
+                        request = request,
+                        credential = credential,
+                        disclosedAttributes = it.matchingResult,
+                    ).getOrThrow()
+                }
             }
         }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
@@ -103,6 +103,7 @@ sealed interface PresentationResponseParameters {
 
     companion object {
         private fun CreatePresentationResult.toJsonPrimitive() = when (val presentationResult = this) {
+            is CreatePresentationResult.Signed -> JsonPrimitive(presentationResult.serialized)
             is CreatePresentationResult.VpJws -> JsonPrimitive(presentationResult.serialized)
             is CreatePresentationResult.VcJws -> JsonPrimitive(presentationResult.serialized)
             is CreatePresentationResult.SdJwt -> JsonPrimitive(presentationResult.serialized)
@@ -122,6 +123,12 @@ sealed interface CreatePresentationResult {
     ) : VcJwsPresentationData
 
     data class VpJws(
+        val serialized: String,
+        val jwsSigned: JwsSigned<VerifiablePresentationJws>,
+    ) : VcJwsPresentationData
+
+    @Deprecated("Replaced with class using more expressive name `VpJws`.", ReplaceWith("VpJws"))
+    data class Signed(
         val serialized: String,
         val jwsSigned: JwsSigned<VerifiablePresentationJws>,
     ) : VcJwsPresentationData

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationDataClasses.kt
@@ -103,7 +103,8 @@ sealed interface PresentationResponseParameters {
 
     companion object {
         private fun CreatePresentationResult.toJsonPrimitive() = when (val presentationResult = this) {
-            is CreatePresentationResult.Signed -> JsonPrimitive(presentationResult.serialized)
+            is CreatePresentationResult.VpJws -> JsonPrimitive(presentationResult.serialized)
+            is CreatePresentationResult.VcJws -> JsonPrimitive(presentationResult.serialized)
             is CreatePresentationResult.SdJwt -> JsonPrimitive(presentationResult.serialized)
             is CreatePresentationResult.DeviceResponse -> JsonPrimitive(
                 coseCompliantSerializer.encodeToByteArray(presentationResult.deviceResponse)
@@ -113,20 +114,26 @@ sealed interface PresentationResponseParameters {
     }
 }
 
-sealed class CreatePresentationResult {
-    data class Signed(
+sealed interface CreatePresentationResult {
+    sealed interface VcJwsPresentationData : CreatePresentationResult
+
+    data class VcJws(
+        val serialized: String,
+    ) : VcJwsPresentationData
+
+    data class VpJws(
         val serialized: String,
         val jwsSigned: JwsSigned<VerifiablePresentationJws>,
-    ) : CreatePresentationResult()
+    ) : VcJwsPresentationData
 
     data class SdJwt(
         val serialized: String,
         val sdJwt: SdJwtSigned,
-    ) : CreatePresentationResult()
+    ) : CreatePresentationResult
 
     data class DeviceResponse(
         val deviceResponse: at.asitplus.iso.DeviceResponse,
-    ) : CreatePresentationResult()
+    ) : CreatePresentationResult
 }
 
 @Serializable

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatiorVcJwsValidationException.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatiorVcJwsValidationException.kt
@@ -1,0 +1,8 @@
+package at.asitplus.wallet.lib.agent
+
+import at.asitplus.wallet.lib.agent.validation.vcJws.VcJwsInputValidationResult
+
+class ValidatiorVcJwsValidationException(
+    @Suppress("CanBeParameter")
+    val validationResult: VcJwsInputValidationResult
+) : Throwable(validationResult.toString())

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorMdoc.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorMdoc.kt
@@ -1,5 +1,7 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.KmmResult
+import at.asitplus.catching
 import at.asitplus.iso.DeviceResponse
 import at.asitplus.iso.Document
 import at.asitplus.iso.IssuerSigned
@@ -47,10 +49,10 @@ class ValidatorMdoc(
     suspend fun verifyDeviceResponse(
         deviceResponse: DeviceResponse,
         verifyDocumentCallback: suspend (MobileSecurityObject, Document) -> Boolean,
-    ): VerifyPresentationResult {
+    ): KmmResult<VerifyPresentationResult.SuccessIso> = catching {
         require(deviceResponse.status == 0U) { "status: ${deviceResponse.status}" }
         require(deviceResponse.documents != null) { "documents are null" }
-        return VerifyPresentationResult.SuccessIso(
+        VerifyPresentationResult.SuccessIso(
             documents = deviceResponse.documents!!.map {
                 verifyDocument(it, verifyDocumentCallback)
             }
@@ -135,14 +137,12 @@ class ValidatorMdoc(
      *
      * @param it The [IssuerSigned] structure from ISO 18013-5
      */
-    suspend fun verifyIsoCred(it: IssuerSigned, issuerKey: CoseKey?): VerifyCredentialResult {
+    suspend fun verifyIsoCred(it: IssuerSigned, issuerKey: CoseKey?) = catching {
         Napier.d("Verifying ISO Cred $it")
         val mdocInputValidator = mdocInputValidator(it, issuerKey)
         if (!mdocInputValidator.isSuccess) {
-            return VerifyCredentialResult.ValidationError(
-                cause = mdocInputValidator.error ?: IllegalArgumentException("No details available")
-            )
+            throw mdocInputValidator.error ?: IllegalArgumentException("No details available")
         }
-        return SuccessIso(it)
+        SuccessIso(it)
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwt.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwt.kt
@@ -1,13 +1,13 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.KmmResult
+import at.asitplus.catching
 import at.asitplus.csc.contentEquals
 import at.asitplus.iso.sha256
 import at.asitplus.openid.TransactionDataBase64Url
 import at.asitplus.openid.digest
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.wallet.lib.agent.Verifier.VerifyCredentialResult
-import at.asitplus.wallet.lib.agent.Verifier.VerifyCredentialResult.SuccessSdJwt
-import at.asitplus.wallet.lib.agent.Verifier.VerifyCredentialResult.ValidationError
 import at.asitplus.wallet.lib.agent.Verifier.VerifyPresentationResult
 import at.asitplus.wallet.lib.agent.validation.sdJwt.SdJwtInputValidator
 import at.asitplus.wallet.lib.data.KeyBindingJws
@@ -50,48 +50,43 @@ class ValidatorSdJwt(
         challenge: String,
         clientId: String,
         transactionData: List<TransactionDataBase64Url>?,
-    ): VerifyPresentationResult {
+    ): KmmResult<VerifyPresentationResult.SuccessSdJwt> = catching {
         Napier.d("verifyVpSdJwt: '$input', '$challenge', '$clientId', '$transactionData'")
-        val sdJwtResult = verifySdJwt(input, null)
-        if (sdJwtResult !is SuccessSdJwt) {
-            val error = (sdJwtResult as? ValidationError)?.cause
-                ?: Throwable("SD-JWT not verified: $sdJwtResult")
-            return VerifyPresentationResult.ValidationError(error)
-        }
+        val sdJwtResult = verifySdJwt(input, null).getOrThrow()
         val keyBindingSigned = sdJwtResult.sdJwtSigned.keyBindingJws
-            ?: return VerifyPresentationResult.ValidationError("No key binding JWT")
+            ?: throw Throwable("No key binding JWT")
 
         val vcSdJwt = sdJwtResult.verifiableCredentialSdJwt
         vcSdJwt.confirmationClaim?.let {
             if (!verifyJwsSignatureWithCnf(keyBindingSigned, it)) {
-                return VerifyPresentationResult.ValidationError("Key binding JWT not verified (from cnf)")
+                throw Throwable("Key binding JWT not verified (from cnf)")
             }
         } ?: run {
             verifyJwsObject(keyBindingSigned).getOrElse {
-                return VerifyPresentationResult.ValidationError("Key binding JWT not verified. $it")
+                throw Throwable("Key binding JWT not verified. $it")
             }
         }
         val keyBinding = keyBindingSigned.payload
-        if (keyBinding.challenge != challenge) {
-            return VerifyPresentationResult.ValidationError("Challenge not correct: ${keyBinding.challenge}")
+        require(keyBinding.challenge == challenge) {
+            "Challenge not correct: ${keyBinding.challenge}"
         }
-        if (keyBinding.audience != clientId) {
-            return VerifyPresentationResult.ValidationError("Audience not correct: ${keyBinding.audience}")
+        require(keyBinding.audience == clientId) {
+            "Audience not correct: ${keyBinding.audience}"
         }
         if (!keyBinding.sdHash.contentEquals(input.hashInput.encodeToByteArray().sha256())) {
-            return VerifyPresentationResult.ValidationError("KB-JWT does not contain correct sd_hash")
+            throw Throwable("KB-JWT does not contain correct sd_hash")
         }
         if (verifyTransactionData) {
             transactionData?.let { data ->
                 val digests = data.map { it.digest(keyBinding.transactionDataHashesAlgorithm) }
                 if (keyBinding.transactionDataHashes?.contentEquals(digests) == false) {
-                    return VerifyPresentationResult.ValidationError("KB-JWT does not contain correct transaction data hashes")
+                    throw Throwable("KB-JWT does not contain correct transaction data hashes")
                 }
             }
         }
 
         Napier.d("verifyVpSdJwt: Valid")
-        return VerifyPresentationResult.SuccessSdJwt(
+        VerifyPresentationResult.SuccessSdJwt(
             sdJwtSigned = sdJwtResult.sdJwtSigned,
             verifiableCredentialSdJwt = vcSdJwt,
             reconstructedJsonObject = sdJwtResult.reconstructedJsonObject,
@@ -108,16 +103,16 @@ class ValidatorSdJwt(
     suspend fun verifySdJwt(
         sdJwtSigned: SdJwtSigned,
         publicKey: CryptoPublicKey?,
-    ): VerifyCredentialResult {
+    ): KmmResult<VerifyCredentialResult.SuccessSdJwt> = catching {
         Napier.d("Verifying SD-JWT $sdJwtSigned for $publicKey")
         val validationResult = sdJwtInputValidator.invoke(sdJwtSigned, publicKey)
         return when {
-            !validationResult.isIntegrityGood -> ValidationError("Signature not verified")
-            validationResult.payloadCredentialValidationSummary.getOrNull()?.isSuccess == false
-                -> ValidationError("cnf claim invalid")
+            !validationResult.isIntegrityGood -> throw Throwable("Signature not verified")
 
-            else -> validationResult.payload.getOrElse { return ValidationError(it) }
+            validationResult.payloadCredentialValidationSummary.getOrNull()?.isSuccess == false
+                -> throw IllegalArgumentException("cnf claim invalid")
+
+            else -> validationResult.payload
         }
     }
-
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcJws.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcJws.kt
@@ -12,11 +12,11 @@ package at.asitplus.wallet.lib.agent
  * see the "LICENSE" file for more details
  */
 
+import at.asitplus.KmmResult
+import at.asitplus.catching
 import at.asitplus.signum.indispensable.CryptoPublicKey
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.agent.Verifier.VerifyCredentialResult
-import at.asitplus.wallet.lib.agent.Verifier.VerifyCredentialResult.SuccessJwt
-import at.asitplus.wallet.lib.agent.Verifier.VerifyCredentialResult.ValidationError
 import at.asitplus.wallet.lib.agent.Verifier.VerifyPresentationResult
 import at.asitplus.wallet.lib.agent.validation.vcJws.VcJwsInputValidationResult.ContentValidationSummary
 import at.asitplus.wallet.lib.agent.validation.vcJws.VcJwsInputValidationResult.ParsingError
@@ -67,7 +67,7 @@ class ValidatorVcJws(
         input: JwsSigned<VerifiablePresentationJws>,
         challenge: String,
         clientId: String,
-    ): VerifyPresentationResult {
+    ): KmmResult<VerifyPresentationResult.Success> = catching {
         Napier.d("Verifying VP $input with $challenge and $clientId")
         verifyJwsObject(input).getOrThrow()
         val vpJws = input.payload.validate(challenge, clientId)
@@ -75,15 +75,15 @@ class ValidatorVcJws(
             .map { it to verifyVcJws(it, input.header.publicKey, input) }
 
         val invalidVcList = vcValidationResults.filter {
-            it.second !is SuccessJwt
+            it.second.isFailure
         }.map {
             it.first
         }
 
         val verificationResultWithFreshnessSummary = vcValidationResults.map {
             it.second
-        }.filterIsInstance<SuccessJwt>().map {
-            it.jws
+        }.mapNotNull {
+            it.getOrNull()?.jws
         }.map {
             VcJwsVerificationResultWrapper(
                 vcJws = it,
@@ -105,7 +105,7 @@ class ValidatorVcJws(
         )
         Napier.d("VP: Valid")
 
-        return VerifyPresentationResult.Success(vp)
+        VerifyPresentationResult.Success(vp)
     }
 
     @Throws(IllegalArgumentException::class)
@@ -145,16 +145,17 @@ class ValidatorVcJws(
         input: String,
         publicKey: CryptoPublicKey?,
         vpJws: JwsSigned<VerifiablePresentationJws>? = null,
-    ): VerifyCredentialResult =
+    ): KmmResult<VerifyCredentialResult.SuccessJwt> = catching {
         when (val result = vcJwsInputValidator(input, publicKey, vpJws)) {
-            is ParsingError -> ValidationError(result.throwable)
-            is ContentValidationSummary ->
-                if (result.isSuccess)
-                    SuccessJwt(result.payload)
-                else
-                    ValidationError(result.toString())
+            is ParsingError -> throw result.throwable
+            is ContentValidationSummary -> if (result.isSuccess) {
+                VerifyCredentialResult.SuccessJwt(result.payload)
+            } else {
+                throw ValidatiorVcJwsValidationException(result)
+            }
         }.also {
             Napier.d("Validating VC-JWS $input got $it")
         }
-
+    }
 }
+

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -306,7 +306,7 @@ class VerifiablePresentationFactory(
     suspend fun createVcPresentation(
         validCredentials: List<StoreEntry.Vc>,
         request: PresentationRequestParameters,
-    ): CreatePresentationResult.Signed = with(
+    ): CreatePresentationResult.VcJwsPresentationData = with(
         signVerifiablePresentation(
             JwsContentTypeConstants.JWT,
             VerifiablePresentation(validCredentials.map { it.vcSerialized }).toJws(
@@ -318,6 +318,6 @@ class VerifiablePresentationFactory(
         ).getOrElse {
             throw PresentationException(it)
         }) {
-        CreatePresentationResult.Signed(serialize(), this)
+        CreatePresentationResult.VpJws(serialize(), this)
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.KmmResult
 import at.asitplus.iso.DeviceResponse
 import at.asitplus.iso.Document
 import at.asitplus.iso.IssuerSigned
@@ -12,6 +13,7 @@ import at.asitplus.wallet.lib.agent.validation.CredentialFreshnessSummary
 import at.asitplus.wallet.lib.data.ConstantIndex
 import at.asitplus.wallet.lib.data.IsoDocumentParsed
 import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
+import at.asitplus.wallet.lib.data.VcJwsVerificationResultWrapper
 import at.asitplus.wallet.lib.data.VerifiableCredentialJws
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
@@ -35,7 +37,7 @@ interface Verifier {
         input: SdJwtSigned,
         challenge: String,
         transactionData: List<TransactionDataBase64Url>? = null,
-    ): VerifyPresentationResult
+    ): KmmResult<VerifyPresentationResult.SuccessSdJwt>
 
     /**
      * Verifies a presentation of some credentials in [ConstantIndex.CredentialRepresentation.PLAIN_JWT] from a holder,
@@ -44,7 +46,11 @@ interface Verifier {
     suspend fun verifyPresentationVcJwt(
         input: JwsSigned<VerifiablePresentationJws>,
         challenge: String,
-    ): VerifyPresentationResult
+    ): KmmResult<VerifyPresentationResult.Success>
+
+    suspend fun verifyUnsignedVcJws(
+        input: String
+    ): KmmResult<VerifyPresentationResult.SuccessUnsignedVcJws>
 
     /**
      * Verifies a presentation of some credentials in [ConstantIndex.CredentialRepresentation.ISO_MDOC] from a holder,
@@ -53,9 +59,13 @@ interface Verifier {
     suspend fun verifyPresentationIsoMdoc(
         input: DeviceResponse,
         verifyDocument: suspend (MobileSecurityObject, Document) -> Boolean,
-    ): VerifyPresentationResult
+    ): KmmResult<VerifyPresentationResult.SuccessIso>
 
     sealed class VerifyPresentationResult {
+        data class SuccessUnsignedVcJws(
+            val vc: VcJwsVerificationResultWrapper,
+        ) : VerifyPresentationResult()
+
         data class Success(
             val vp: VerifiablePresentationParsed,
         ) : VerifyPresentationResult()
@@ -71,12 +81,6 @@ interface Verifier {
         data class SuccessIso(
             val documents: List<IsoDocumentParsed>,
         ) : VerifyPresentationResult()
-
-        data class ValidationError(
-            val cause: Throwable,
-        ) : VerifyPresentationResult() {
-            constructor(message: String) : this(Throwable(message))
-        }
     }
 
     sealed class VerifyCredentialResult {
@@ -95,14 +99,7 @@ interface Verifier {
         data class SuccessIso(
             val issuerSigned: IssuerSigned,
         ) : VerifyCredentialResult()
-
-        data class ValidationError(
-            val cause: Throwable,
-        ) : VerifyCredentialResult() {
-            constructor(message: String) : this(Throwable(message))
-        }
     }
-
 }
 
 /**
@@ -120,4 +117,3 @@ fun CryptoPublicKey.matchesIdentifier(input: String): Boolean {
     return false
 }
 
-class VerificationError(cause: Throwable) : Throwable(cause)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
@@ -1,12 +1,14 @@
 package at.asitplus.wallet.lib.agent
 
-import at.asitplus.catchingUnwrapped
+import at.asitplus.KmmResult
+import at.asitplus.catching
 import at.asitplus.iso.DeviceResponse
 import at.asitplus.iso.Document
 import at.asitplus.iso.MobileSecurityObject
 import at.asitplus.openid.TransactionDataBase64Url
 import at.asitplus.signum.indispensable.josef.JwsSigned
 import at.asitplus.wallet.lib.agent.Verifier.VerifyPresentationResult
+import at.asitplus.wallet.lib.data.VcJwsVerificationResultWrapper
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 
@@ -24,32 +26,46 @@ class VerifierAgent(
     private val validatorSdJwt: ValidatorSdJwt = ValidatorSdJwt(),
     private val validatorMdoc: ValidatorMdoc = ValidatorMdoc(),
 ) : Verifier {
-
     override suspend fun verifyPresentationSdJwt(
         input: SdJwtSigned,
         challenge: String,
         transactionData: List<TransactionDataBase64Url>?,
-    ): VerifyPresentationResult = catchingUnwrapped {
-        validatorSdJwt.verifyVpSdJwt(input, challenge, identifier, transactionData)
-    }.getOrElse {
-        VerifyPresentationResult.ValidationError(it)
-    }
+    ): KmmResult<VerifyPresentationResult.SuccessSdJwt> = validatorSdJwt.verifyVpSdJwt(
+        input = input,
+        challenge = challenge,
+        clientId = identifier,
+        transactionData = transactionData,
+    )
 
     override suspend fun verifyPresentationVcJwt(
         input: JwsSigned<VerifiablePresentationJws>,
         challenge: String,
-    ): VerifyPresentationResult = catchingUnwrapped {
-        validatorVcJws.verifyVpJws(input, challenge, identifier)
-    }.getOrElse {
-        VerifyPresentationResult.ValidationError(it)
+    ): KmmResult<VerifyPresentationResult.Success> = validatorVcJws.verifyVpJws(
+        input = input,
+        challenge = challenge,
+        clientId = identifier,
+    )
+
+    override suspend fun verifyUnsignedVcJws(
+        input: String
+    ): KmmResult<VerifyPresentationResult.SuccessUnsignedVcJws> = validatorVcJws.verifyVcJws(
+        input = input,
+        publicKey = null,
+        vpJws = null
+    ).map { jws ->
+        VerifyPresentationResult.SuccessUnsignedVcJws(
+            VcJwsVerificationResultWrapper(
+                vcJws = jws.jws,
+                freshnessSummary = validatorVcJws.checkCredentialFreshness(jws.jws),
+            )
+        )
     }
 
     override suspend fun verifyPresentationIsoMdoc(
         input: DeviceResponse,
         verifyDocument: suspend (MobileSecurityObject, Document) -> Boolean,
-    ): VerifyPresentationResult = catchingUnwrapped {
-        validatorMdoc.verifyDeviceResponse(input, verifyDocument)
-    }.getOrElse {
-        VerifyPresentationResult.ValidationError(it)
-    }
+    ): KmmResult<VerifyPresentationResult.SuccessIso> = validatorMdoc.verifyDeviceResponse(
+        deviceResponse = input,
+        verifyDocumentCallback = verifyDocument,
+    )
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialPresentationRequest.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialPresentationRequest.kt
@@ -13,6 +13,9 @@ import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
+/**
+ * This class encodes the credential requirements from the verifier.
+ */
 @Serializable(with = CredentialPresentationRequestSerializer::class)
 sealed interface CredentialPresentationRequest {
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCRequestOptions.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCRequestOptions.kt
@@ -1,11 +1,16 @@
 package at.asitplus.wallet.lib.iso
 
+import at.asitplus.iso.DeviceRequest
+import at.asitplus.iso.ItemsRequest
+import at.asitplus.iso.ItemsRequestList
 import at.asitplus.wallet.lib.RequestOptions
 import at.asitplus.wallet.lib.RequestOptionsCredential
 
 data class Iso180137AnnexCRequestOptions(
-    /** Requested credentials, should be at least one. */
-    override val credentials: Set<RequestOptionsCredential>,
+    /**
+     * Device request can be built using [CredentialPresentationRequestBuilder]
+     */
+    val deviceRequest: DeviceRequest,
     /** Transaction ID. */
     override val state: String,
 ) : RequestOptions

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCResponseResult.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCResponseResult.kt
@@ -1,6 +1,7 @@
 package at.asitplus.wallet.lib.iso
 
 import at.asitplus.wallet.lib.data.IsoDocumentParsed
+import at.asitplus.wallet.lib.data.VcJwsVerificationResultWrapper
 import at.asitplus.wallet.lib.data.VerifiablePresentationParsed
 
 /**
@@ -16,17 +17,17 @@ sealed class Iso180137AnnexCResponseResult {
     ) : Iso180137AnnexCResponseResult()
 
     /**
-     * Error when validating
+     * Successfully decoded and validated the response from the Wallet
      */
-    data class ValidationError(
-        val cause: Throwable? = null,
+    data class Success(
+        val vp: VerifiablePresentationParsed,
     ) : Iso180137AnnexCResponseResult()
 
     /**
      * Successfully decoded and validated the response from the Wallet
      */
-    data class Success(
-        val vp: VerifiablePresentationParsed,
+    data class SuccessUnsigned(
+        val vc: VcJwsVerificationResultWrapper,
     ) : Iso180137AnnexCResponseResult()
 
     /**

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCVerifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCVerifier.kt
@@ -1,25 +1,22 @@
 package at.asitplus.wallet.lib.iso
 
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
 import at.asitplus.dcapi.DCAPIHandover
 import at.asitplus.dcapi.DCAPIHandover.Companion.TYPE_DCAPI
 import at.asitplus.dcapi.DCAPIInfo
 import at.asitplus.dcapi.DCAPIResponse
 import at.asitplus.dcapi.SessionTranscriptContentHashable
 import at.asitplus.dcapi.request.IsoMdocRequest
-import at.asitplus.iso.DeviceRequest
 import at.asitplus.iso.DeviceResponse
-import at.asitplus.iso.DocRequest
 import at.asitplus.iso.EncryptionInfo
 import at.asitplus.iso.EncryptionParameters
-import at.asitplus.iso.ItemsRequest
-import at.asitplus.iso.ItemsRequestList
 import at.asitplus.iso.SessionTranscript
-import at.asitplus.iso.SingleItemsRequest
 import at.asitplus.iso.serializeOrigin
 import at.asitplus.iso.sha256
 import at.asitplus.signum.indispensable.CryptoPrivateKey
 import at.asitplus.signum.indispensable.SecretExposure
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.wallet.lib.AbstractMdocVerifier
@@ -31,7 +28,9 @@ import at.asitplus.wallet.lib.agent.ValidatorMdoc
 import at.asitplus.wallet.lib.agent.Verifier.VerifyPresentationResult
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
-import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation
+import at.asitplus.wallet.lib.iso.Iso180137AnnexCResponseResult.Success
+import at.asitplus.wallet.lib.iso.Iso180137AnnexCResponseResult.SuccessIso
+import at.asitplus.wallet.lib.iso.Iso180137AnnexCResponseResult.SuccessUnsigned
 import at.asitplus.wallet.lib.utils.DefaultMapStore
 import at.asitplus.wallet.lib.utils.MapStore
 import io.github.aakira.napier.Napier
@@ -69,19 +68,7 @@ class Iso180137AnnexCVerifier(
     suspend fun createRequest(
         requestOptions: Iso180137AnnexCRequestOptions,
     ): IsoMdocRequest {
-        val docRequests = requestOptions.credentials.map {
-            if (it.representation != CredentialRepresentation.ISO_MDOC) {
-                throw UnsupportedOperationException("Wrong representation: Only ISO MDoc is supported")
-            }
-            val namespace = it.credentialScheme.isoNamespace ?: throw IllegalStateException("Missing namespace")
-            val docType = it.credentialScheme.isoDocType ?: throw IllegalStateException("Missing doc type")
-            val itemsRequestsListEntries = it.requestedAttributes?.map { reqAttr ->
-                SingleItemsRequest(reqAttr, false)
-            } ?: listOf()
-            val itemsRequestList = mapOf(namespace to ItemsRequestList(itemsRequestsListEntries))
-            DocRequest(ByteStringWrapper(ItemsRequest(docType, itemsRequestList)))
-        }.toTypedArray()
-        val deviceRequest = DeviceRequest("1.0", docRequests)
+        val deviceRequest = requestOptions.deviceRequest
 
         val encryptionParameters = EncryptionParameters(
             nonceService.provideNonce().toByteArray(),
@@ -107,11 +94,13 @@ class Iso180137AnnexCVerifier(
         )
     )
 
-    private fun VerifyPresentationResult.mapToResponseResult() = when (this) {
-        is VerifyPresentationResult.ValidationError -> Iso180137AnnexCResponseResult.ValidationError(cause = cause)
-        is VerifyPresentationResult.Success -> Iso180137AnnexCResponseResult.Success(vp)
-        is VerifyPresentationResult.SuccessIso -> Iso180137AnnexCResponseResult.SuccessIso(documents)
-        is VerifyPresentationResult.SuccessSdJwt -> throw IllegalStateException("Unexpected SuccessSdJwt")
+    private fun KmmResult<VerifyPresentationResult>.mapToResponseResult() = map {
+        when (it) {
+            is VerifyPresentationResult.Success -> Success(it.vp)
+            is VerifyPresentationResult.SuccessIso -> SuccessIso(it.documents)
+            is VerifyPresentationResult.SuccessSdJwt -> throw IllegalStateException("Unexpected SuccessSdJwt")
+            is VerifyPresentationResult.SuccessUnsignedVcJws -> SuccessUnsigned(it.vc)
+        }
     }
 
     @OptIn(SecretExposure::class)
@@ -120,7 +109,7 @@ class Iso180137AnnexCVerifier(
         externalId: String,
         decryptHpke: suspend (ByteArray, ByteArray, CryptoPrivateKey.EC.WithPublicKey, ByteArray) -> ByteArray,
         expectedOrigin: String
-    ): Iso180137AnnexCResponseResult {
+    ): KmmResult<Iso180137AnnexCResponseResult> = catching {
         val isoMdocRequest = stateToIsoMdocRequestStore.get(externalId)!!
         val privateKey = decryptionKeyMaterial.exportPrivateKey().getOrThrow()
                 as? CryptoPrivateKey.EC.WithPublicKey ?: throw IllegalStateException("Expected EC private key")

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentComplexSdJwtDcqlTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentComplexSdJwtDcqlTest.kt
@@ -69,7 +69,7 @@ val AgentComplexSdJwtDcqlTest by testSuite {
             val vp = createPresentation(it.holder, it.challenge, dcqlQuery, it.verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 1 // for address only
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -102,7 +102,7 @@ val AgentComplexSdJwtDcqlTest by testSuite {
             val vp = createPresentation(it.holder, it.challenge, dcqlQuery, it.verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 2 // for region, country
 
@@ -137,7 +137,7 @@ val AgentComplexSdJwtDcqlTest by testSuite {
             val vp = createPresentation(it.holder, it.challenge, dcqlQuery, it.verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -164,7 +164,7 @@ val AgentComplexSdJwtDcqlTest by testSuite {
             val vp = createPresentation(it.holder, it.challenge, dcqlQuery, it.verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -193,7 +193,7 @@ val AgentComplexSdJwtDcqlTest by testSuite {
             val vp = createPresentation(it.holder, it.challenge, dcqlQuery, it.verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -220,7 +220,7 @@ val AgentComplexSdJwtDcqlTest by testSuite {
             val vp = createPresentation(it.holder, it.challenge, dcqlQuery, it.verifierId)
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 2 // claim_given_name, claim_family_name
                     reconstructedJsonObject[AtomicAttribute2023.CLAIM_GIVEN_NAME]

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentComplexSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentComplexSdJwtTest.kt
@@ -63,7 +63,7 @@ val AgentComplexSdJwtTest by testSuite {
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 1 // for address only
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -96,7 +96,7 @@ val AgentComplexSdJwtTest by testSuite {
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 2 // for region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -130,7 +130,7 @@ val AgentComplexSdJwtTest by testSuite {
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -161,7 +161,7 @@ val AgentComplexSdJwtTest by testSuite {
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -190,7 +190,7 @@ val AgentComplexSdJwtTest by testSuite {
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 3 // for address, region, country
                     reconstructedJsonObject[CLAIM_ADDRESS]?.jsonObject?.get(CLAIM_ADDRESS_REGION)
@@ -221,7 +221,7 @@ val AgentComplexSdJwtTest by testSuite {
                 .presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     disclosures.size shouldBe 2 // claim_given_name, claim_family_name
                     reconstructedJsonObject[CLAIM_GIVEN_NAME]

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentIsoMdocMultipleDocumentsTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentIsoMdocMultipleDocumentsTest.kt
@@ -108,7 +108,7 @@ val AgentIsoMdocMultipleDocumentsTest by testSuite {
 
             presentationParameters.presentationResults.shouldHaveSize(2).forEach { result ->
                 result.shouldBeInstanceOf<CreatePresentationResult.DeviceResponse>()
-                it.verifier.verifyPresentationIsoMdoc(result.deviceResponse, documentVerifier())
+                it.verifier.verifyPresentationIsoMdoc(result.deviceResponse, documentVerifier()).getOrThrow()
                     .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessIso>().apply {
                         documents.shouldBeSingleton().forEach {
                             it.freshnessSummary.tokenStatusValidationResult
@@ -118,7 +118,7 @@ val AgentIsoMdocMultipleDocumentsTest by testSuite {
             }
             val validItems = presentationParameters.presentationResults
                 .filterIsInstance<CreatePresentationResult.DeviceResponse>()
-                .map { resp -> it.verifier.verifyPresentationIsoMdoc(resp.deviceResponse, documentVerifier()) }
+                .map { resp -> it.verifier.verifyPresentationIsoMdoc(resp.deviceResponse, documentVerifier()).getOrThrow() }
                 .flatMap { it.shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessIso>().documents }
                 .flatMap { it.validItems }
             validItems.firstOrNull { item -> item.elementIdentifier == CLAIM_GIVEN_NAME }
@@ -150,7 +150,7 @@ val AgentIsoMdocMultipleDocumentsTest by testSuite {
             presentationParameters.presentationResults
                 .shouldBeSingleton().firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.DeviceResponse>().let { result ->
-                    it.verifier.verifyPresentationIsoMdoc(result.deviceResponse, documentVerifier())
+                    it.verifier.verifyPresentationIsoMdoc(result.deviceResponse, documentVerifier()).getOrThrow()
                         .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessIso>().apply {
                             documents.shouldHaveSize(2).forEach {
                                 it.freshnessSummary.tokenStatusValidationResult
@@ -161,7 +161,7 @@ val AgentIsoMdocMultipleDocumentsTest by testSuite {
 
             val validItems = presentationParameters.presentationResults
                 .filterIsInstance<CreatePresentationResult.DeviceResponse>()
-                .map { resp -> it.verifier.verifyPresentationIsoMdoc(resp.deviceResponse, documentVerifier()) }
+                .map { resp -> it.verifier.verifyPresentationIsoMdoc(resp.deviceResponse, documentVerifier()).getOrThrow() }
                 .flatMap { it.shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessIso>().documents }
                 .flatMap { it.validItems }
             validItems.firstOrNull { item -> item.elementIdentifier == CLAIM_GIVEN_NAME }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentIsoMdocTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentIsoMdocTest.kt
@@ -298,7 +298,7 @@ private suspend fun IsoMdocFixture.createDcqlDeviceResponse(vararg attributeName
 )
 
 private suspend fun IsoMdocFixture.verifyPresentation(deviceResponse: CreatePresentationResult.DeviceResponse) =
-    verifier.verifyPresentationIsoMdoc(deviceResponse.deviceResponse, documentVerifier())
+    verifier.verifyPresentationIsoMdoc(deviceResponse.deviceResponse, documentVerifier()).getOrThrow()
         .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessIso>()
 
 private suspend fun IsoMdocFixture.revokeSingleStoredCredential(): Boolean {

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentIsoMdocTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentIsoMdocTest.kt
@@ -175,7 +175,7 @@ val AgentIsoMdocTest by testSuite {
                         ),
                     )
 
-                    mismatchedVerifier.verifyPresentationIsoMdoc(vp.deviceResponse, documentVerifier())
+                    mismatchedVerifier.verifyPresentationIsoMdoc(vp.deviceResponse, documentVerifier()).getOrThrow()
                         .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessIso>()
                         .documents.shouldBeSingleton().first().freshnessSummary.tokenStatusValidationResult
                         .shouldBeInstanceOf<TokenStatusValidationResult.Rejected>()
@@ -281,13 +281,14 @@ private fun statusListResolver(statusListIssuer: StatusListAgent) = TokenStatusR
     }
 )
 
-private suspend fun IsoMdocFixture.createPresexDeviceResponse(vararg attributeNames: String) = createPresexDeviceResponse(
-    holder = holder,
-    challenge = challenge,
-    verifierId = verifierId,
-    signer = signer,
-    attributeNames = attributeNames,
-)
+private suspend fun IsoMdocFixture.createPresexDeviceResponse(vararg attributeNames: String) =
+    createPresexDeviceResponse(
+        holder = holder,
+        challenge = challenge,
+        verifierId = verifierId,
+        signer = signer,
+        attributeNames = attributeNames,
+    )
 
 private suspend fun IsoMdocFixture.createDcqlDeviceResponse(vararg attributeNames: String) = createDcqlDeviceResponse(
     holder = holder,

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -164,7 +164,7 @@ val AgentRevocationTest by testSuite {
                 fail("no issued credentials")
             }.shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-            ValidatorVcJws().verifyVcJws(result.signedVcJws, it.verifierKeyMaterial.publicKey)
+            ValidatorVcJws().verifyVcJws(result.signedVcJws, it.verifierKeyMaterial.publicKey).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyCredentialResult.SuccessJwt>()
                 .jws.vc.credentialStatus
                 .shouldNotBeNull()

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentSdJwtTest.kt
@@ -39,6 +39,7 @@ import at.asitplus.wallet.lib.jws.VerifyStatusListTokenHAIP
 import at.asitplus.wallet.lib.randomCwtOrJwtResolver
 import com.benasher44.uuid.uuid4
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -105,7 +106,7 @@ val AgentSdJwtTest by testSuite {
                 validSdJwtCredential = credential,
                 claimName = CLAIM_GIVEN_NAME
             )
-            it.verifier.verifyPresentationSdJwt(sdJwt.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(sdJwt.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     reconstructedJsonObject.keys shouldContain CLAIM_GIVEN_NAME
                     freshnessSummary.tokenStatusValidationResult
@@ -122,7 +123,7 @@ val AgentSdJwtTest by testSuite {
             val vp = presentationParameters.presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     reconstructedJsonObject[CLAIM_GIVEN_NAME]?.jsonPrimitive?.content shouldBe "Susanne"
                     reconstructedJsonObject[CLAIM_DATE_OF_BIRTH]?.jsonPrimitive?.content shouldBe "1990-01-01"
@@ -143,8 +144,12 @@ val AgentSdJwtTest by testSuite {
             val freshKbJwt = createFreshSdJwtKeyBinding(it.challenge, it.verifierId)
             val malformedVpSdJwt = vp.serialized.replaceAfterLast("~", freshKbJwt.substringAfterLast("~"))
 
-            it.verifier.verifyPresentationSdJwt(SdJwtSigned.parseCatching(malformedVpSdJwt).getOrThrow(), it.challenge)
-                .shouldBeInstanceOf<Verifier.VerifyPresentationResult.ValidationError>()
+            shouldThrowAny {
+                it.verifier.verifyPresentationSdJwt(
+                    SdJwtSigned.parseCatching(malformedVpSdJwt).getOrThrow(),
+                    it.challenge
+                ).getOrThrow()
+            }
         }
 
         "presex: wrong challenge in key binding jwt" {
@@ -157,8 +162,9 @@ val AgentSdJwtTest by testSuite {
             val vp = presentationParameters.presentationResults.firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
-                .shouldBeInstanceOf<Verifier.VerifyPresentationResult.ValidationError>()
+            shouldThrowAny {
+                it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
+            }
         }
 
         "presex: revoked sd jwt" {
@@ -177,7 +183,7 @@ val AgentSdJwtTest by testSuite {
                         storeEntry.sdJwt.statusElement.shouldBeInstanceOf<StatusListInfo>().index
                     ) shouldBe true
                 }
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
                 .freshnessSummary.tokenStatusValidationResult
                 .shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()
@@ -201,7 +207,7 @@ val AgentSdJwtTest by testSuite {
             val vp = presentationParameters.verifiablePresentations.values.flatten().firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>().apply {
                     reconstructedJsonObject[CLAIM_GIVEN_NAME]?.jsonPrimitive?.content shouldBe "Susanne"
                     reconstructedJsonObject[CLAIM_DATE_OF_BIRTH]?.jsonPrimitive?.content shouldBe "1990-01-01"
@@ -228,8 +234,12 @@ val AgentSdJwtTest by testSuite {
             val freshKbJwt = createFreshSdJwtKeyBinding(it.challenge, it.verifierId)
             val malformedVpSdJwt = vp.serialized.replaceAfterLast("~", freshKbJwt.substringAfterLast("~"))
 
-            it.verifier.verifyPresentationSdJwt(SdJwtSigned.parseCatching(malformedVpSdJwt).getOrThrow(), it.challenge)
-                .shouldBeInstanceOf<Verifier.VerifyPresentationResult.ValidationError>()
+            shouldThrowAny {
+                it.verifier.verifyPresentationSdJwt(
+                    SdJwtSigned.parseCatching(malformedVpSdJwt).getOrThrow(),
+                    it.challenge
+                ).getOrThrow()
+            }
         }
 
         "dcql: wrong challenge in key binding jwt" {
@@ -251,8 +261,9 @@ val AgentSdJwtTest by testSuite {
             val vp = presentationParameters.verifiablePresentations.values.flatten().firstOrNull()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
-                .shouldBeInstanceOf<Verifier.VerifyPresentationResult.ValidationError>()
+            shouldThrowAny {
+                it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
+            }
         }
 
         "dcql: revoked sd jwt" {
@@ -278,7 +289,7 @@ val AgentSdJwtTest by testSuite {
                         storeEntry.sdJwt.statusElement.shouldBeInstanceOf<StatusListInfo>().index,
                     ) shouldBe true
                 }
-            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            it.verifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
                 .freshnessSummary.tokenStatusValidationResult
                 .shouldBeInstanceOf<TokenStatusValidationResult.Invalid>()
@@ -316,7 +327,7 @@ val AgentSdJwtTest by testSuite {
             val vp = presentationParameters.verifiablePresentations.values.first().first()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            haipVerifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            haipVerifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
                 .freshnessSummary.tokenStatusValidationResult
                 .shouldBeInstanceOf<TokenStatusValidationResult.Valid>()
@@ -362,7 +373,7 @@ val AgentSdJwtTest by testSuite {
             val vp = presentationParameters.verifiablePresentations.values.first().first()
                 .shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
 
-            val test = haipVerifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge)
+            val test = haipVerifier.verifyPresentationSdJwt(vp.sdJwt, it.challenge).getOrThrow()
 
             test.shouldBeInstanceOf<Verifier.VerifyPresentationResult.SuccessSdJwt>()
                 .freshnessSummary.tokenStatusValidationResult

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentTest.kt
@@ -33,8 +33,10 @@ import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.randomCwtOrJwtResolver
 import com.benasher44.uuid.uuid4
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -104,8 +106,8 @@ val AgentTest by testSuite {
                 .shouldBeInstanceOf<PresentationResponseParameters.PresentationExchangeParameters>()
 
             val vp = presentationParameters.presentationResults.first()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
+            it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.Success>()
         }
 
@@ -130,9 +132,10 @@ val AgentTest by testSuite {
                 .shouldBeInstanceOf<PresentationResponseParameters.PresentationExchangeParameters>()
 
             val vp = presentationParameters.presentationResults.first()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
-                .shouldBeInstanceOf<Verifier.VerifyPresentationResult.ValidationError>()
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
+            shouldThrowAny {
+                it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
+            }
         }
 
         test("presex: getting credentials when there are no credentials stored") {
@@ -221,9 +224,9 @@ val AgentTest by testSuite {
 
             val vp = presentationParameters.presentationResults.firstOrNull()
                 .shouldNotBeNull()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
 
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
+            it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.Success>()
                 .also {
                     it.vp.notVerifiablyFreshVerifiableCredentials.shouldBeEmpty()
@@ -252,7 +255,7 @@ val AgentTest by testSuite {
 
             val vp = presentationParameters.presentationResults.firstOrNull()
                 .shouldNotBeNull()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
 
             val credentialToRevoke = it.issuer.issueCredential(
                 DummyCredentialDataProvider.getCredential(
@@ -267,7 +270,7 @@ val AgentTest by testSuite {
                 credentialToRevoke.vc.credentialStatus.shouldBeInstanceOf<StatusListInfo>().index
             ) shouldBe true
 
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
+            it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.Success>()
         }
 
@@ -310,8 +313,8 @@ val AgentTest by testSuite {
                 )
             ).getOrThrow() as PresentationResponseParameters.DCQLParameters
             val vp = presentationParameters.verifiablePresentations.values.flatten().first()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
+            it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.Success>()
         }
 
@@ -336,9 +339,10 @@ val AgentTest by testSuite {
                 )
             ).getOrThrow() as PresentationResponseParameters.DCQLParameters
             val vp = presentationParameters.verifiablePresentations.values.flatten().first()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
-                .shouldBeInstanceOf<Verifier.VerifyPresentationResult.ValidationError>()
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
+            shouldThrowAny {
+                it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
+            }
         }
 
         test("dcql: building presentation without necessary credentials") {
@@ -374,9 +378,9 @@ val AgentTest by testSuite {
             presentationParameters.shouldNotBeNull()
             val vp = presentationParameters.verifiablePresentations.values.flatten().firstOrNull()
                 .shouldNotBeNull()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
 
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
+            it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.Success>()
                 .also {
                     it.vp.notVerifiablyFreshVerifiableCredentials.shouldBeEmpty()
@@ -405,7 +409,7 @@ val AgentTest by testSuite {
             presentationParameters.shouldNotBeNull()
             val vp = presentationParameters.verifiablePresentations.values.flatten().firstOrNull()
                 .shouldNotBeNull()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
 
             val credentialToRevoke = it.issuer.issueCredential(
                 DummyCredentialDataProvider.getCredential(
@@ -421,8 +425,48 @@ val AgentTest by testSuite {
                 credentialToRevoke.vc.credentialStatus.shouldBeInstanceOf<StatusListInfo>().index
             ) shouldBe true
 
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
+            it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyPresentationResult.Success>()
+        }
+
+        test("dcql: present raw vcjws when requiring no cryptographic holder binding") {
+            val credentials = it.issuer.issueCredential(
+                DummyCredentialDataProvider.getCredential(
+                    it.holderKeyMaterial.publicKey,
+                    ConstantIndex.AtomicAttribute2023,
+                    PLAIN_JWT,
+                ).getOrThrow()
+            ).getOrThrow()
+            it.holder.storeCredential(credentials.toStoreCredentialInput()).getOrThrow()
+            val presentationParameters = it.holder.createDefaultPresentation(
+                request = PresentationRequestParameters(
+                    nonce = it.challenge,
+                    audience = it.verifierId
+                ),
+                credentialPresentationRequest = CredentialPresentationRequest.DCQLRequest(
+                    dcqlQuery = DCQLQuery(
+                        credentials = DCQLCredentialQueryList(
+                            DCQLJwtVcCredentialQuery(
+                                id = DCQLCredentialQueryIdentifier(uuid4().toString()),
+                                format = CredentialFormatEnum.JWT_VC,
+                                meta = DCQLJwtVcCredentialMetadataAndValidityConstraints(
+                                    typeValues = nonEmptyListOf(
+                                        listOf(
+                                            VERIFIABLE_CREDENTIAL,
+                                            ConstantIndex.AtomicAttribute2023.vcType
+                                        )
+                                    )
+                                ),
+                                requireCryptographicHolderBinding = false,
+                            )
+                        ),
+                    )
+                )
+            ).getOrNull() as PresentationResponseParameters.DCQLParameters?
+            presentationParameters.shouldNotBeNull()
+            presentationParameters.verifiablePresentations.values.flatten().firstOrNull()
+                .shouldNotBeNull()
+                .shouldBeInstanceOf<CreatePresentationResult.VcJws>()
         }
     }
 }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorMdocTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorMdocTest.kt
@@ -86,7 +86,7 @@ val ValidatorMdocTest by testSuite {
                         ?.getOrNull()
                 }
 
-            validator.verifyIsoCred(credential.issuerSigned, issuerKey)
+            validator.verifyIsoCred(credential.issuerSigned, issuerKey).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyCredentialResult.SuccessIso>()
         }
     }
@@ -108,7 +108,7 @@ val ValidatorMdocTest by testSuite {
                         ?.getOrNull()
                 }
 
-            val value = validator.verifyIsoCred(credential.issuerSigned, issuerKey)
+            val value = validator.verifyIsoCred(credential.issuerSigned, issuerKey).getOrThrow()
                 .shouldBeInstanceOf<Verifier.VerifyCredentialResult.SuccessIso>()
             issuerCredentialStore.setStatus(
                 timePeriod = FixedTimePeriodProvider.timePeriod,

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwtTest.kt
@@ -20,6 +20,8 @@ import at.asitplus.wallet.lib.jws.SdJwtSigned
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.jws.SignJwtFun
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.comparables.shouldNotBeGreaterThan
@@ -63,7 +65,10 @@ val ValidatorSdJwtTest by testSuite {
                 val signIssuedSdJwt: SignJwtFun<JsonObject> = SignJwt(holderKeyMaterial, JwsHeaderCertOrJwk())
                 val expirationDate = credential.expiration
                 val subjectId = credential.subjectPublicKey.didEncoded
-                val (sdJwt, disclosures) = credential.claims.toSdJsonObject(RandomSource.Default, credential.sdAlgorithm)
+                val (sdJwt, disclosures) = credential.claims.toSdJsonObject(
+                    RandomSource.Default,
+                    credential.sdAlgorithm
+                )
                 val vcSdJwt = VerifiableCredentialSdJwt(
                     subject = if (scrambleSubject) subjectId.reversed() else subjectId,
                     notBefore = issuanceDate,
@@ -106,7 +111,7 @@ val ValidatorSdJwtTest by testSuite {
             }
 
         }
-    }- {
+    } - {
 
         test("credentials are valid for holder's key") {
             val credential = it.issuer.issueCredential(it.buildCredentialData()).getOrThrow()
@@ -116,16 +121,16 @@ val ValidatorSdJwtTest by testSuite {
                     sdJwtVc.issuedAt.shouldNotBeNull() shouldNotBeGreaterThan Clock.System.now()
                 }
 
-            it.validator.verifySdJwt(credential.signedSdJwtVc, it.holderKeyMaterial.publicKey)
-                .shouldBeInstanceOf<Verifier.VerifyCredentialResult.SuccessSdJwt>()
+            it.validator.verifySdJwt(credential.signedSdJwtVc, it.holderKeyMaterial.publicKey).getOrThrow()
         }
 
         test("credentials are not valid for some other key") {
             val credential = it.issuer.issueCredential(it.buildCredentialData()).getOrThrow()
                 .shouldBeInstanceOf<Issuer.IssuedCredential.VcSdJwt>()
 
-            it.validator.verifySdJwt(credential.signedSdJwtVc, EphemeralKeyWithoutCert().publicKey)
-                .shouldBeInstanceOf<Verifier.VerifyCredentialResult.ValidationError>()
+            shouldThrowAny {
+                it.validator.verifySdJwt(credential.signedSdJwtVc, EphemeralKeyWithoutCert().publicKey).getOrThrow()
+            }
         }
 
         test("credentials without cnf are not valid") {
@@ -135,8 +140,9 @@ val ValidatorSdJwtTest by testSuite {
                 buildCnf = false,
             ).shouldBeInstanceOf<Issuer.IssuedCredential.VcSdJwt>()
 
-            it.validator.verifySdJwt(credential.signedSdJwtVc, it.holderKeyMaterial.publicKey)
-                .shouldBeInstanceOf<Verifier.VerifyCredentialResult.ValidationError>()
+            shouldThrowAny {
+                it.validator.verifySdJwt(credential.signedSdJwtVc, it.holderKeyMaterial.publicKey).getOrThrow()
+            }
         }
 
         test("credentials with random subject are valid") {
@@ -146,8 +152,7 @@ val ValidatorSdJwtTest by testSuite {
                 scrambleSubject = true,
             ).shouldBeInstanceOf<Issuer.IssuedCredential.VcSdJwt>()
 
-            it.validator.verifySdJwt(credential.signedSdJwtVc, it.holderKeyMaterial.publicKey)
-                .shouldBeInstanceOf<Verifier.VerifyCredentialResult.SuccessSdJwt>()
+            it.validator.verifySdJwt(credential.signedSdJwtVc, it.holderKeyMaterial.publicKey).getOrThrow()
         }
 
         test("credentials are valid with vctm added") {
@@ -171,14 +176,13 @@ val ValidatorSdJwtTest by testSuite {
                     } shouldBe typeMetadata
                 }
 
-            it.validator.verifySdJwt(credential.signedSdJwtVc, it.holderKeyMaterial.publicKey)
-                .shouldBeInstanceOf<Verifier.VerifyCredentialResult.SuccessSdJwt>().apply {
-                    sdJwtSigned.jws.header.vcTypeMetadata.shouldNotBeNull().shouldBeSingleton().first().let {
-                        it.decodeToByteArray(Base64UrlStrict).decodeToString().let {
-                            joseCompliantSerializer.decodeFromString<SdJwtTypeMetadata>(it)
-                        }
-                    } shouldBe typeMetadata
-                }
+            it.validator.verifySdJwt(credential.signedSdJwtVc, it.holderKeyMaterial.publicKey).getOrThrow().apply {
+                sdJwtSigned.jws.header.vcTypeMetadata.shouldNotBeNull().shouldBeSingleton().first().let {
+                    it.decodeToByteArray(Base64UrlStrict).decodeToString().let {
+                        joseCompliantSerializer.decodeFromString<SdJwtTypeMetadata>(it)
+                    }
+                } shouldBe typeMetadata
+            }
         }
     }
 

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
@@ -35,6 +35,7 @@ import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.randomCwtOrJwtResolver
 import com.benasher44.uuid.uuid4
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.comparables.shouldNotBeGreaterThan
 import io.kotest.matchers.shouldBe
@@ -157,7 +158,7 @@ val ValidatorVcTest by testSuite {
                 }
 
 
-            it.validator.verifyVcJws(credential.signedVcJws, it.verifierKeyMaterial.publicKey)
+            it.validator.verifyVcJws(credential.signedVcJws, it.verifierKeyMaterial.publicKey).getOrThrow()
                 .shouldBeInstanceOf<VerifyCredentialResult.SuccessJwt>()
         }
 
@@ -171,7 +172,7 @@ val ValidatorVcTest by testSuite {
             ).getOrThrow()
                 .shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-            val value = it.validator.verifyVcJws(credential.signedVcJws, it.verifierKeyMaterial.publicKey)
+            val value = it.validator.verifyVcJws(credential.signedVcJws, it.verifierKeyMaterial.publicKey).getOrThrow()
                 .shouldBeInstanceOf<VerifyCredentialResult.SuccessJwt>()
             it.issuerCredentialStore.setStatus(
                 timePeriod = FixedTimePeriodProvider.timePeriod,
@@ -179,7 +180,7 @@ val ValidatorVcTest by testSuite {
                 status = TokenStatus.Invalid,
             ) shouldBe true
 
-            it.validator.verifyVcJws(credential.signedVcJws, it.verifierKeyMaterial.publicKey)
+            it.validator.verifyVcJws(credential.signedVcJws, it.verifierKeyMaterial.publicKey).getOrThrow()
                 .shouldBeInstanceOf<VerifyCredentialResult.SuccessJwt>()
 
             it.validator.checkRevocationStatus(value.jws)
@@ -197,8 +198,9 @@ val ValidatorVcTest by testSuite {
             ).getOrThrow()
                 .shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-            it.validator.verifyVcJws(credential.signedVcJws, it.verifierKeyMaterial.publicKey)
-                .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+            shouldThrowAny {
+                it.validator.verifyVcJws(credential.signedVcJws, it.verifierKeyMaterial.publicKey).getOrThrow()
+            }
         }
 
         test("credential with invalid JWS format is not valid") {
@@ -211,10 +213,12 @@ val ValidatorVcTest by testSuite {
             ).getOrThrow()
                 .shouldBeInstanceOf<Issuer.IssuedCredential.VcJwt>()
 
-            it.validator.verifyVcJws(
-                credential.signedVcJws.serialize().replaceFirstChar { "f" },
-                it.verifierKeyMaterial.publicKey
-            ).shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+            shouldThrowAny {
+                it.validator.verifyVcJws(
+                    credential.signedVcJws.serialize().replaceFirstChar { "f" },
+                    it.verifierKeyMaterial.publicKey
+                ).getOrThrow()
+            }
         }
 
         "Manually created and valid credential is valid" { context ->
@@ -227,7 +231,7 @@ val ValidatorVcTest by testSuite {
                     .let { context.wrapVcInJws(it) }
                     .let { context.signJws(it) }
                     .let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
+                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow()
                             .shouldBeInstanceOf<VerifyCredentialResult.SuccessJwt>()
                     }
             }
@@ -243,8 +247,9 @@ val ValidatorVcTest by testSuite {
                     .let { context.wrapVcInJws(it) }
                     .let { context.wrapVcInJwsWrongKey(it) }
                     .let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+                        shouldThrowAny {
+                            context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow()
+                        }
                     }
             }
         }
@@ -259,8 +264,9 @@ val ValidatorVcTest by testSuite {
                     .let { context.wrapVcInJws(it, subject = "vc.id") }
                     .let { context.signJws(it) }
                     .let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+                        shouldThrowAny {
+                            context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow()
+                        }
                     }
             }
         }
@@ -274,8 +280,9 @@ val ValidatorVcTest by testSuite {
                 context.issueCredential(it)
                     .let { context.wrapVcInJws(it, issuer = "vc.issuer") }
                     .let { context.signJws(it) }.let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+                        shouldThrowAny {
+                            context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow()
+                        }
                     }
             }
         }
@@ -290,8 +297,9 @@ val ValidatorVcTest by testSuite {
                     .let { context.wrapVcInJws(it, jwtId = "vc.jwtId") }
                     .let { context.signJws(it) }
                     .let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+                        shouldThrowAny {
+                            context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow()
+                        }
                     }
             }
         }
@@ -315,8 +323,9 @@ val ValidatorVcTest by testSuite {
                     }
                     .let { vcJws -> context.signJws(vcJws) }
                     .let { signVcJws ->
-                        context.validator.verifyVcJws(signVcJws, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+                        shouldThrowAny {
+                            context.validator.verifyVcJws(signVcJws, context.verifierKeyMaterial.publicKey).getOrThrow()
+                        }
                     }
             }
         }
@@ -331,8 +340,7 @@ val ValidatorVcTest by testSuite {
                     .let { context.wrapVcInJws(it) }
                     .let { context.signJws(it) }
                     .let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.SuccessJwt>()
+                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow()
                     }
             }
         }
@@ -347,8 +355,9 @@ val ValidatorVcTest by testSuite {
                     .let { context.wrapVcInJws(it, expirationDate = Clock.System.now() - 1.hours) }
                     .let { context.signJws(it) }
                     .let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+                        shouldThrowAny {
+                            context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow()
+                        }
                     }
             }
         }
@@ -363,8 +372,9 @@ val ValidatorVcTest by testSuite {
                     .let { context.wrapVcInJws(it, expirationDate = Clock.System.now() + 2.hours) }
                     .let { context.signJws(it) }
                     .let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+                        shouldThrowAny {
+                            context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow()
+                        }
                     }
             }
         }
@@ -379,8 +389,9 @@ val ValidatorVcTest by testSuite {
                     .let { context.wrapVcInJws(it, issuanceDate = Clock.System.now() + 2.hours) }
                     .let { context.signJws(it) }
                     .let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+                        shouldThrowAny {
+                            context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow()
+                        }
                     }
             }
         }
@@ -395,10 +406,9 @@ val ValidatorVcTest by testSuite {
                     .let { context.wrapVcInJws(it) }
                     .let { context.signJws(it) }
                     .let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.SuccessJwt>().apply {
-                                context.validator.checkCredentialTimeliness(this.jws).isTimely shouldBe false
-                            }
+                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow().apply {
+                            context.validator.checkCredentialTimeliness(this.jws).isTimely shouldBe false
+                        }
                     }
             }
         }
@@ -413,8 +423,9 @@ val ValidatorVcTest by testSuite {
                     .let { context.wrapVcInJws(it, issuanceDate = Clock.System.now()) }
                     .let { context.signJws(it) }
                     .let {
-                        context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey)
-                            .shouldBeInstanceOf<VerifyCredentialResult.ValidationError>()
+                        shouldThrowAny {
+                            context.validator.verifyVcJws(it, context.verifierKeyMaterial.publicKey).getOrThrow()
+                        }
                     }
             }
         }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVpTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVpTest.kt
@@ -35,6 +35,7 @@ import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.randomCwtOrJwtResolver
 import com.benasher44.uuid.uuid4
 import de.infix.testBalloon.framework.core.testSuite
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldHaveSize
@@ -111,9 +112,8 @@ val ValidatorVpTest by testSuite {
             ).getOrNull().shouldBeInstanceOf<PresentationResponseParameters.PresentationExchangeParameters>()
 
             val vp = presentationParameters.presentationResults.first()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
-                .shouldBeInstanceOf<VerifyPresentationResult.Success>()
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
+            it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
         }
 
         "Presentation of VC from different holder is detected" {
@@ -135,10 +135,9 @@ val ValidatorVpTest by testSuite {
             val vp = it.verifiablePresentationFactory.createVcPresentation(
                 holderVc,
                 PresentationRequestParameters(nonce = it.challenge, audience = it.verifierId)
-            ).shouldBeInstanceOf<CreatePresentationResult.Signed>()
+            ).shouldBeInstanceOf<CreatePresentationResult.VpJws>()
 
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge).also {
-                it.shouldBeInstanceOf<VerifyPresentationResult.Success>()
+            it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow().also {
                 it.vp.freshVerifiableCredentials.shouldBeEmpty()
                 it.vp.notVerifiablyFreshVerifiableCredentials.shouldBeEmpty()
                 it.vp.invalidVerifiableCredentials.shouldBe(holderVc.map { it.vcSerialized })
@@ -152,9 +151,10 @@ val ValidatorVpTest by testSuite {
             ).getOrNull().shouldBeInstanceOf<PresentationResponseParameters.PresentationExchangeParameters>()
 
             val vp = presentationParameters.presentationResults.firstOrNull()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
-                .shouldBeInstanceOf<VerifyPresentationResult.ValidationError>()
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
+            shouldThrowAny {
+                it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
+            }
         }
 
         "wrong audience in VP leads to error" {
@@ -164,9 +164,10 @@ val ValidatorVpTest by testSuite {
             ).getOrThrow().shouldBeInstanceOf<PresentationResponseParameters.PresentationExchangeParameters>()
 
             val vp = presentationParameters.presentationResults.first()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge)
-                .shouldBeInstanceOf<VerifyPresentationResult.ValidationError>()
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
+            shouldThrowAny {
+                it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow()
+            }
         }
 
         "valid parsed presentation should separate revoked and valid credentials" {
@@ -176,7 +177,7 @@ val ValidatorVpTest by testSuite {
             ).getOrNull().shouldBeInstanceOf<PresentationResponseParameters.PresentationExchangeParameters>()
 
             val vp = presentationResults.presentationResults.first()
-                .shouldBeInstanceOf<CreatePresentationResult.Signed>()
+                .shouldBeInstanceOf<CreatePresentationResult.VpJws>()
             it.holderCredentialStore.getCredentials().getOrThrow()
                 .filterIsInstance<SubjectCredentialStore.StoreEntry.Vc>()
                 .map { it.vc }
@@ -188,7 +189,7 @@ val ValidatorVpTest by testSuite {
                     ) shouldBe true
                 }
 
-            it.verifier.verifyPresentationVcJwt(vp.jwsSigned, it.challenge).also {
+            it.verifier.verifyPresentationVcJwt(vp.jwsSigned.shouldNotBeNull(), it.challenge).getOrThrow().also {
                 it.shouldBeInstanceOf<VerifyPresentationResult.Success>()
                 it.vp.freshVerifiableCredentials.shouldBeEmpty()
             }
@@ -218,7 +219,7 @@ val ValidatorVpTest by testSuite {
                 VerifiablePresentationJws.serializer()
             ).getOrThrow()
 
-            it.verifier.verifyPresentationVcJwt(vpJws, it.challenge)
+            it.verifier.verifyPresentationVcJwt(vpJws, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<VerifyPresentationResult.Success>()
         }
 
@@ -244,7 +245,7 @@ val ValidatorVpTest by testSuite {
                 VerifiablePresentationJws.serializer()
             ).getOrThrow()
 
-            it.verifier.verifyPresentationVcJwt(vpJws, it.challenge)
+            it.verifier.verifyPresentationVcJwt(vpJws, it.challenge).getOrThrow()
                 .shouldBeInstanceOf<VerifyPresentationResult.Success>()
         }
 
@@ -265,8 +266,9 @@ val ValidatorVpTest by testSuite {
                 VerifiablePresentationJws.serializer()
             ).getOrThrow()
 
-            it.verifier.verifyPresentationVcJwt(vpJws, it.challenge)
-                .shouldBeInstanceOf<VerifyPresentationResult.ValidationError>()
+            shouldThrowAny {
+                it.verifier.verifyPresentationVcJwt(vpJws, it.challenge).getOrThrow()
+            }
         }
 
         "Wrong type in VP is not valid" {
@@ -289,8 +291,9 @@ val ValidatorVpTest by testSuite {
                 VerifiablePresentationJws.serializer()
             ).getOrThrow()
 
-            it.verifier.verifyPresentationVcJwt(vpJws, it.challenge)
-                .shouldBeInstanceOf<VerifyPresentationResult.ValidationError>()
+            shouldThrowAny {
+                it.verifier.verifyPresentationVcJwt(vpJws, it.challenge).getOrThrow()
+            }
         }
     }
 }


### PR DESCRIPTION
+ Refactoring of validation procedure to have more expressive types 
+ Changing OpenId4VPRequestOptions to transports a presentation request instead of it being built from credentials and presentation mechanism