### PR TITLE
Support credentials without cryptographic holder binding if none was required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Release 5.12.0 (unreleased):
    - Added `CredentialRenewalInfo` to `SubjectCredentialStore.StoreEntry`
    - Added support for refresh tokens in BearerTokenService
    - Change: When no cryptographic holder binding is required, present raw W3C Verifiable Credentials
-   - Change: When no cryptographic holder binding is required and no holder binding is available in SdJwt and IsoMdoc credentials, still accept those credentials
+   - Change: When no cryptographic holder binding is required and no holder binding is available in SdJwt credentials, still accept those credentials
    - Change: OpenId4VPRequestOptions now transports a presentation request directly instead of credentials and presentation mechanism
    - Change: Return type of `Verifier.verifyPresentationSdJwt` from `VerifyPresentationResult` to `KmmResult<VerifyPresentationResult.SuccessSdJwt>`
    - Change: Return type of `Verifier.verifyPresentationVcJwt` from `VerifyPresentationResult` to `KmmResult<VerifyPresentationResult.Success>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Release 5.12.0 (unreleased):
    - Added `CredentialRenewalInfo` to `SubjectCredentialStore.StoreEntry`
    - Added support for refresh tokens in BearerTokenService
    - Change: When no cryptographic holder binding is required, present raw W3C Verifiable Credentials
+   - Change: When no cryptographic holder binding is required and no holder binding is available in SdJwt and IsoMdoc credentials, still accept those credentials
    - Change: OpenId4VPRequestOptions now transports a presentation request directly instead of credentials and presentation mechanism
    - Change: Return type of `Verifier.verifyPresentationSdJwt` from `VerifyPresentationResult` to `KmmResult<VerifyPresentationResult.SuccessSdJwt>`
    - Change: Return type of `Verifier.verifyPresentationVcJwt` from `VerifyPresentationResult` to `KmmResult<VerifyPresentationResult.Success>`

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -703,7 +703,8 @@ class OpenId4VpVerifier(
                 throw IllegalArgumentException("relatedPresentation")
             },
             challenge = expectedNonce,
-            transactionData = transactionData
+            transactionData = transactionData,
+            requireCryptographicHolderBinding = requireCryptographicHolderBinding != false,
         )
 
         ClaimFormat.JWT_VP -> if (requireCryptographicHolderBinding != false) {
@@ -726,17 +727,23 @@ class OpenId4VpVerifier(
         ClaimFormat.MSO_MDOC -> verifier.verifyPresentationIsoMdoc(
             input = relatedPresentation.extractContent().decodeToByteArray(Base64UrlStrict)
                 .let { coseCompliantSerializer.decodeFromByteArray<DeviceResponse>(it) },
-            verifyDocument = verifyDocument(
-                sessionTranscript = createSessionTranscript(
-                    input = input,
-                    clientId = clientId,
-                    expectedNonce = expectedNonce,
-                    hasBeenEncrypted = input.hasBeenEncrypted,
-                    responseUrl = responseUrl,
-                    clientIdRequired = clientIdRequired,
-                    origin = origin
+            verifyDocument = if (requireCryptographicHolderBinding != false) {
+                verifyDocument(
+                    sessionTranscript = createSessionTranscript(
+                        input = input,
+                        clientId = clientId,
+                        expectedNonce = expectedNonce,
+                        hasBeenEncrypted = input.hasBeenEncrypted,
+                        responseUrl = responseUrl,
+                        clientIdRequired = clientIdRequired,
+                        origin = origin
+                    )
                 )
-            )
+            } else {
+                { _, _ ->
+                    true
+                }
+            }
         )
 
         else -> throw IllegalArgumentException("descriptor.format: $claimFormat")

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -727,23 +727,17 @@ class OpenId4VpVerifier(
         ClaimFormat.MSO_MDOC -> verifier.verifyPresentationIsoMdoc(
             input = relatedPresentation.extractContent().decodeToByteArray(Base64UrlStrict)
                 .let { coseCompliantSerializer.decodeFromByteArray<DeviceResponse>(it) },
-            verifyDocument = if (requireCryptographicHolderBinding != false) {
-                verifyDocument(
-                    sessionTranscript = createSessionTranscript(
-                        input = input,
-                        clientId = clientId,
-                        expectedNonce = expectedNonce,
-                        hasBeenEncrypted = input.hasBeenEncrypted,
-                        responseUrl = responseUrl,
-                        clientIdRequired = clientIdRequired,
-                        origin = origin
-                    )
+            verifyDocument = verifyDocument(
+                sessionTranscript = createSessionTranscript(
+                    input = input,
+                    clientId = clientId,
+                    expectedNonce = expectedNonce,
+                    hasBeenEncrypted = input.hasBeenEncrypted,
+                    responseUrl = responseUrl,
+                    clientIdRequired = clientIdRequired,
+                    origin = origin
                 )
-            } else {
-                { _, _ ->
-                    true
-                }
-            }
+            )
         )
 
         else -> throw IllegalArgumentException("descriptor.format: $claimFormat")

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwt.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ValidatorSdJwt.kt
@@ -50,37 +50,45 @@ class ValidatorSdJwt(
         challenge: String,
         clientId: String,
         transactionData: List<TransactionDataBase64Url>?,
+        requireCryptographicHolderBinding: Boolean = true,
     ): KmmResult<VerifyPresentationResult.SuccessSdJwt> = catching {
         Napier.d("verifyVpSdJwt: '$input', '$challenge', '$clientId', '$transactionData'")
         val sdJwtResult = verifySdJwt(input, null).getOrThrow()
-        val keyBindingSigned = sdJwtResult.sdJwtSigned.keyBindingJws
-            ?: throw Throwable("No key binding JWT")
-
         val vcSdJwt = sdJwtResult.verifiableCredentialSdJwt
-        vcSdJwt.confirmationClaim?.let {
-            if (!verifyJwsSignatureWithCnf(keyBindingSigned, it)) {
-                throw Throwable("Key binding JWT not verified (from cnf)")
+
+        // verify if present or holder binding is required
+        if (requireCryptographicHolderBinding && sdJwtResult.sdJwtSigned.keyBindingJws == null) {
+            throw Throwable("No key binding JWT")
+        }
+        sdJwtResult.sdJwtSigned.keyBindingJws?.also { keyBindingSigned ->
+            vcSdJwt.confirmationClaim?.let {
+                if (!verifyJwsSignatureWithCnf(keyBindingSigned, it)) {
+                    throw Throwable("Key binding JWT not verified (from cnf)")
+                }
+            } ?: run {
+                verifyJwsObject(keyBindingSigned).getOrElse {
+                    throw Throwable("Key binding JWT not verified. $it")
+                }
             }
-        } ?: run {
-            verifyJwsObject(keyBindingSigned).getOrElse {
-                throw Throwable("Key binding JWT not verified. $it")
+
+            val keyBinding = keyBindingSigned.payload
+            require(keyBinding.challenge == challenge) {
+                "Challenge not correct: ${keyBinding.challenge}"
             }
-        }
-        val keyBinding = keyBindingSigned.payload
-        require(keyBinding.challenge == challenge) {
-            "Challenge not correct: ${keyBinding.challenge}"
-        }
-        require(keyBinding.audience == clientId) {
-            "Audience not correct: ${keyBinding.audience}"
-        }
-        if (!keyBinding.sdHash.contentEquals(input.hashInput.encodeToByteArray().sha256())) {
-            throw Throwable("KB-JWT does not contain correct sd_hash")
-        }
-        if (verifyTransactionData) {
-            transactionData?.let { data ->
-                val digests = data.map { it.digest(keyBinding.transactionDataHashesAlgorithm) }
-                if (keyBinding.transactionDataHashes?.contentEquals(digests) == false) {
-                    throw Throwable("KB-JWT does not contain correct transaction data hashes")
+            require(keyBinding.audience == clientId) {
+                "Audience not correct: ${keyBinding.audience}"
+            }
+
+            if (!keyBinding.sdHash.contentEquals(input.hashInput.encodeToByteArray().sha256())) {
+                throw Throwable("KB-JWT does not contain correct sd_hash")
+            }
+
+            if (verifyTransactionData) {
+                transactionData?.let { data ->
+                    val digests = data.map { it.digest(keyBinding.transactionDataHashesAlgorithm) }
+                    if (keyBinding.transactionDataHashes?.contentEquals(digests) == false) {
+                        throw Throwable("KB-JWT does not contain correct transaction data hashes")
+                    }
                 }
             }
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/Verifier.kt
@@ -37,6 +37,7 @@ interface Verifier {
         input: SdJwtSigned,
         challenge: String,
         transactionData: List<TransactionDataBase64Url>? = null,
+        requireCryptographicHolderBinding: Boolean = true,
     ): KmmResult<VerifyPresentationResult.SuccessSdJwt>
 
     /**

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
@@ -30,6 +30,7 @@ class VerifierAgent(
         input: SdJwtSigned,
         challenge: String,
         transactionData: List<TransactionDataBase64Url>?,
+        requireCryptographicHolderBinding: Boolean,
     ): KmmResult<VerifyPresentationResult.SuccessSdJwt> = validatorSdJwt.verifyVpSdJwt(
         input = input,
         challenge = challenge,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifierAgent.kt
@@ -36,6 +36,7 @@ class VerifierAgent(
         challenge = challenge,
         clientId = identifier,
         transactionData = transactionData,
+        requireCryptographicHolderBinding = requireCryptographicHolderBinding,
     )
 
     override suspend fun verifyPresentationVcJwt(


### PR DESCRIPTION
Please verify that ISO MDOC validateDocument can just be skipped in that case (as implemented)