### PR TITLE
OID4VCI: fix required key attestation proof handling

### DIFF
--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletService.kt
@@ -351,14 +351,16 @@ class WalletService(
             clientNonce = clientNonce,
             credentialIssuer = metadata.credentialIssuer,
             clock = clock,
-            keyAttestationRequired = type.keyAttestationRequired
+            keyAttestationRequired = type.keyAttestationRequired,
+            supportedAlgorithms = type.supportedSigningAlgorithms,
         )
     } ?: credentialFormat.supportedProofTypes?.get(ProofTypes.ATTESTATION)?.let { type ->
         createCredentialRequestProofAttestation(
             clientNonce = clientNonce,
             credentialIssuer = metadata.credentialIssuer,
             clock = clock,
-            keyAttestationRequired = type.keyAttestationRequired
+            keyAttestationRequired = type.keyAttestationRequired,
+            supportedAlgorithms = type.supportedSigningAlgorithms,
         )
     } ?: CredentialRequestProofContainer()
 
@@ -366,17 +368,29 @@ class WalletService(
         clientNonce: String?,
         credentialIssuer: String?,
         clock: Clock = Clock.System,
-        keyAttestationRequired: KeyAttestationRequired? = null
+        keyAttestationRequired: KeyAttestationRequired? = null,
+        supportedAlgorithms: Collection<String>? = null,
     ): CredentialRequestProofContainer {
-        if (keyAttestationRequired != null && loadKeyAttestation == null) {
+        if (keyAttestationRequired != null && loadKeyAttestation == null && loadUnitAttestationPop == null) {
             throw IllegalArgumentException("Key attestation required, none provided")
         }
         val keyAttestation: JwsSigned<KeyAttestationJwt>? = loadKeyAttestation?.invoke(
             KeyAttestationInput(
                 clientNonce = clientNonce,
-                supportedAlgorithms = listOf() // TODO
+                supportedAlgorithms = supportedAlgorithms
             )
-        )?.getOrNull()
+        )?.getOrElse { throw IllegalArgumentException("Key attestation required, none provided", it) }
+            ?: loadUnitAttestationPop?.invoke(
+                LoadUnitAttestationPopInput(
+                    ttl = keyAttestationRequired?.preferredTtl ?: 31.days,
+                    payload = JsonWebToken(
+                        nonce = clientNonce,
+                        audience = credentialIssuer,
+                        issuedAt = clock.now(),
+                    ),
+                )
+            )?.getOrElse { throw IllegalArgumentException("Key attestation required, none provided", it) }
+                ?.let { JwsSigned.deserialize(KeyAttestationJwt.serializer(), it.serialize(), joseCompliantSerializer).getOrThrow() }
         keyAttestation?.requireKeyMaterialAtAttestedKeyIndex0()
 
         return CredentialRequestProofContainer(
@@ -408,15 +422,27 @@ class WalletService(
         clientNonce: String?,
         credentialIssuer: String?,
         clock: Clock = Clock.System,
-        keyAttestationRequired: KeyAttestationRequired? = null
+        keyAttestationRequired: KeyAttestationRequired? = null,
+        supportedAlgorithms: Collection<String>? = null,
     ): CredentialRequestProofContainer = CredentialRequestProofContainer(
         attestation = setOf(
-            loadKeyAttestation?.invoke(
+            (loadKeyAttestation?.invoke(
                 KeyAttestationInput(
                     clientNonce = clientNonce,
-                    supportedAlgorithms = listOf() // TODO
+                    supportedAlgorithms = supportedAlgorithms
                 )
             )?.getOrElse { throw IllegalArgumentException("Key attestation required, none provided", it) }
+                ?: loadUnitAttestationPop?.invoke(
+                    LoadUnitAttestationPopInput(
+                        ttl = keyAttestationRequired?.preferredTtl ?: 31.days,
+                        payload = JsonWebToken(
+                            nonce = clientNonce,
+                            audience = credentialIssuer,
+                            issuedAt = clock.now(),
+                        ),
+                    )
+                )?.getOrElse { throw IllegalArgumentException("Key attestation required, none provided", it) }
+            )
                 ?.serialize()
                 ?: throw IllegalArgumentException("Key attestation required, none provided"))
     )


### PR DESCRIPTION
### Motivation
- Attestation-proof issuance failed because the code read a nested `keyAttestation` header claim instead of using the JWS serialization returned by the loader. 
- Required-attestation failures were being swallowed, allowing building proofs without a required attestation and hiding the root cause. 
- The issuer-declared `proof_signing_alg_values_supported` was not forwarded to the attestation loader and the deprecated `loadUnitAttestationPop` was not preserved as a fallback.

### Description
- Forward `proof_signing_alg_values_supported` from `CredentialRequestProofSupported` into `createCredentialRequestProofJwt` and `createCredentialRequestProofAttestation` via a new `supportedAlgorithms` parameter. 
- Only raise `Key attestation required, none provided` when both `loadKeyAttestation` and `loadUnitAttestationPop` are missing, preserving the deprecated callback as a fallback. 
- Propagate loader failures by using `getOrElse { throw IllegalArgumentException(..., it) }` instead of silently dropping errors. 
- Use the returned JWS serialization as the attestation proof payload and, when using the deprecated POP callback, deserialize its JWS and convert it to a `JwsSigned<KeyAttestationJwt>` before embedding/serializing it for the proof.

### Testing
- Started the automated test run `./gradlew :vck-openid:commonTest --tests "*OidvciAttestationTest*" --console=plain`, which progressed through project configuration and compilation but did not complete within the session window so test completion/success could not be confirmed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2d71eb9d8833084543c7434caa337)