### PR TITLE
Change: Don't send response on user initiated signature cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Release 5.12.0 (unreleased):
    - Change: Update DCQLClaimsQuery to OpenID4VP 1.0
    - Change: Do not fail when only matching credentials without submitting a presentation
    - Allow issuance and verification of `IdentifierList` Revocation Mechanism
+   - Change: Don't send response on user initiated signature cancellation
  - OpenID for Verifiable Credential Issuance:
    - Moved the class `RefreshTokenInfo` from `OpenId4VciClient` to `SubjectCredentialStore.kt` and renamed it to `CredentialRenewalInfo` to better describe its role in the renewal process.
      Kept `RefreshTokenInfo` in the original package for backward compatibility

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
@@ -180,10 +180,9 @@ class OpenId4VpWallet(
             preparationState = preparationState,
             credentialPresentation = credentialPresentation
         ).getOrElse {
-            if(it is UserInitiatedCancellationReason) {
-                throw it // DON'T send error response for user initiated signature cancellation
+            if(it !is UserInitiatedCancellationReason) {
+                sendAuthnErrorResponse(it, preparationState.request)
             }
-            sendAuthnErrorResponse(it, preparationState.request)
             throw it
         }.let {
             handleResponseResult(it)

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
@@ -6,6 +6,7 @@ import at.asitplus.catchingUnwrapped
 import at.asitplus.dcapi.request.DCAPIWalletRequest
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.RequestParametersFrom
+import at.asitplus.signum.supreme.UserInitiatedCancellationReason
 import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
@@ -179,6 +180,9 @@ class OpenId4VpWallet(
             preparationState = preparationState,
             credentialPresentation = credentialPresentation
         ).getOrElse {
+            if(it is UserInitiatedCancellationReason) {
+                throw it // DON'T send error response for user initiated signature cancellation
+            }
             sendAuthnErrorResponse(it, preparationState.request)
             throw it
         }.let {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -34,6 +34,7 @@ import at.asitplus.signum.indispensable.josef.JsonWebKeySet
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
+import at.asitplus.signum.supreme.UserInitiatedCancellationReason
 import at.asitplus.wallet.lib.RemoteResourceRetrieverFunction
 import at.asitplus.wallet.lib.RemoteResourceRetrieverInput
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
@@ -230,10 +231,24 @@ class OpenId4VpHolder(
         finalizeAuthorizationResponseParameters(
             state = preparationState,
         ).getOrElse {
+            it.getUserSignatureCancellationException()?.let {
+                throw it // DON'T create error response for user initiated signature cancellation, just expose it
+            }
             return createAuthnErrorResponse(it, preparationState.request)
         }.let {
             authenticationResponseFactory.createAuthenticationResponse(preparationState.request, it)
         }
+    }
+
+    private fun Throwable.getUserSignatureCancellationException(): UserInitiatedCancellationReason? {
+        var current: Throwable? = this
+        while(current != null) {
+            if(current is UserInitiatedCancellationReason) {
+                return current // DON'T send error response for user cancellation
+            }
+            current = current.cause
+        }
+        return null
     }
 
     /**
@@ -293,6 +308,9 @@ class OpenId4VpHolder(
             state = preparationState,
             credentialPresentation = credentialPresentation
         ).getOrElse {
+            it.getUserSignatureCancellationException()?.let { userCancellationException ->
+                throw userCancellationException // DON'T create error response for user initiated signature cancellation
+            }
             return createAuthnErrorResponse(it, preparationState.request)
         }.let {
             authenticationResponseFactory.createAuthenticationResponse(preparationState.request, it)


### PR DESCRIPTION
When the user cancels presentation signing, the app currently aborts the whole flow and goes to an error page.
This is because the library itself sends an error response. 

In order to improve the user presentation flow, we don't want to send an error response on user initiated signature cancellations. The user may just want to review or change selected credentials instead of aborting the whole flow.