### PR TITLE
Integrate DCAPIWalletRequest into RequestParametersFrom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,13 @@ Release 6.0.0 (unreleased):
    - Change: `SdJwtSigned` now stores the issuer JWS as `JwsCompact` and key binding JWS as `JwsCompactTyped<KeyBindingJws>`
    - Deprecate `SdJwtSigned.getPayloadAsVerifiableCredentialSdJwt()` and `SdJwtSigned.getPayloadAsJsonObject()`, use `SdJwtSigned.jws.getPayload<...>()`
  - OpenID for Verifiable Presentations:
-   - Add `DcApiMultiSigned` member to `RequestParameterFrom` sealed class
+   - BREAKING: Integrate DC API request wrappers into `RequestParametersFrom` as `OpenId4VpDcApiUnsigned`, `OpenId4VpDcApiSigned`, `OpenId4VpDcApiMultiSigned`, and `IsoMdocDcApi`; DC API metadata such as `protocol`, `credentialIds`, `callingPackageName`, and `callingOrigin` is now represented directly on `RequestParametersFrom.DcApiRequest`
    - Add `attributePaths` and `optionalAttributePaths` to `RequestOptionsCredential` for requesting literal claim names containing dots with `DCQLClaimsPathPointer`, while keeping the deprecated string attributes as nested dot-notation shorthand. ISO mdoc requests also accept explicit namespace/name paths and prefix single claim names with the credential scheme namespace.
    - Change: `RequestInfo.dpop`/`RequestInfo.clientAttestation`/`RequestInfo.clientAttestationDpop` now `JwsCompactTyped` instead of `String`
    - Change: `BuildDPoPHeader`/`BuildClientAttestationJwt`/`BuildClientAttestationPoPJwt` objects now return `JwsCompactTyped` instead of `String`
    - Change `JarRequestParameter.clientId` from optional to mandatory to enforce RFC9101 definition.
  - Digital Credentials API:
-   - Add `OpenId4VpMultisigned` member to `DCAPIWalletRequest` sealed class
-   - BREAKING: Refactor `DCAPIWalletRequest.request` from `RequestParameter` to `String` to more narrowly convey content (`JWS` or `JsonString`)
+   - Deprecate `DCAPIWalletRequest` in favor of `RequestParametersFrom.DcApiRequest`; compatibility type aliases are provided for the old wallet request names
    - BREAKING: Refactor `DigitalCredentialGetRequest.OpenId4Vp`
      - Renamed `request` to `data` to reflect serial name
      - Introduced `SignedDataElement` `MultiSignedDataElement` wrapper to keep serialization shape

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequest.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequest.kt
@@ -22,7 +22,7 @@ typealias DCAPIWalletRequest = RequestParametersFrom.DcApiRequest
     ),
     level = DeprecationLevel.WARNING
 )
-typealias DCAPIWalletOpenId4VpSigned = RequestParametersFrom.OpenId4VpSigned
+typealias DCAPIWalletOpenId4VpSigned = RequestParametersFrom.OpenId4VpDcApiSigned
 
 @Deprecated(
     message = "Use RequestParametersFrom.OpenId4VpMultiSigned instead.",
@@ -32,7 +32,7 @@ typealias DCAPIWalletOpenId4VpSigned = RequestParametersFrom.OpenId4VpSigned
     ),
     level = DeprecationLevel.WARNING
 )
-typealias DCAPIWalletOpenId4VpMultiSigned = RequestParametersFrom.OpenId4VpMultiSigned
+typealias DCAPIWalletOpenId4VpMultiSigned = RequestParametersFrom.OpenId4VpDcApiMultiSigned
 
 @Deprecated(
     message = "Use RequestParametersFrom.OpenId4VpUnsigned instead.",
@@ -42,7 +42,7 @@ typealias DCAPIWalletOpenId4VpMultiSigned = RequestParametersFrom.OpenId4VpMulti
     ),
     level = DeprecationLevel.WARNING
 )
-typealias DCAPIWalletOpenId4VpUnsigned = RequestParametersFrom.OpenId4VpUnsigned
+typealias DCAPIWalletOpenId4VpUnsigned = RequestParametersFrom.OpenId4VpDcApiUnsigned
 
 @Deprecated(
     message = "Use RequestParametersFrom.IsoMdoc instead.",
@@ -52,4 +52,4 @@ typealias DCAPIWalletOpenId4VpUnsigned = RequestParametersFrom.OpenId4VpUnsigned
     ),
     level = DeprecationLevel.WARNING
 )
-typealias DCAPIWalletIsoMdoc = RequestParametersFrom.IsoMdoc
+typealias DCAPIWalletIsoMdoc = RequestParametersFrom.IsoMdocDcApi

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequest.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequest.kt
@@ -17,7 +17,7 @@ typealias DCAPIWalletRequest = RequestParametersFrom.DcApiRequest
 @Deprecated(
     message = "Use RequestParametersFrom.OpenId4VpSigned instead.",
     replaceWith = ReplaceWith(
-        expression = "RequestParametersFrom.OpenId4VpSigned",
+        expression = "RequestParametersFrom.OpenId4VpDcApiSigned",
         imports = ["at.asitplus.openid.RequestParametersFrom"]
     ),
     level = DeprecationLevel.WARNING
@@ -27,7 +27,7 @@ typealias DCAPIWalletOpenId4VpSigned = RequestParametersFrom.OpenId4VpDcApiSigne
 @Deprecated(
     message = "Use RequestParametersFrom.OpenId4VpMultiSigned instead.",
     replaceWith = ReplaceWith(
-        expression = "RequestParametersFrom.OpenId4VpMultiSigned",
+        expression = "RequestParametersFrom.OpenId4VpDcApiMultiSigned",
         imports = ["at.asitplus.openid.RequestParametersFrom"]
     ),
     level = DeprecationLevel.WARNING
@@ -37,7 +37,7 @@ typealias DCAPIWalletOpenId4VpMultiSigned = RequestParametersFrom.OpenId4VpDcApi
 @Deprecated(
     message = "Use RequestParametersFrom.OpenId4VpUnsigned instead.",
     replaceWith = ReplaceWith(
-        expression = "RequestParametersFrom.OpenId4VpUnsigned",
+        expression = "RequestParametersFrom.OpenId4VpDcApiUnsigned",
         imports = ["at.asitplus.openid.RequestParametersFrom"]
     ),
     level = DeprecationLevel.WARNING
@@ -47,7 +47,7 @@ typealias DCAPIWalletOpenId4VpUnsigned = RequestParametersFrom.OpenId4VpDcApiUns
 @Deprecated(
     message = "Use RequestParametersFrom.IsoMdoc instead.",
     replaceWith = ReplaceWith(
-        expression = "RequestParametersFrom.IsoMdoc",
+        expression = "RequestParametersFrom.IsoMdocDcApi",
         imports = ["at.asitplus.openid.RequestParametersFrom"]
     ),
     level = DeprecationLevel.WARNING

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequest.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequest.kt
@@ -1,173 +1,55 @@
+@file:Suppress("DEPRECATION")
+
 package at.asitplus.dcapi.request
 
-import at.asitplus.openid.AuthenticationRequestParameters
-import at.asitplus.openid.JarRequestParameters
-import at.asitplus.openid.RequestParameters
-import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
-import at.asitplus.signum.indispensable.josef.JWS
-import at.asitplus.signum.indispensable.josef.JwsCompactStringSerializer
-import at.asitplus.signum.indispensable.josef.JwsTyped
-import at.asitplus.signum.indispensable.josef.typed
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonClassDiscriminator
-import kotlin.jvm.JvmInline
-import at.asitplus.signum.indispensable.josef.JwsCompact as JosefJwsCompact
-import at.asitplus.signum.indispensable.josef.JwsGeneral as JosefJwsGeneral
+import at.asitplus.openid.RequestParametersFrom
 
-/**
- * Abstract base class for requests received by the wallet via the Digital Credentials API.
- */
-@Serializable
-@JsonClassDiscriminator("protocol")
-sealed interface DCAPIWalletRequest {
-    val protocol: ExchangeProtocolIdentifier
-
-    /** The credential IDs of the credentials the user has chosen in the UI provided by the system.
-    Not available on iOS. */
-    val credentialIds: Collection<String>?
-
-    /** The package name of the calling (browser) application providing the calling origin. Not available on iOS. */
-    val callingPackageName: String?
-    val callingOrigin: String
-
-    @Serializable
-    data class IsoMdoc(
-        @SerialName("isoMdocRequest")
-        val isoMdocRequest: IsoMdocRequest,
-        @SerialName("credentialIds")
-        override val credentialIds: Collection<String>? = null,
-        @SerialName("callingPackageName")
-        override val callingPackageName: String? = null,
-        @SerialName("callingOrigin")
-        override val callingOrigin: String,
-    ) : DCAPIWalletRequest {
-
-        override val protocol: ExchangeProtocolIdentifier
-            get() = ExchangeProtocolIdentifier.IsoMdocAnnexC
-    }
-
-    sealed class OpenId4Vp : DCAPIWalletRequest {
-        abstract val request: OpenId4VpRequest
-        abstract override val protocol: ExchangeProtocolIdentifier
-
-
-        sealed interface OpenId4VpRequest {
-            @JvmInline
-            @Serializable(with = JwsCompact.Serializer::class)
-            value class JwsCompact(
-                val request: JwsTyped<JosefJwsCompact, AuthenticationRequestParameters>
-            ) : OpenId4VpRequest {
-                object Serializer : KSerializer<JwsCompact> by TransformingSerializerTemplate(
-                    parent = JwsTypedSerializerTemplate(
-                        JwsCompactStringSerializer,
-                        AuthenticationRequestParameters.serializer()
-                    ),
-                    encodeAs = JwsCompact::request,
-                    decodeAs = ::JwsCompact,
-                )
-            }
-
-            @JvmInline
-            @Serializable(with = JwsGeneral.Serializer::class)
-            value class JwsGeneral(
-                val request: JwsTyped<JosefJwsGeneral, AuthenticationRequestParameters>
-            ) : OpenId4VpRequest {
-                object Serializer : KSerializer<JwsGeneral> by TransformingSerializerTemplate(
-                    parent = JwsTypedSerializerTemplate(
-                        JosefJwsGeneral.serializer(),
-                        AuthenticationRequestParameters.serializer()
-                    ),
-                    encodeAs = JwsGeneral::request,
-                    decodeAs = ::JwsGeneral,
-                )
-            }
-
-            @JvmInline
-            @Serializable
-            value class Unsigned(
-                val request: AuthenticationRequestParameters,
-            ) : OpenId4VpRequest
-        }
-    }
-
-    @Serializable
-    @SerialName(ExchangeProtocolIdentifier.OPENID4VP_V1_MULTISIGNED)
-    data class OpenId4VpMultiSigned(
-        @SerialName("request")
-        override val request: OpenId4VpRequest.JwsGeneral,
-        @SerialName("credentialIds")
-        override val credentialIds: Collection<String>,
-        @SerialName("callingPackageName")
-        override val callingPackageName: String,
-        @SerialName("callingOrigin")
-        override val callingOrigin: String,
-    ) : OpenId4Vp() {
-
-        override val protocol: ExchangeProtocolIdentifier
-            get() = ExchangeProtocolIdentifier.OpenId4VpV1Multisigned
-    }
-
-    @Serializable
-    data class OpenId4VpSigned(
-        @SerialName("request")
-        override val request: OpenId4VpRequest.JwsCompact,
-        @SerialName("credentialIds")
-        override val credentialIds: Collection<String>,
-        @SerialName("callingPackageName")
-        override val callingPackageName: String,
-        @SerialName("callingOrigin")
-        override val callingOrigin: String,
-    ) : DCAPIWalletRequest, OpenId4Vp() {
-
-        @Deprecated(
-            "Changed request type from RequestParameter to JwsCompactTyped<AuthenticationRequestParameters>. Wrapping with `JarRequestParameters` is no longer necessary",
-            replaceWith = ReplaceWith(
-                "OpenId4VpSigned(request = (request as JarRequestParameters).request, credentialIds = credentialIds, callingPackageName = callingPackageName, callingOrigin = callingOrigin)"
-            )
-        )
-        constructor(
-            request: RequestParameters,
-            credentialIds: Collection<String>,
-            callingPackageName: String,
-            callingOrigin: String,
-        ) : this(
-            request = OpenId4VpRequest.JwsCompact(JosefJwsCompact((request as JarRequestParameters).request!!).typed<AuthenticationRequestParameters, JosefJwsCompact>()),
-            credentialIds = credentialIds,
-            callingPackageName = callingPackageName,
-            callingOrigin = callingOrigin
-        )
-
-        override val protocol: ExchangeProtocolIdentifier
-            get() = ExchangeProtocolIdentifier.OpenId4VpV1Signed
-    }
-
-    @Serializable
-    data class OpenId4VpUnsigned(
-        @SerialName("request")
-        override val request: OpenId4VpRequest.Unsigned,
-        @SerialName("credentialIds")
-        override val credentialIds: Collection<String>,
-        @SerialName("callingPackageName")
-        override val callingPackageName: String,
-        @SerialName("callingOrigin")
-        override val callingOrigin: String,
-    ) : DCAPIWalletRequest, OpenId4Vp() {
-
-        override val protocol: ExchangeProtocolIdentifier
-            get() = ExchangeProtocolIdentifier.OpenId4VpV1Unsigned
-
-    }
-
-}
-
-@Deprecated("Will move into Signum in the next release", level = DeprecationLevel.WARNING)
-class JwsTypedSerializerTemplate<J : JWS, P>(
-    jwsSerializer: KSerializer<J>,
-    private val payloadSerializer: KSerializer<P>,
-) : TransformingSerializerTemplate<JwsTyped<J, P>, J>(
-    parent = jwsSerializer,
-    encodeAs = { it.jws },
-    decodeAs = { jws -> JwsTyped(jws, jws.getPayload(payloadSerializer).getOrThrow()) }
+@Deprecated(
+    message = "Use RequestParametersFrom.DcApiRequest instead.",
+    replaceWith = ReplaceWith(
+        expression = "RequestParametersFrom.DcApiRequest",
+        imports = ["at.asitplus.openid.RequestParametersFrom"]
+    ),
+    level = DeprecationLevel.WARNING
 )
+typealias DCAPIWalletRequest = RequestParametersFrom.DcApiRequest
+
+@Deprecated(
+    message = "Use RequestParametersFrom.OpenId4VpSigned instead.",
+    replaceWith = ReplaceWith(
+        expression = "RequestParametersFrom.OpenId4VpSigned",
+        imports = ["at.asitplus.openid.RequestParametersFrom"]
+    ),
+    level = DeprecationLevel.WARNING
+)
+typealias DCAPIWalletOpenId4VpSigned = RequestParametersFrom.OpenId4VpSigned
+
+@Deprecated(
+    message = "Use RequestParametersFrom.OpenId4VpMultiSigned instead.",
+    replaceWith = ReplaceWith(
+        expression = "RequestParametersFrom.OpenId4VpMultiSigned",
+        imports = ["at.asitplus.openid.RequestParametersFrom"]
+    ),
+    level = DeprecationLevel.WARNING
+)
+typealias DCAPIWalletOpenId4VpMultiSigned = RequestParametersFrom.OpenId4VpMultiSigned
+
+@Deprecated(
+    message = "Use RequestParametersFrom.OpenId4VpUnsigned instead.",
+    replaceWith = ReplaceWith(
+        expression = "RequestParametersFrom.OpenId4VpUnsigned",
+        imports = ["at.asitplus.openid.RequestParametersFrom"]
+    ),
+    level = DeprecationLevel.WARNING
+)
+typealias DCAPIWalletOpenId4VpUnsigned = RequestParametersFrom.OpenId4VpUnsigned
+
+@Deprecated(
+    message = "Use RequestParametersFrom.IsoMdoc instead.",
+    replaceWith = ReplaceWith(
+        expression = "RequestParametersFrom.IsoMdoc",
+        imports = ["at.asitplus.openid.RequestParametersFrom"]
+    ),
+    level = DeprecationLevel.WARNING
+)
+typealias DCAPIWalletIsoMdoc = RequestParametersFrom.IsoMdoc

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/dcapi/request/verifier/DigitalCredentialGetRequest.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/dcapi/request/verifier/DigitalCredentialGetRequest.kt
@@ -8,7 +8,6 @@ import at.asitplus.signum.indispensable.josef.JwsCompactStringSerializer
 import at.asitplus.signum.indispensable.josef.JwsGeneral
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
 import kotlinx.serialization.json.JsonClassDiscriminator
 
 @Serializable

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/JwsTypedSerializerTemplate.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/JwsTypedSerializerTemplate.kt
@@ -1,0 +1,16 @@
+package at.asitplus.openid
+
+import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
+import at.asitplus.signum.indispensable.josef.JWS
+import at.asitplus.signum.indispensable.josef.JwsTyped
+import kotlinx.serialization.KSerializer
+
+@Deprecated("Will move into Signum in the next release", level = DeprecationLevel.WARNING)
+class JwsTypedSerializerTemplate<J : JWS, P>(
+    jwsSerializer: KSerializer<J>,
+    private val payloadSerializer: KSerializer<P>,
+) : TransformingSerializerTemplate<JwsTyped<J, P>, J>(
+    parent = jwsSerializer,
+    encodeAs = { it.jws },
+    decodeAs = { jws -> JwsTyped(jws, jws.getPayload(payloadSerializer).getOrThrow()) }
+)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameterSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameterSerializer.kt
@@ -13,7 +13,7 @@ object RequestParametersSerializer : JsonContentPolymorphicSerializer<RequestPar
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<RequestParameters> {
         val parameters = element.jsonObject
         return when {
-            "deviceRequest" in parameters -> RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper.serializer()
+            "deviceRequest" in parameters -> RequestParametersFrom.IsoMdocDcApi.IsoMdocRequestWrapper.serializer()
             "documentDigests" in parameters -> SignatureRequestParameters.serializer()
             ("request" in parameters) || ("request_uri" in parameters) -> JarRequestParameters.serializer()
             else -> AuthenticationRequestParameters.serializer()

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameterSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParameterSerializer.kt
@@ -13,6 +13,7 @@ object RequestParametersSerializer : JsonContentPolymorphicSerializer<RequestPar
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<RequestParameters> {
         val parameters = element.jsonObject
         return when {
+            "deviceRequest" in parameters -> RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper.serializer()
             "documentDigests" in parameters -> SignatureRequestParameters.serializer()
             ("request" in parameters) || ("request_uri" in parameters) -> JarRequestParameters.serializer()
             else -> AuthenticationRequestParameters.serializer()

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
@@ -1,12 +1,20 @@
 package at.asitplus.openid
 
-import at.asitplus.dcapi.request.DCAPIWalletRequest
+import at.asitplus.dcapi.request.ExchangeProtocolIdentifier
+import at.asitplus.dcapi.request.IsoMdocRequest
+import at.asitplus.dcapi.request.JwsTypedSerializerTemplate
+import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.josef.JWS
 import at.asitplus.signum.indispensable.josef.JwsCompactStringSerializer
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JwsGeneral
+import at.asitplus.signum.indispensable.josef.JwsGeneralTyped
+import at.asitplus.signum.indispensable.josef.JwsTyped
 import io.ktor.http.*
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonClassDiscriminator
 
 @Serializable(with = RequestParametersFromSerializer::class)
 sealed class RequestParametersFrom<S : RequestParameters> {
@@ -18,67 +26,152 @@ sealed class RequestParametersFrom<S : RequestParameters> {
      * (e.g., classic OpenID requests or DC-API signed requests).
      */
     sealed class RequestParametersSigned<T : RequestParameters> : RequestParametersFrom<T>() {
-        abstract val jws: JWS
+        abstract val jwsTyped: JwsTyped<*, T>
         abstract val verified: Boolean
     }
 
     /**
      * Common ancestor for request parameters that are [DCAPIWalletRequest.OpenId4Vp] subtypes
      */
+    @JsonClassDiscriminator("protocol")
     sealed interface DcApiRequest {
-        val dcApiRequest: DCAPIWalletRequest.OpenId4Vp
+        @SerialName("credentialIds")
+        val credentialIds: Collection<String>
+
+        @SerialName("callingPackageName")
+        val callingPackageName: String
+
+        @SerialName("callingOrigin")
+        val callingOrigin: String
+
+        val protocol: ExchangeProtocolIdentifier
     }
 
     @Serializable
     @SerialName(SerialNames.TYPE_JWS)
     data class Jws<T : RequestParameters>(
         @SerialName(SerialNames.JWS)
-        override val jws: JWS,
+        val jws: JWS,
         @SerialName(SerialNames.PARAMETERS)
         override val parameters: T,
         @SerialName(SerialNames.VERIFIED)
         override val verified: Boolean,
         @SerialName(SerialNames.PARENT)
         val parent: Url? = null,
-    ) : RequestParametersSigned<T>()
+    ) : RequestParametersSigned<T>() {
+        override val jwsTyped get() = JwsTyped(jws, parameters)
+    }
 
     @Serializable
     @SerialName(SerialNames.TYPE_DCAPI_MULTISIGNED)
-    data class DcApiMultiSigned<T : RequestParameters>(
-        @SerialName(SerialNames.DC_API_REQUEST)
-        override val dcApiRequest: DCAPIWalletRequest.OpenId4VpMultiSigned,
-        @SerialName(SerialNames.PARAMETERS)
-        override val parameters: T,
+    data class OpenId4VpMultiSigned(
+        @Serializable(with = JwsGeneralAuthParamSerializer::class)
         @SerialName(SerialNames.JWS)
-        override val jws: JwsGeneral,
+        override val jwsTyped: JwsGeneralTyped<AuthenticationRequestParameters>,
         @SerialName(SerialNames.VERIFIED)
         override val verified: Boolean,
-    ) : RequestParametersSigned<T>(), DcApiRequest
+        @SerialName("credentialIds")
+        override val credentialIds: Collection<String>,
+        @SerialName("callingPackageName")
+        override val callingPackageName: String,
+        @SerialName("callingOrigin")
+        override val callingOrigin: String
+    ) : RequestParametersSigned<AuthenticationRequestParameters>(), DcApiRequest {
+
+        @SerialName(SerialNames.PARAMETERS)
+        override val parameters: AuthenticationRequestParameters = jwsTyped.payload
+
+        override val protocol: ExchangeProtocolIdentifier
+            get() = ExchangeProtocolIdentifier.OpenId4VpV1Multisigned
+
+        object JwsGeneralAuthParamSerializer :
+            KSerializer<JwsGeneralTyped<AuthenticationRequestParameters>> by JwsTypedSerializerTemplate(
+                JwsGeneral.serializer(),
+                AuthenticationRequestParameters.serializer()
+            )
+    }
 
     @Serializable
     @SerialName(SerialNames.TYPE_DCAPI_SIGNED)
-    data class DcApiSigned<T : RequestParameters>(
-        @SerialName(SerialNames.DC_API_REQUEST)
-        override val dcApiRequest: DCAPIWalletRequest.OpenId4VpSigned,
-        @SerialName(SerialNames.PARAMETERS)
-        override val parameters: T,
-        @Serializable(JwsCompactStringSerializer::class)
+    data class OpenId4VpSigned(
+        @Serializable(JwsCompactAuthParamSerializer::class)
         @SerialName(SerialNames.JWS)
-        override val jws: at.asitplus.signum.indispensable.josef.JwsCompact,
+        override val jwsTyped: JwsCompactTyped<AuthenticationRequestParameters>,
         @SerialName(SerialNames.VERIFIED)
         override val verified: Boolean,
-    ) : RequestParametersSigned<T>(), DcApiRequest
+        @SerialName("credentialIds")
+        override val credentialIds: Collection<String>,
+        @SerialName("callingPackageName")
+        override val callingPackageName: String,
+        @SerialName("callingOrigin")
+        override val callingOrigin: String
+    ) : RequestParametersSigned<AuthenticationRequestParameters>(), DcApiRequest {
+
+        @SerialName(SerialNames.PARAMETERS)
+        override val parameters: AuthenticationRequestParameters = jwsTyped.payload
+
+        override val protocol: ExchangeProtocolIdentifier
+            get() = ExchangeProtocolIdentifier.OpenId4VpV1Signed
+
+        object JwsCompactAuthParamSerializer :
+            KSerializer<JwsCompactTyped<AuthenticationRequestParameters>> by JwsTypedSerializerTemplate(
+                JwsCompactStringSerializer,
+                AuthenticationRequestParameters.serializer()
+            )
+
+    }
 
     @Serializable
     @SerialName(SerialNames.TYPE_DCAPI_UNSIGNED)
-    data class DcApiUnsigned<T : RequestParameters>(
-        @SerialName(SerialNames.DC_API_REQUEST)
-        override val dcApiRequest: DCAPIWalletRequest.OpenId4VpUnsigned,
+    data class OpenId4VpUnsigned(
         @SerialName(SerialNames.PARAMETERS)
-        override val parameters: T,
+        override val parameters: AuthenticationRequestParameters,
         @SerialName(SerialNames.JSON_STRING)
         val jsonString: String,
-    ) : DcApiRequest, RequestParametersFrom<T>()
+        @SerialName("credentialIds")
+        override val credentialIds: Collection<String>,
+        @SerialName("callingPackageName")
+        override val callingPackageName: String,
+        @SerialName("callingOrigin")
+        override val callingOrigin: String
+    ) : DcApiRequest, RequestParametersFrom<AuthenticationRequestParameters>() {
+
+        override val protocol: ExchangeProtocolIdentifier
+            get() = ExchangeProtocolIdentifier.OpenId4VpV1Unsigned
+
+    }
+
+    @Serializable
+    @SerialName(SerialNames.TYPE_DCAPI_UNSIGNED)
+    data class IsoMdoc(
+        override val parameters: IsoMdocRequestWrapper,
+        @SerialName(SerialNames.JSON_STRING)
+        val jsonString: String,
+        @SerialName("credentialIds")
+        override val credentialIds: Collection<String>,
+        @SerialName("callingPackageName")
+        override val callingPackageName: String,
+        @SerialName("callingOrigin")
+        override val callingOrigin: String
+    ) : DcApiRequest, RequestParametersFrom<IsoMdoc.IsoMdocRequestWrapper>() {
+
+        @Serializable(with = IsoMdocRequestWrapper.Serializer::class)
+        data class IsoMdocRequestWrapper(
+            val isoMdocRequest: IsoMdocRequest
+        ) : RequestParameters() {
+            object Serializer :
+                KSerializer<IsoMdocRequestWrapper> by TransformingSerializerTemplate(
+                    parent = IsoMdocRequest.serializer(),
+                    encodeAs = { it.isoMdocRequest },
+                    decodeAs = { IsoMdocRequestWrapper(it) }
+                )
+        }
+
+        override val protocol: ExchangeProtocolIdentifier
+            get() = ExchangeProtocolIdentifier.OpenId4VpV1Unsigned
+
+    }
+
 
     @Serializable
     @SerialName(SerialNames.TYPE_URI)

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
@@ -63,7 +63,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
 
     @Serializable
     @SerialName(SerialNames.TYPE_DCAPI_MULTISIGNED)
-    data class OpenId4VpMultiSigned(
+    data class OpenId4VpDcApiMultiSigned(
         @Serializable(with = JwsGeneralAuthParamSerializer::class)
         @SerialName(SerialNames.JWS)
         override val jwsTyped: JwsGeneralTyped<AuthenticationRequestParameters>,
@@ -92,7 +92,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
 
     @Serializable
     @SerialName(SerialNames.TYPE_DCAPI_SIGNED)
-    data class OpenId4VpSigned(
+    data class OpenId4VpDcApiSigned(
         @Serializable(JwsCompactAuthParamSerializer::class)
         @SerialName(SerialNames.JWS)
         override val jwsTyped: JwsCompactTyped<AuthenticationRequestParameters>,
@@ -122,7 +122,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
 
     @Serializable
     @SerialName(SerialNames.TYPE_DCAPI_UNSIGNED)
-    data class OpenId4VpUnsigned(
+    data class OpenId4VpDcApiUnsigned(
         @SerialName(SerialNames.PARAMETERS)
         override val parameters: AuthenticationRequestParameters,
         @SerialName(SerialNames.JSON_STRING)
@@ -142,7 +142,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
 
     @Serializable
     @SerialName(SerialNames.TYPE_DCAPI_ISO_MDOC)
-    data class IsoMdoc(
+    data class IsoMdocDcApi(
         override val parameters: IsoMdocRequestWrapper,
         @SerialName(SerialNames.JSON_STRING)
         val jsonString: String,
@@ -152,7 +152,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         override val callingPackageName: String,
         @SerialName("callingOrigin")
         override val callingOrigin: String
-    ) : DcApiRequest, RequestParametersFrom<IsoMdoc.IsoMdocRequestWrapper>() {
+    ) : DcApiRequest, RequestParametersFrom<IsoMdocDcApi.IsoMdocRequestWrapper>() {
 
         @Serializable(with = IsoMdocRequestWrapper.Serializer::class)
         data class IsoMdocRequestWrapper(

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
@@ -15,6 +15,11 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
 
+/**
+ * This class tracks Requests, their contents and their origin with relevant parameters.
+ *
+ * Used for data management. Does not follow any standard in particular
+ */
 @Serializable(with = RequestParametersFromSerializer::class)
 sealed class RequestParametersFrom<S : RequestParameters> {
 
@@ -34,16 +39,22 @@ sealed class RequestParametersFrom<S : RequestParameters> {
      */
     @JsonClassDiscriminator("protocol")
     sealed interface DcApiRequest {
-        @SerialName("credentialIds")
+        @SerialName(SerialNames.CREDENTIAL_IDS)
         val credentialIds: Collection<String>
 
-        @SerialName("callingPackageName")
+        @SerialName(SerialNames.CALLING_PACKAGE_NAME)
         val callingPackageName: String
 
-        @SerialName("callingOrigin")
+        @SerialName(SerialNames.CALLING_ORIGIN)
         val callingOrigin: String
 
         val protocol: ExchangeProtocolIdentifier
+
+        object SerialNames {
+            const val CREDENTIAL_IDS = "credentialIds"
+            const val CALLING_PACKAGE_NAME = "callingPackageName"
+            const val CALLING_ORIGIN = "callingOrigin"
+        }
     }
 
     @Serializable
@@ -69,11 +80,11 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         override val jwsTyped: JwsGeneralTyped<AuthenticationRequestParameters>,
         @SerialName(SerialNames.VERIFIED)
         override val verified: Boolean,
-        @SerialName("credentialIds")
+        @SerialName(DcApiRequest.SerialNames.CREDENTIAL_IDS)
         override val credentialIds: Collection<String>,
-        @SerialName("callingPackageName")
+        @SerialName(DcApiRequest.SerialNames.CALLING_PACKAGE_NAME)
         override val callingPackageName: String,
-        @SerialName("callingOrigin")
+        @SerialName(DcApiRequest.SerialNames.CALLING_ORIGIN)
         override val callingOrigin: String
     ) : RequestParametersSigned<AuthenticationRequestParameters>(), DcApiRequest {
 
@@ -98,11 +109,11 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         override val jwsTyped: JwsCompactTyped<AuthenticationRequestParameters>,
         @SerialName(SerialNames.VERIFIED)
         override val verified: Boolean,
-        @SerialName("credentialIds")
+        @SerialName(DcApiRequest.SerialNames.CREDENTIAL_IDS)
         override val credentialIds: Collection<String>,
-        @SerialName("callingPackageName")
+        @SerialName(DcApiRequest.SerialNames.CALLING_PACKAGE_NAME)
         override val callingPackageName: String,
-        @SerialName("callingOrigin")
+        @SerialName(DcApiRequest.SerialNames.CALLING_ORIGIN)
         override val callingOrigin: String
     ) : RequestParametersSigned<AuthenticationRequestParameters>(), DcApiRequest {
 
@@ -127,11 +138,11 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         override val parameters: AuthenticationRequestParameters,
         @SerialName(SerialNames.JSON_STRING)
         val jsonString: String,
-        @SerialName("credentialIds")
+        @SerialName(DcApiRequest.SerialNames.CREDENTIAL_IDS)
         override val credentialIds: Collection<String>,
-        @SerialName("callingPackageName")
+        @SerialName(DcApiRequest.SerialNames.CALLING_PACKAGE_NAME)
         override val callingPackageName: String,
-        @SerialName("callingOrigin")
+        @SerialName(DcApiRequest.SerialNames.CALLING_ORIGIN)
         override val callingOrigin: String
     ) : DcApiRequest, RequestParametersFrom<AuthenticationRequestParameters>() {
 
@@ -146,11 +157,11 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         override val parameters: IsoMdocRequestWrapper,
         @SerialName(SerialNames.JSON_STRING)
         val jsonString: String,
-        @SerialName("credentialIds")
+        @SerialName(DcApiRequest.SerialNames.CREDENTIAL_IDS)
         override val credentialIds: Collection<String>,
-        @SerialName("callingPackageName")
+        @SerialName(DcApiRequest.SerialNames.CALLING_PACKAGE_NAME)
         override val callingPackageName: String,
-        @SerialName("callingOrigin")
+        @SerialName(DcApiRequest.SerialNames.CALLING_ORIGIN)
         override val callingOrigin: String
     ) : DcApiRequest, RequestParametersFrom<IsoMdocDcApi.IsoMdocRequestWrapper>() {
 
@@ -206,7 +217,6 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         const val URL = "url"
         const val PARENT = "parent"
         const val PARAMETERS = "parameters"
-        const val DC_API_REQUEST = "dcApiRequest"
         const val VERIFIED = "verified"
     }
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
@@ -2,7 +2,6 @@ package at.asitplus.openid
 
 import at.asitplus.dcapi.request.ExchangeProtocolIdentifier
 import at.asitplus.dcapi.request.IsoMdocRequest
-import at.asitplus.dcapi.request.JwsTypedSerializerTemplate
 import at.asitplus.signum.indispensable.io.TransformingSerializerTemplate
 import at.asitplus.signum.indispensable.josef.JWS
 import at.asitplus.signum.indispensable.josef.JwsCompactStringSerializer
@@ -31,7 +30,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
     }
 
     /**
-     * Common ancestor for request parameters that are [DCAPIWalletRequest.OpenId4Vp] subtypes
+     * Common ancestor for request parameters that are DC-API subtypes
      */
     @JsonClassDiscriminator("protocol")
     sealed interface DcApiRequest {
@@ -142,7 +141,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
     }
 
     @Serializable
-    @SerialName(SerialNames.TYPE_DCAPI_UNSIGNED)
+    @SerialName(SerialNames.TYPE_DCAPI_ISO_MDOC)
     data class IsoMdoc(
         override val parameters: IsoMdocRequestWrapper,
         @SerialName(SerialNames.JSON_STRING)
@@ -168,7 +167,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         }
 
         override val protocol: ExchangeProtocolIdentifier
-            get() = ExchangeProtocolIdentifier.OpenId4VpV1Unsigned
+            get() = ExchangeProtocolIdentifier.IsoMdocAnnexC
 
     }
 
@@ -199,6 +198,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         const val TYPE_DCAPI_UNSIGNED = "DcApiUnsigned"
         const val TYPE_DCAPI_SIGNED = "DcApiSigned"
         const val TYPE_DCAPI_MULTISIGNED = "DcApiMultiSigned"
+        const val TYPE_DCAPI_ISO_MDOC = "IsoMdoc"
         const val TYPE_URI = "Uri"
 
         const val JWS = "jws"

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
@@ -9,6 +9,7 @@ import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JwsGeneral
 import at.asitplus.signum.indispensable.josef.JwsGeneralTyped
 import at.asitplus.signum.indispensable.josef.JwsTyped
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import io.ktor.http.*
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -41,10 +42,10 @@ sealed class RequestParametersFrom<S : RequestParameters> {
     @JsonClassDiscriminator("protocol")
     sealed interface DcApiRequest {
         @SerialName(SerialNames.CREDENTIAL_IDS)
-        val credentialIds: Collection<String>
+        val credentialIds: Collection<String>?
 
         @SerialName(SerialNames.CALLING_PACKAGE_NAME)
-        val callingPackageName: String
+        val callingPackageName: String?
 
         @SerialName(SerialNames.CALLING_ORIGIN)
         val callingOrigin: String
@@ -80,7 +81,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         @SerialName(SerialNames.JWS)
         override val jwsTyped: JwsGeneralTyped<AuthenticationRequestParameters>,
         @SerialName(SerialNames.VERIFIED)
-        override val verified: Boolean,
+        override val verified: Boolean = false,
         @SerialName(DcApiRequest.SerialNames.CREDENTIAL_IDS)
         override val credentialIds: Collection<String>,
         @SerialName(DcApiRequest.SerialNames.CALLING_PACKAGE_NAME)
@@ -91,6 +92,10 @@ sealed class RequestParametersFrom<S : RequestParameters> {
 
         @SerialName(SerialNames.PARAMETERS)
         override val parameters: AuthenticationRequestParameters = jwsTyped.payload
+
+        @Deprecated("Renamed", replaceWith = ReplaceWith("jwsTyped"))
+        val request: JwsGeneralTyped<AuthenticationRequestParameters>
+            get() = jwsTyped
 
         override val protocol: ExchangeProtocolIdentifier
             get() = ExchangeProtocolIdentifier.OpenId4VpV1Multisigned
@@ -109,7 +114,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         @SerialName(SerialNames.JWS)
         override val jwsTyped: JwsCompactTyped<AuthenticationRequestParameters>,
         @SerialName(SerialNames.VERIFIED)
-        override val verified: Boolean,
+        override val verified: Boolean = false,
         @SerialName(DcApiRequest.SerialNames.CREDENTIAL_IDS)
         override val credentialIds: Collection<String>,
         @SerialName(DcApiRequest.SerialNames.CALLING_PACKAGE_NAME)
@@ -120,6 +125,29 @@ sealed class RequestParametersFrom<S : RequestParameters> {
 
         @SerialName(SerialNames.PARAMETERS)
         override val parameters: AuthenticationRequestParameters = jwsTyped.payload
+
+        @Deprecated(
+            message = "Please use primary constructor",
+            replaceWith = ReplaceWith(
+                "OpenId4VpDcApiSigned(jwsTyped = request, verified = false, credentialIds = credentialIds, callingPackageName = callingPackageName, callingOrigin = callingOrigin)"
+            )
+        )
+        constructor(
+            request: JwsCompactTyped<AuthenticationRequestParameters>,
+            credentialIds: Collection<String>,
+            callingPackageName: String,
+            callingOrigin: String,
+        ) : this(
+            jwsTyped = request,
+            verified = false,
+            credentialIds = credentialIds,
+            callingPackageName = callingPackageName,
+            callingOrigin = callingOrigin,
+        )
+
+        @Deprecated("Renamed", replaceWith = ReplaceWith("jwsTyped"))
+        val request: JwsCompactTyped<AuthenticationRequestParameters>
+            get() = jwsTyped
 
         override val protocol: ExchangeProtocolIdentifier
             get() = ExchangeProtocolIdentifier.OpenId4VpV1Signed
@@ -150,6 +178,30 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         override val protocol: ExchangeProtocolIdentifier
             get() = ExchangeProtocolIdentifier.OpenId4VpV1Unsigned
 
+        @Deprecated(
+            message = "Use the primary constructor.",
+            replaceWith = ReplaceWith(
+                "OpenId4VpDcApiUnsigned(parameters = request, jsonString = joseCompliantSerializer.encodeToString(request), credentialIds = credentialIds, callingPackageName = callingPackageName, callingOrigin = callingOrigin)",
+                imports = ["at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer"]
+            )
+        )
+        constructor(
+            request: AuthenticationRequestParameters,
+            credentialIds: Collection<String>,
+            callingPackageName: String,
+            callingOrigin: String,
+        ) : this(
+            parameters = request,
+            jsonString = joseCompliantSerializer.encodeToString(request),
+            credentialIds = credentialIds,
+            callingPackageName = callingPackageName,
+            callingOrigin = callingOrigin,
+        )
+
+        @Deprecated("Renamed", replaceWith = ReplaceWith("parameters"))
+        val request: AuthenticationRequestParameters
+            get() = parameters
+
     }
 
     @Serializable
@@ -159,9 +211,9 @@ sealed class RequestParametersFrom<S : RequestParameters> {
         @SerialName(SerialNames.JSON_STRING)
         val jsonString: String,
         @SerialName(DcApiRequest.SerialNames.CREDENTIAL_IDS)
-        override val credentialIds: Collection<String>,
+        override val credentialIds: Collection<String>? = null,
         @SerialName(DcApiRequest.SerialNames.CALLING_PACKAGE_NAME)
-        override val callingPackageName: String,
+        override val callingPackageName: String? = null,
         @SerialName(DcApiRequest.SerialNames.CALLING_ORIGIN)
         override val callingOrigin: String
     ) : DcApiRequest, RequestParametersFrom<IsoMdocDcApi.IsoMdocRequestWrapper>() {
@@ -180,6 +232,30 @@ sealed class RequestParametersFrom<S : RequestParameters> {
 
         override val protocol: ExchangeProtocolIdentifier
             get() = ExchangeProtocolIdentifier.IsoMdocAnnexC
+
+        @Deprecated(
+            message = "Use the primary constructor with parameters and jsonString.",
+            replaceWith = ReplaceWith(
+                "IsoMdocDcApi(parameters = IsoMdocDcApi.IsoMdocRequestWrapper(isoMdocRequest), jsonString = joseCompliantSerializer.encodeToString(isoMdocRequest), credentialIds = credentialIds, callingPackageName = callingPackageName, callingOrigin = callingOrigin)",
+                imports = ["at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer"]
+            )
+        )
+        constructor(
+            isoMdocRequest: IsoMdocRequest,
+            credentialIds: Collection<String>? = null,
+            callingPackageName: String? = null,
+            callingOrigin: String,
+        ) : this(
+            parameters = IsoMdocRequestWrapper(isoMdocRequest),
+            jsonString = joseCompliantSerializer.encodeToString(isoMdocRequest),
+            credentialIds = credentialIds,
+            callingPackageName = callingPackageName,
+            callingOrigin = callingOrigin,
+        )
+
+        @Deprecated("Use parameters.isoMdocRequest instead.", replaceWith = ReplaceWith("parameters.isoMdocRequest"))
+        val isoMdocRequest: IsoMdocRequest
+            get() = parameters.isoMdocRequest
 
     }
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFrom.kt
@@ -37,6 +37,7 @@ sealed class RequestParametersFrom<S : RequestParameters> {
     /**
      * Common ancestor for request parameters that are DC-API subtypes
      */
+    @Serializable
     @JsonClassDiscriminator("protocol")
     sealed interface DcApiRequest {
         @SerialName(SerialNames.CREDENTIAL_IDS)
@@ -206,10 +207,10 @@ sealed class RequestParametersFrom<S : RequestParameters> {
     object SerialNames {
         const val TYPE_JWS = "Jws"
         const val TYPE_JSON = "Json"
-        const val TYPE_DCAPI_UNSIGNED = "DcApiUnsigned"
-        const val TYPE_DCAPI_SIGNED = "DcApiSigned"
-        const val TYPE_DCAPI_MULTISIGNED = "DcApiMultiSigned"
-        const val TYPE_DCAPI_ISO_MDOC = "IsoMdoc"
+        const val TYPE_DCAPI_UNSIGNED = ExchangeProtocolIdentifier.OPENID4VP_V1_UNSIGNED
+        const val TYPE_DCAPI_SIGNED = ExchangeProtocolIdentifier.OPENID4VP_V1_SIGNED
+        const val TYPE_DCAPI_MULTISIGNED = ExchangeProtocolIdentifier.OPENID4VP_V1_MULTISIGNED
+        const val TYPE_DCAPI_ISO_MDOC = ExchangeProtocolIdentifier.ORG_ISO_MDOC
         const val TYPE_URI = "Uri"
 
         const val JWS = "jws"

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFromSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFromSerializer.kt
@@ -1,6 +1,6 @@
 package at.asitplus.openid
 
-import at.asitplus.openid.RequestParametersFrom.SerialNames.DC_API_REQUEST
+import at.asitplus.dcapi.request.ExchangeProtocolIdentifier
 import at.asitplus.openid.RequestParametersFrom.SerialNames.JSON_STRING
 import at.asitplus.openid.RequestParametersFrom.SerialNames.JWS
 import at.asitplus.openid.RequestParametersFrom.SerialNames.PARAMETERS
@@ -12,15 +12,12 @@ import at.asitplus.signum.indispensable.josef.JWS
 import at.asitplus.signum.indispensable.josef.JwsCompact
 import at.asitplus.signum.indispensable.josef.JwsFlattened
 import at.asitplus.signum.indispensable.josef.JwsGeneral
-import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
+import at.asitplus.signum.indispensable.josef.JwsTyped
 import io.ktor.http.*
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.decodeFromJsonElement
-import kotlinx.serialization.json.encodeToJsonElement
 
 /**
  * In order to de-/serialize generic types we need a kind of factory approach.
@@ -29,13 +26,10 @@ import kotlinx.serialization.json.encodeToJsonElement
  * [RequestParametersFrom] subtype.
  *
  * During serialization, the subtype is flattened into that surrogate. During
- * deserialization, the field combination determines the subtype again. The
- * surrogate represents the nested DC API request as a [JsonObject] until the
- * concrete [RequestParametersFrom] branch is known: [JwsGeneral] plus a DC API
- * request becomes [RequestParametersFrom.DcApiMultiSigned], [JwsCompact] plus a
- * DC API request becomes [RequestParametersFrom.DcApiSigned], and a JSON string
- * plus a DC API request becomes [RequestParametersFrom.DcApiUnsigned]. Plain
- * JSON, JWS, and URI requests are selected from their respective fields.
+ * deserialization, the field combination determines the subtype again. DC API
+ * request metadata is represented directly on the surrogate, matching
+ * [RequestParametersFrom.DcApiRequest]. Plain JSON, JWS, and URI requests are
+ * selected from their respective fields.
  * Missing [RequestParametersFrom.RequestParametersSigned.verified] values
  * default to `false`; [JwsFlattened] is recognized but not implemented.
  */
@@ -61,19 +55,27 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
     @Serializable(UrlSerializer::class)
     @SerialName(PARENT)
     val parent: Url? = null,
-    @SerialName(DC_API_REQUEST)
-    val dcApiRequest: JsonObject? = null,
     @SerialName(VERIFIED)
     val verified: Boolean? = null,
+    @SerialName(PROTOCOL)
+    val protocol: ExchangeProtocolIdentifier? = null,
+    @SerialName(CREDENTIAL_IDS)
+    val credentialIds: Collection<String>? = null,
+    @SerialName(CALLING_PACKAGE_NAME)
+    val callingPackageName: String? = null,
+    @SerialName(CALLING_ORIGIN)
+    val callingOrigin: String? = null,
 ) {
     constructor(value: RequestParametersFrom<T>) : this(
         parameters = value.parameters,
         jws = when (value) {
-            is RequestParametersFrom.RequestParametersSigned -> value.jws
+            is RequestParametersFrom.Jws -> value.jws
+            is RequestParametersFrom.RequestParametersSigned -> value.jwsTyped.jws
             else -> null
         },
         jsonString = when (value) {
-            is RequestParametersFrom.DcApiUnsigned<*> -> value.jsonString
+            is RequestParametersFrom.OpenId4VpUnsigned -> value.jsonString
+            is RequestParametersFrom.IsoMdoc -> value.jsonString
             is RequestParametersFrom.Json -> value.jsonString
             else -> null
         },
@@ -83,40 +85,57 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
             is RequestParametersFrom.Json -> value.parent
             else -> null
         },
-        dcApiRequest = when (value) {
-            is RequestParametersFrom.DcApiSigned<*> -> joseCompliantSerializer.encodeToJsonElement(value.dcApiRequest) as JsonObject
-            is RequestParametersFrom.DcApiUnsigned<*> -> joseCompliantSerializer.encodeToJsonElement(value.dcApiRequest) as JsonObject
-            is RequestParametersFrom.DcApiMultiSigned<*> -> joseCompliantSerializer.encodeToJsonElement(value.dcApiRequest) as JsonObject
+        verified = (value as? RequestParametersFrom.RequestParametersSigned<*>)?.verified,
+        protocol = when (value) {
+            is RequestParametersFrom.OpenId4VpMultiSigned -> ExchangeProtocolIdentifier.OpenId4VpV1Multisigned
+            is RequestParametersFrom.OpenId4VpSigned -> ExchangeProtocolIdentifier.OpenId4VpV1Signed
+            is RequestParametersFrom.OpenId4VpUnsigned -> ExchangeProtocolIdentifier.OpenId4VpV1Unsigned
+            is RequestParametersFrom.IsoMdoc -> ExchangeProtocolIdentifier.IsoMdocAnnexC
             else -> null
         },
-        verified = (value as? RequestParametersFrom.RequestParametersSigned<*>)?.verified,
+        credentialIds = (value as? RequestParametersFrom.DcApiRequest)?.credentialIds,
+        callingPackageName = (value as? RequestParametersFrom.DcApiRequest)?.callingPackageName,
+        callingOrigin = (value as? RequestParametersFrom.DcApiRequest)?.callingOrigin,
     )
 
     fun toRequestParametersFrom(): RequestParametersFrom<T> = when {
-        jws is JwsGeneral && dcApiRequest != null ->
-            RequestParametersFrom.DcApiMultiSigned(
-                dcApiRequest = joseCompliantSerializer.decodeFromJsonElement(dcApiRequest),
-                parameters = parameters,
-                jws = jws,
-                verified = verified ?: false
-            )
+        protocol == ExchangeProtocolIdentifier.OpenId4VpV1Multisigned ->
+            RequestParametersFrom.OpenId4VpMultiSigned(
+                jwsTyped = JwsTyped(requireJwsGeneral(), requireAuthenticationRequestParameters()),
+                verified = verified ?: false,
+                credentialIds = requireCredentialIds(),
+                callingPackageName = requireCallingPackageName(),
+                callingOrigin = requireCallingOrigin(),
+            ).cast()
 
-        jws is JwsCompact && dcApiRequest != null ->
-            RequestParametersFrom.DcApiSigned(
-                dcApiRequest = joseCompliantSerializer.decodeFromJsonElement(dcApiRequest),
-                parameters = parameters,
-                jws = jws,
-                verified = verified ?: false
-            )
+        protocol == ExchangeProtocolIdentifier.OpenId4VpV1Signed ->
+            RequestParametersFrom.OpenId4VpSigned(
+                jwsTyped = JwsTyped(requireJwsCompact(), requireAuthenticationRequestParameters()),
+                verified = verified ?: false,
+                credentialIds = requireCredentialIds(),
+                callingPackageName = requireCallingPackageName(),
+                callingOrigin = requireCallingOrigin(),
+            ).cast()
+
+        protocol == ExchangeProtocolIdentifier.OpenId4VpV1Unsigned ->
+            RequestParametersFrom.OpenId4VpUnsigned(
+                parameters = requireAuthenticationRequestParameters(),
+                jsonString = requireJsonString(),
+                credentialIds = requireCredentialIds(),
+                callingPackageName = requireCallingPackageName(),
+                callingOrigin = requireCallingOrigin(),
+            ).cast()
+
+        protocol == ExchangeProtocolIdentifier.IsoMdocAnnexC ->
+            RequestParametersFrom.IsoMdoc(
+                parameters = requireIsoMdocRequestWrapper(),
+                jsonString = requireJsonString(),
+                credentialIds = requireCredentialIds(),
+                callingPackageName = requireCallingPackageName(),
+                callingOrigin = requireCallingOrigin(),
+            ).cast()
 
         jws is JwsFlattened -> throw UnsupportedOperationException("Not implemented yet")
-
-        jsonString != null && dcApiRequest != null ->
-            RequestParametersFrom.DcApiUnsigned(
-                dcApiRequest = joseCompliantSerializer.decodeFromJsonElement(dcApiRequest),
-                parameters = parameters,
-                jsonString = jsonString,
-            )
 
         jsonString != null ->
             RequestParametersFrom.Json(
@@ -141,4 +160,40 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
 
         else -> throw SerializationException("Unknown RequestParametersFrom surrogate. Input: $this")
     }
+
+    private fun requireAuthenticationRequestParameters(): AuthenticationRequestParameters =
+        parameters as? AuthenticationRequestParameters
+            ?: throw SerializationException("Expected AuthenticationRequestParameters for protocol $protocol")
+
+    private fun requireIsoMdocRequestWrapper(): RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper =
+        parameters as? RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper
+            ?: throw SerializationException("Expected IsoMdocRequestWrapper for protocol $protocol")
+
+    private fun requireJwsCompact(): JwsCompact =
+        jws as? JwsCompact
+            ?: throw SerializationException("Expected compact JWS for protocol $protocol")
+
+    private fun requireJwsGeneral(): JwsGeneral =
+        jws as? JwsGeneral
+            ?: throw SerializationException("Expected general JWS for protocol $protocol")
+
+    private fun requireJsonString(): String =
+        jsonString ?: throw SerializationException("Missing $JSON_STRING for protocol $protocol")
+
+    private fun requireCredentialIds(): Collection<String> =
+        credentialIds ?: throw SerializationException("Missing $CREDENTIAL_IDS for protocol $protocol")
+
+    private fun requireCallingPackageName(): String =
+        callingPackageName ?: throw SerializationException("Missing $CALLING_PACKAGE_NAME for protocol $protocol")
+
+    private fun requireCallingOrigin(): String =
+        callingOrigin ?: throw SerializationException("Missing $CALLING_ORIGIN for protocol $protocol")
+
+    @Suppress("UNCHECKED_CAST")
+    private fun RequestParametersFrom<*>.cast(): RequestParametersFrom<T> = this as RequestParametersFrom<T>
 }
+
+private const val PROTOCOL = "protocol"
+private const val CREDENTIAL_IDS = "credentialIds"
+private const val CALLING_PACKAGE_NAME = "callingPackageName"
+private const val CALLING_ORIGIN = "callingOrigin"

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFromSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFromSerializer.kt
@@ -130,8 +130,8 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
             RequestParametersFrom.IsoMdocDcApi(
                 parameters = requireIsoMdocRequestWrapper(),
                 jsonString = requireJsonString(),
-                credentialIds = requireCredentialIds(),
-                callingPackageName = requireCallingPackageName(),
+                credentialIds = credentialIds,
+                callingPackageName = callingPackageName,
                 callingOrigin = requireCallingOrigin(),
             ).cast()
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFromSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/RequestParametersFromSerializer.kt
@@ -74,8 +74,8 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
             else -> null
         },
         jsonString = when (value) {
-            is RequestParametersFrom.OpenId4VpUnsigned -> value.jsonString
-            is RequestParametersFrom.IsoMdoc -> value.jsonString
+            is RequestParametersFrom.OpenId4VpDcApiUnsigned -> value.jsonString
+            is RequestParametersFrom.IsoMdocDcApi -> value.jsonString
             is RequestParametersFrom.Json -> value.jsonString
             else -> null
         },
@@ -87,10 +87,10 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
         },
         verified = (value as? RequestParametersFrom.RequestParametersSigned<*>)?.verified,
         protocol = when (value) {
-            is RequestParametersFrom.OpenId4VpMultiSigned -> ExchangeProtocolIdentifier.OpenId4VpV1Multisigned
-            is RequestParametersFrom.OpenId4VpSigned -> ExchangeProtocolIdentifier.OpenId4VpV1Signed
-            is RequestParametersFrom.OpenId4VpUnsigned -> ExchangeProtocolIdentifier.OpenId4VpV1Unsigned
-            is RequestParametersFrom.IsoMdoc -> ExchangeProtocolIdentifier.IsoMdocAnnexC
+            is RequestParametersFrom.OpenId4VpDcApiMultiSigned -> ExchangeProtocolIdentifier.OpenId4VpV1Multisigned
+            is RequestParametersFrom.OpenId4VpDcApiSigned -> ExchangeProtocolIdentifier.OpenId4VpV1Signed
+            is RequestParametersFrom.OpenId4VpDcApiUnsigned -> ExchangeProtocolIdentifier.OpenId4VpV1Unsigned
+            is RequestParametersFrom.IsoMdocDcApi -> ExchangeProtocolIdentifier.IsoMdocAnnexC
             else -> null
         },
         credentialIds = (value as? RequestParametersFrom.DcApiRequest)?.credentialIds,
@@ -100,7 +100,7 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
 
     fun toRequestParametersFrom(): RequestParametersFrom<T> = when {
         protocol == ExchangeProtocolIdentifier.OpenId4VpV1Multisigned ->
-            RequestParametersFrom.OpenId4VpMultiSigned(
+            RequestParametersFrom.OpenId4VpDcApiMultiSigned(
                 jwsTyped = JwsTyped(requireJwsGeneral(), requireAuthenticationRequestParameters()),
                 verified = verified ?: false,
                 credentialIds = requireCredentialIds(),
@@ -109,7 +109,7 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
             ).cast()
 
         protocol == ExchangeProtocolIdentifier.OpenId4VpV1Signed ->
-            RequestParametersFrom.OpenId4VpSigned(
+            RequestParametersFrom.OpenId4VpDcApiSigned(
                 jwsTyped = JwsTyped(requireJwsCompact(), requireAuthenticationRequestParameters()),
                 verified = verified ?: false,
                 credentialIds = requireCredentialIds(),
@@ -118,7 +118,7 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
             ).cast()
 
         protocol == ExchangeProtocolIdentifier.OpenId4VpV1Unsigned ->
-            RequestParametersFrom.OpenId4VpUnsigned(
+            RequestParametersFrom.OpenId4VpDcApiUnsigned(
                 parameters = requireAuthenticationRequestParameters(),
                 jsonString = requireJsonString(),
                 credentialIds = requireCredentialIds(),
@@ -127,7 +127,7 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
             ).cast()
 
         protocol == ExchangeProtocolIdentifier.IsoMdocAnnexC ->
-            RequestParametersFrom.IsoMdoc(
+            RequestParametersFrom.IsoMdocDcApi(
                 parameters = requireIsoMdocRequestWrapper(),
                 jsonString = requireJsonString(),
                 credentialIds = requireCredentialIds(),
@@ -165,8 +165,8 @@ private data class RequestParametersFromSurrogate<T : RequestParameters>(
         parameters as? AuthenticationRequestParameters
             ?: throw SerializationException("Expected AuthenticationRequestParameters for protocol $protocol")
 
-    private fun requireIsoMdocRequestWrapper(): RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper =
-        parameters as? RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper
+    private fun requireIsoMdocRequestWrapper(): RequestParametersFrom.IsoMdocDcApi.IsoMdocRequestWrapper =
+        parameters as? RequestParametersFrom.IsoMdocDcApi.IsoMdocRequestWrapper
             ?: throw SerializationException("Expected IsoMdocRequestWrapper for protocol $protocol")
 
     private fun requireJwsCompact(): JwsCompact =

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequestSerializationTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequestSerializationTest.kt
@@ -1,10 +1,10 @@
 package at.asitplus.dcapi.request
 
-import at.asitplus.dcapi.request.DCAPIWalletRequest.OpenId4Vp.OpenId4VpRequest
 import at.asitplus.dcapi.request.verifier.testIsoMdocRequest
 import at.asitplus.dcapi.request.verifier.testSignedOpenId4VpRequest
 import at.asitplus.dcapi.request.verifier.testUnsignedOpenId4VpRequest
 import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JwsFlattened
 import at.asitplus.signum.indispensable.josef.JwsGeneralTyped
@@ -18,58 +18,73 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 
+private typealias IsoMdocRequestParametersFrom =
+    RequestParametersFrom<RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper>
+
 val DCAPIWalletRequestSerializationTest by testSuite {
     test("openid4vp unsigned request round-trips") {
-        val request = DCAPIWalletRequest.OpenId4VpUnsigned(
-            request = OpenId4VpRequest.Unsigned(testUnsignedOpenId4VpRequest.data),
+        val parameters = testUnsignedOpenId4VpRequest.data
+        val request = RequestParametersFrom.OpenId4VpUnsigned(
+            parameters = parameters,
+            jsonString = joseCompliantSerializer.encodeToString(parameters),
             credentialIds = listOf("044c78be429198ffc2a66d935ff86e4e2bdb8ca2ab0cd1bacc85f3a73d8347b4"),
             callingPackageName = "com.android.chrome",
             callingOrigin = "https://wallet.a-sit.at"
         )
 
-        val encoded = joseCompliantSerializer.encodeToString<DCAPIWalletRequest>(request)
+        val encoded =
+            joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(request)
         encoded.shouldContain("\"credentialIds\"")
         encoded.shouldNotContain("\"credentialId\"")
-        val decoded = joseCompliantSerializer.decodeFromString<DCAPIWalletRequest>(encoded)
+        val decoded =
+            joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(encoded)
 
         decoded shouldBe request
     }
 
     test("openid4vp signed request round-trips") {
         val request: JwsCompactTyped<AuthenticationRequestParameters> = testSignedOpenId4VpRequest.data.request.typed()
-        val walletRequest = DCAPIWalletRequest.OpenId4VpSigned(
-            request = OpenId4VpRequest.JwsCompact(request),
+        val walletRequest = RequestParametersFrom.OpenId4VpSigned(
+            jwsTyped = request,
+            verified = false,
             credentialIds = listOf("044c78be429198ffc2a66d935ff86e4e2bdb8ca2ab0cd1bacc85f3a73d8347b4"),
             callingPackageName = "com.android.chrome",
             callingOrigin = "https://wallet.a-sit.at"
         )
 
-        val encoded = joseCompliantSerializer.encodeToString<DCAPIWalletRequest>(walletRequest)
+        val encoded =
+            joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(walletRequest)
         encoded.shouldContain("\"credentialIds\"")
         encoded.shouldNotContain("\"credentialId\"")
-        val decoded = joseCompliantSerializer.decodeFromString<DCAPIWalletRequest>(encoded)
+        val decoded =
+            joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(encoded)
 
         decoded shouldBe walletRequest
     }
 
     test("openid4vp multisigned request round-trips") {
         val requestElement: JwsFlattened = testSignedOpenId4VpRequest.data.request.toJwsFlattened()
-        val request: JwsGeneralTyped<AuthenticationRequestParameters> = (0..5).map { requestElement }.toJwsGeneral().typed()
-        val walletRequest = DCAPIWalletRequest.OpenId4VpMultiSigned(
-            request = OpenId4VpRequest.JwsGeneral(request),
+        val request: JwsGeneralTyped<AuthenticationRequestParameters> =
+            (0..5).map { requestElement }.toJwsGeneral().typed()
+        val walletRequest = RequestParametersFrom.OpenId4VpMultiSigned(
+            jwsTyped = request,
+            verified = false,
             credentialIds = listOf("044c78be429198ffc2a66d935ff86e4e2bdb8ca2ab0cd1bacc85f3a73d8347b4"),
             callingPackageName = "com.android.chrome",
             callingOrigin = "https://wallet.a-sit.at"
         )
 
-        val encoded = joseCompliantSerializer.encodeToString<DCAPIWalletRequest>(walletRequest)
+        val encoded =
+            joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(walletRequest)
         encoded.shouldContain("\"credentialIds\"")
         encoded.shouldNotContain("\"credentialId\"")
         // The protocol discriminator must be the spec-defined string, not the auto-generated class name,
         // so that external DC API payloads (from browsers/platform) with "protocol":"openid4vp-v1-multisigned"
         // are correctly decoded.
         encoded.shouldContain("\"protocol\":\"openid4vp-v1-multisigned\"")
-        val decoded = joseCompliantSerializer.decodeFromString<DCAPIWalletRequest>(encoded)
+        val decoded =
+            joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(encoded)
+
         decoded shouldBe walletRequest
     }
 
@@ -90,20 +105,21 @@ val DCAPIWalletRequestSerializationTest by testSuite {
         // is equivalent to decoding a real platform payload.
         val decoded = joseCompliantSerializer.decodeFromString<DCAPIWalletRequest>(canonical)
         decoded.shouldBeInstanceOf<DCAPIWalletRequest.OpenId4VpMultiSigned>()
-        decoded shouldBe walletRequest
     }
 
-    test("iso mdoc request round-trips") {
-        val request = DCAPIWalletRequest.IsoMdoc(
-            isoMdocRequest = testIsoMdocRequest.data,
+        test("iso mdoc request round-trips") {
+        val request = RequestParametersFrom.IsoMdoc(
+            parameters = RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper(testIsoMdocRequest.data),
+            jsonString = joseCompliantSerializer.encodeToString(testIsoMdocRequest.data),
             credentialIds = listOf("044c78be429198ffc2a66d935ff86e4e2bdb8ca2ab0cd1bacc85f3a73d8347b4"),
+            callingPackageName = "com.android.chrome",
             callingOrigin = "https://wallet.a-sit.at"
         )
 
-        val encoded = joseCompliantSerializer.encodeToString<DCAPIWalletRequest>(request)
+        val encoded = joseCompliantSerializer.encodeToString<IsoMdocRequestParametersFrom>(request)
         encoded.shouldContain("\"credentialIds\"")
         encoded.shouldNotContain("\"credentialId\"")
-        val decoded = joseCompliantSerializer.decodeFromString<DCAPIWalletRequest>(encoded)
+        val decoded = joseCompliantSerializer.decodeFromString<IsoMdocRequestParametersFrom>(encoded)
 
         decoded shouldBe request
     }

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequestSerializationTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequestSerializationTest.kt
@@ -91,8 +91,9 @@ val DCAPIWalletRequestSerializationTest by testSuite {
     test("openid4vp multisigned request can be decoded from external dc api discriminator value") {
         val requestElement: JwsFlattened = testSignedOpenId4VpRequest.data.request.toJwsFlattened()
         val request: JwsGeneralTyped<AuthenticationRequestParameters> = listOf(requestElement).toJwsGeneral().typed()
-        val walletRequest = DCAPIWalletRequest.OpenId4VpMultiSigned(
-            request = OpenId4VpRequest.JwsGeneral(request),
+        val walletRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
+            jwsTyped = request,
+            verified = false,
             credentialIds = listOf("044c78be429198ffc2a66d935ff86e4e2bdb8ca2ab0cd1bacc85f3a73d8347b4"),
             callingPackageName = "com.android.chrome",
             callingOrigin = "https://wallet.a-sit.at"
@@ -100,11 +101,11 @@ val DCAPIWalletRequestSerializationTest by testSuite {
 
         // Encode, then tamper the protocol value to simulate what a real DC API platform payload looks like:
         // verify the decoder can find the class via the spec-defined discriminator string.
-        val canonical = joseCompliantSerializer.encodeToString<DCAPIWalletRequest>(walletRequest)
+        val canonical = joseCompliantSerializer.encodeToString<RequestParametersFrom.DcApiRequest>(walletRequest)
         // After the @SerialName fix the canonical form already contains the correct value, so decoding it
         // is equivalent to decoding a real platform payload.
-        val decoded = joseCompliantSerializer.decodeFromString<DCAPIWalletRequest>(canonical)
-        decoded.shouldBeInstanceOf<DCAPIWalletRequest.OpenId4VpMultiSigned>()
+        val decoded = joseCompliantSerializer.decodeFromString<RequestParametersFrom.DcApiRequest>(canonical)
+        decoded.shouldBeInstanceOf<RequestParametersFrom.OpenId4VpDcApiMultiSigned>()
     }
 
     test("iso mdoc request round-trips") {

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequestSerializationTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/dcapi/request/DCAPIWalletRequestSerializationTest.kt
@@ -19,12 +19,12 @@ import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 private typealias IsoMdocRequestParametersFrom =
-    RequestParametersFrom<RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper>
+    RequestParametersFrom<RequestParametersFrom.IsoMdocDcApi.IsoMdocRequestWrapper>
 
 val DCAPIWalletRequestSerializationTest by testSuite {
     test("openid4vp unsigned request round-trips") {
         val parameters = testUnsignedOpenId4VpRequest.data
-        val request = RequestParametersFrom.OpenId4VpUnsigned(
+        val request = RequestParametersFrom.OpenId4VpDcApiUnsigned(
             parameters = parameters,
             jsonString = joseCompliantSerializer.encodeToString(parameters),
             credentialIds = listOf("044c78be429198ffc2a66d935ff86e4e2bdb8ca2ab0cd1bacc85f3a73d8347b4"),
@@ -44,7 +44,7 @@ val DCAPIWalletRequestSerializationTest by testSuite {
 
     test("openid4vp signed request round-trips") {
         val request: JwsCompactTyped<AuthenticationRequestParameters> = testSignedOpenId4VpRequest.data.request.typed()
-        val walletRequest = RequestParametersFrom.OpenId4VpSigned(
+        val walletRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
             jwsTyped = request,
             verified = false,
             credentialIds = listOf("044c78be429198ffc2a66d935ff86e4e2bdb8ca2ab0cd1bacc85f3a73d8347b4"),
@@ -66,7 +66,7 @@ val DCAPIWalletRequestSerializationTest by testSuite {
         val requestElement: JwsFlattened = testSignedOpenId4VpRequest.data.request.toJwsFlattened()
         val request: JwsGeneralTyped<AuthenticationRequestParameters> =
             (0..5).map { requestElement }.toJwsGeneral().typed()
-        val walletRequest = RequestParametersFrom.OpenId4VpMultiSigned(
+        val walletRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
             jwsTyped = request,
             verified = false,
             credentialIds = listOf("044c78be429198ffc2a66d935ff86e4e2bdb8ca2ab0cd1bacc85f3a73d8347b4"),
@@ -107,9 +107,9 @@ val DCAPIWalletRequestSerializationTest by testSuite {
         decoded.shouldBeInstanceOf<DCAPIWalletRequest.OpenId4VpMultiSigned>()
     }
 
-        test("iso mdoc request round-trips") {
-        val request = RequestParametersFrom.IsoMdoc(
-            parameters = RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper(testIsoMdocRequest.data),
+    test("iso mdoc request round-trips") {
+        val request = RequestParametersFrom.IsoMdocDcApi(
+            parameters = RequestParametersFrom.IsoMdocDcApi.IsoMdocRequestWrapper(testIsoMdocRequest.data),
             jsonString = joseCompliantSerializer.encodeToString(testIsoMdocRequest.data),
             credentialIds = listOf("044c78be429198ffc2a66d935ff86e4e2bdb8ca2ab0cd1bacc85f3a73d8347b4"),
             callingPackageName = "com.android.chrome",

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
@@ -3,7 +3,6 @@ package at.asitplus.wallet.lib.ktor.openid
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.catchingUnwrapped
-import at.asitplus.dcapi.request.DCAPIWalletRequest
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
@@ -134,11 +133,6 @@ class OpenId4VpWallet(
 
     suspend fun startAuthorizationResponsePreparation(
         input: String,
-    ): KmmResult<AuthorizationResponsePreparationState> =
-        openId4VpHolder.startAuthorizationResponsePreparation(input)
-
-    suspend fun startAuthorizationResponsePreparation(
-        input: DCAPIWalletRequest.OpenId4Vp,
     ): KmmResult<AuthorizationResponsePreparationState> =
         openId4VpHolder.startAuthorizationResponsePreparation(input)
 

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
@@ -3,13 +3,13 @@ package at.asitplus.wallet.lib.ktor.openid
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.data.NonEmptyList.Companion.nonEmptyListOf
-import at.asitplus.dcapi.request.DCAPIWalletRequest
 import at.asitplus.iso.IssuerSignedItem
 import at.asitplus.openid.AuthenticationResponseParameters
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.openid.OidcUserInfo
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.openid.OpenIdConstants.ResponseMode
+import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.openid.RequestObjectParameters
 import at.asitplus.openid.dcql.DCQLClaimsPathPointer
 import at.asitplus.openid.dcql.DCQLClaimsPathPointerSegment.NameSegment
@@ -421,8 +421,9 @@ val OpenId4VpWalletTest by testSuite {
                        "response_type" : "vp_token"
                     }
                     """.trimIndent()
-            val dcApiRequest = DCAPIWalletRequest.OpenId4VpUnsigned(
-                request = joseCompliantSerializer.decodeFromString(request),
+            val dcApiRequest = RequestParametersFrom.OpenId4VpUnsigned(
+                parameters = joseCompliantSerializer.decodeFromString(request),
+                jsonString = request,
                 credentialIds = listOf("c72a2a8a6e94564cd8dea6ef0c7eb47b31a31947620ebcc0f07177bb71078def"),
                 callingPackageName = "com.android.chrome",
                 callingOrigin = "https://apps.egiz.gv.at/customverifier"

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
@@ -421,7 +421,7 @@ val OpenId4VpWalletTest by testSuite {
                        "response_type" : "vp_token"
                     }
                     """.trimIndent()
-            val dcApiRequest = RequestParametersFrom.OpenId4VpUnsigned(
+            val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiUnsigned(
                 parameters = joseCompliantSerializer.decodeFromString(request),
                 jsonString = request,
                 credentialIds = listOf("c72a2a8a6e94564cd8dea6ef0c7eb47b31a31947620ebcc0f07177bb71078def"),

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -19,6 +19,7 @@ import at.asitplus.openid.OpenIdConstants.AUTH_METHOD_ATTEST_JWT_CLIENT_AUTH
 import at.asitplus.openid.PushedAuthenticationResponseParameters
 import at.asitplus.openid.RequestObjectParameters
 import at.asitplus.openid.RequestParameters
+import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.openid.SignatureRequestParameters
 import at.asitplus.openid.TokenIntrospectionJwtResponse
 import at.asitplus.openid.TokenIntrospectionRequest
@@ -394,6 +395,8 @@ class SimpleAuthorizationService(
 
         is RequestObjectParameters -> throw InvalidRequest("could not parse request object from request")
         is SignatureRequestParameters -> throw InvalidRequest("could not parse request object from request")
+        is RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper ->
+            throw InvalidRequest("could not parse request object from request")
     }
 
     /**

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -395,7 +395,7 @@ class SimpleAuthorizationService(
 
         is RequestObjectParameters -> throw InvalidRequest("could not parse request object from request")
         is SignatureRequestParameters -> throw InvalidRequest("could not parse request object from request")
-        is RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper ->
+        is RequestParametersFrom.IsoMdocDcApi.IsoMdocRequestWrapper ->
             throw InvalidRequest("could not parse request object from request")
     }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
@@ -48,11 +48,12 @@ internal class AuthenticationResponseFactory(
         response: AuthenticationResponse,
     ) = AuthenticationResponseResult.DcApi(
         when (request) {
-            is RequestParametersFrom.DcApiUnsigned<*> -> OpenId4VpResponseUnsigned(
+            is RequestParametersFrom.OpenId4VpUnsigned -> OpenId4VpResponseUnsigned(
                 buildResponseParametersDcApi(request, response),
             )
 
-            is RequestParametersFrom.DcApiSigned<*> -> OpenId4VpResponseSigned(
+            is RequestParametersFrom.OpenId4VpSigned,
+            is RequestParametersFrom.OpenId4VpMultiSigned -> OpenId4VpResponseSigned(
                 buildResponseParametersDcApi(request, response)
             )
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
@@ -52,12 +52,11 @@ internal class AuthenticationResponseFactory(
                 buildResponseParametersDcApi(request, response),
             )
 
-            is RequestParametersFrom.OpenId4VpDcApiSigned,
-            is RequestParametersFrom.OpenId4VpDcApiMultiSigned -> OpenId4VpResponseSigned(
+            is RequestParametersFrom.OpenId4VpDcApiSigned -> OpenId4VpResponseSigned(
                 buildResponseParametersDcApi(request, response)
             )
 
-            is RequestParametersFrom.DcApiMultiSigned<*> -> OpenId4VpResponseMultiSigned(
+            is RequestParametersFrom.OpenId4VpDcApiMultiSigned -> OpenId4VpResponseMultiSigned(
                 buildResponseParametersDcApi(request, response)
             )
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthenticationResponseFactory.kt
@@ -48,12 +48,12 @@ internal class AuthenticationResponseFactory(
         response: AuthenticationResponse,
     ) = AuthenticationResponseResult.DcApi(
         when (request) {
-            is RequestParametersFrom.OpenId4VpUnsigned -> OpenId4VpResponseUnsigned(
+            is RequestParametersFrom.OpenId4VpDcApiUnsigned -> OpenId4VpResponseUnsigned(
                 buildResponseParametersDcApi(request, response),
             )
 
-            is RequestParametersFrom.OpenId4VpSigned,
-            is RequestParametersFrom.OpenId4VpMultiSigned -> OpenId4VpResponseSigned(
+            is RequestParametersFrom.OpenId4VpDcApiSigned,
+            is RequestParametersFrom.OpenId4VpDcApiMultiSigned -> OpenId4VpResponseSigned(
                 buildResponseParametersDcApi(request, response)
             )
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationRequestValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationRequestValidator.kt
@@ -61,7 +61,9 @@ internal class AuthorizationRequestValidator(
                 val dcApiRequest = this as RequestParametersFrom.DcApiRequest
                 if (this.parameters.clientId == null)
                     throw InvalidRequest("client_id must be set for DC API signed request")
-                this.parameters.verifyExpectedOrigin(dcApiRequest.callingOrigin)
+                if (!this.parameters.verifyExpectedOrigin(dcApiRequest.callingOrigin)) {
+                    throw InvalidRequest("calling origin does not match expected_origins")
+                }
             }
 
             is RequestParametersFrom.OpenId4VpDcApiUnsigned -> {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationRequestValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationRequestValidator.kt
@@ -56,16 +56,17 @@ internal class AuthorizationRequestValidator(
 
     private fun RequestParametersFrom<AuthenticationRequestParameters>.validateDcApi() {
         when (this) {
-            is RequestParametersFrom.OpenId4VpSigned,
-            is RequestParametersFrom.OpenId4VpMultiSigned -> {
+            is RequestParametersFrom.OpenId4VpDcApiSigned,
+            is RequestParametersFrom.OpenId4VpDcApiMultiSigned -> {
                 val dcApiRequest = this as RequestParametersFrom.DcApiRequest
                 if (this.parameters.clientId == null)
                     throw InvalidRequest("client_id must be set for DC API signed request")
-                if (this.parameters.expectedOrigins != null &&
-                    !this.parameters.verifyExpectedOrigin(dcApiRequest.callingOrigin)
-                ) throw InvalidRequest(
-                    "callingOrigin '${dcApiRequest.callingOrigin}' does not match expected_origins"
-                )
+                this.parameters.verifyExpectedOrigin(dcApiRequest.callingOrigin)
+            }
+
+            is RequestParametersFrom.OpenId4VpDcApiUnsigned -> {
+                if (this.parameters.clientId != null)
+                    throw InvalidRequest("client_id not allowed for DC API unsigned request")
             }
 
             else -> throw InvalidRequest("DC API request not set even though response mode is ${parameters.responseMode}")

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationRequestValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthorizationRequestValidator.kt
@@ -56,29 +56,16 @@ internal class AuthorizationRequestValidator(
 
     private fun RequestParametersFrom<AuthenticationRequestParameters>.validateDcApi() {
         when (this) {
-            is RequestParametersFrom.DcApiSigned<*> -> {
+            is RequestParametersFrom.OpenId4VpSigned,
+            is RequestParametersFrom.OpenId4VpMultiSigned -> {
+                val dcApiRequest = this as RequestParametersFrom.DcApiRequest
                 if (this.parameters.clientId == null)
                     throw InvalidRequest("client_id must be set for DC API signed request")
                 if (this.parameters.expectedOrigins != null &&
-                    !this.parameters.verifyExpectedOrigin(this.dcApiRequest.callingOrigin)
+                    !this.parameters.verifyExpectedOrigin(dcApiRequest.callingOrigin)
                 ) throw InvalidRequest(
-                    "callingOrigin '${this.dcApiRequest.callingOrigin}' does not match expected_origins"
+                    "callingOrigin '${dcApiRequest.callingOrigin}' does not match expected_origins"
                 )
-            }
-
-            is RequestParametersFrom.DcApiMultiSigned<*> -> {
-                if (this.parameters.clientId == null)
-                    throw InvalidRequest("client_id must be set for DC API multisigned request")
-                if (this.parameters.expectedOrigins != null &&
-                    !this.parameters.verifyExpectedOrigin(this.dcApiRequest.callingOrigin)
-                ) throw InvalidRequest(
-                    "callingOrigin '${this.dcApiRequest.callingOrigin}' does not match expected_origins"
-                )
-            }
-
-            is RequestParametersFrom.DcApiUnsigned<*> -> {
-                if (this.parameters.clientId != null)
-                    throw InvalidRequest("client_id not allowed for DC API unsigned request")
             }
 
             else -> throw InvalidRequest("DC API request not set even though response mode is ${parameters.responseMode}")
@@ -105,7 +92,7 @@ internal class AuthorizationRequestValidator(
         val signedRequest = this as? RequestParametersFrom.RequestParametersSigned<AuthenticationRequestParameters>
             ?: throw InvalidRequest("x509 client_id_scheme requires a signed request object")
 
-        val certChain = when (val jws = signedRequest.jws) {
+        val certChain = when (val jws = signedRequest.jwsTyped.jws) {
             is JwsCompact -> jws.jwsHeader.certificateChain
             is JwsGeneral -> jws.signatureElements.firstOrNull()?.jwsHeader?.certificateChain
             else -> null

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -437,7 +437,7 @@ private fun RequestParameters.state() = when (this) {
     is JarRequestParameters -> this.state
     is RequestObjectParameters -> null
     is SignatureRequestParameters -> this.state
-    is RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper -> null
+    is RequestParametersFrom.IsoMdocDcApi.IsoMdocRequestWrapper -> null
 }
 
 fun Throwable.toOAuth2Error(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -407,7 +407,7 @@ class OpenId4VpHolder(
     private fun RequestParametersFrom<AuthenticationRequestParameters>.extractAudience(
         clientJsonWebKeySet: Collection<JsonWebKey>?,
     ) = when (this) {
-        is RequestParametersFrom.DcApiRequest -> "origin:${dcApiRequest.callingOrigin}"
+        is RequestParametersFrom.DcApiRequest -> "origin:$callingOrigin"
         else -> parameters.extractAudience(clientJsonWebKeySet)
     }
 
@@ -420,19 +420,11 @@ class OpenId4VpHolder(
             ?.let { it.keyId ?: it.didEncoded ?: it.jwkThumbprint }
         ?: throw InvalidRequest("could not parse audience")
 
-    private fun RequestParametersFrom<AuthenticationRequestParameters>.callingOrigin() = when (this) {
-        is RequestParametersFrom.DcApiSigned -> dcApiRequest.callingOrigin
-        is RequestParametersFrom.DcApiUnsigned -> dcApiRequest.callingOrigin
-        is RequestParametersFrom.DcApiMultiSigned -> dcApiRequest.callingOrigin
-        else -> null
-    }
+    private fun RequestParametersFrom<AuthenticationRequestParameters>.callingOrigin() =
+        (this as? RequestParametersFrom.DcApiRequest)?.callingOrigin
 
-    private fun RequestParametersFrom<AuthenticationRequestParameters>.credentialIds() = when (this) {
-        is RequestParametersFrom.DcApiSigned -> dcApiRequest.credentialIds
-        is RequestParametersFrom.DcApiUnsigned -> dcApiRequest.credentialIds
-        is RequestParametersFrom.DcApiMultiSigned -> dcApiRequest.credentialIds
-        else -> null
-    }
+    private fun RequestParametersFrom<AuthenticationRequestParameters>.credentialIds() =
+        (this as? RequestParametersFrom.DcApiRequest)?.credentialIds
 
     private suspend fun RelyingPartyMetadata.loadJsonWebKeySet(): JsonWebKeySet? =
         jsonWebKeySet ?: jsonWebKeySetUrl
@@ -464,6 +456,7 @@ private fun RequestParameters.state() = when (this) {
     is JarRequestParameters -> this.state
     is RequestObjectParameters -> null
     is SignatureRequestParameters -> this.state
+    is RequestParametersFrom.IsoMdoc.IsoMdocRequestWrapper -> null
 }
 
 fun Throwable.toOAuth2Error(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -3,7 +3,6 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.catchingUnwrapped
-import at.asitplus.dcapi.request.DCAPIWalletRequest
 import at.asitplus.dif.PresentationDefinition
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.AuthenticationResponseParameters
@@ -193,12 +192,6 @@ class OpenId4VpHolder(
     ) = requestParser.parseRequestParameters(input)
         .getOrThrow() as RequestParametersFrom<AuthenticationRequestParameters>
 
-    @Suppress("UNCHECKED_CAST")
-    private suspend fun parse(
-        input: DCAPIWalletRequest.OpenId4Vp,
-    ) = requestParser.parseRequestParameters(input)
-        .getOrThrow() as RequestParametersFrom<AuthenticationRequestParameters>
-
     /** Creates an error response for the [error], which can be sent to the verifier / relying party. */
     suspend fun createAuthnErrorResponse(
         error: Throwable,
@@ -259,18 +252,6 @@ class OpenId4VpHolder(
      */
     suspend fun startAuthorizationResponsePreparation(
         input: String,
-    ): KmmResult<AuthorizationResponsePreparationState> = catching {
-        startAuthorizationResponsePreparation(parse(input)).getOrThrow()
-    }
-
-    /**
-     * Loads the [AuthenticationRequestParameters] from DC API [input].
-     * Clients need to inform the user, get consent, and resume in [finalizeAuthorizationResponse].
-     *
-     * Exceptions thrown during request parsing are caught by [KmmResult],
-     */
-    suspend fun startAuthorizationResponsePreparation(
-        input: DCAPIWalletRequest.OpenId4Vp,
     ): KmmResult<AuthorizationResponsePreparationState> = catching {
         startAuthorizationResponsePreparation(parse(input)).getOrThrow()
     }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -60,10 +60,10 @@ class RequestParser(
         input: RequestParametersFrom.DcApiRequest,
     ): KmmResult<RequestParametersFrom<AuthenticationRequestParameters>> = catching {
         when (input) {
-            is RequestParametersFrom.OpenId4VpSigned -> input
-            is RequestParametersFrom.OpenId4VpUnsigned -> input
-            is RequestParametersFrom.OpenId4VpMultiSigned -> input
-            is RequestParametersFrom.IsoMdoc -> throw InvalidRequest("ISO mdoc DC API requests are not OpenID4VP requests")
+            is RequestParametersFrom.OpenId4VpDcApiSigned -> input
+            is RequestParametersFrom.OpenId4VpDcApiUnsigned -> input
+            is RequestParametersFrom.OpenId4VpDcApiMultiSigned -> input
+            is RequestParametersFrom.IsoMdocDcApi -> throw InvalidRequest("ISO mdoc DC API requests are not OpenID4VP requests")
         }
     }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -3,7 +3,6 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.catchingUnwrapped
-import at.asitplus.dcapi.request.DCAPIWalletRequest
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.OpenIdConstants
@@ -58,9 +57,14 @@ class RequestParser(
      * Pass in the data received by the DC API in signed or unsigned form. Will return [RequestParametersFrom].
      */
     suspend fun parseRequestParameters(
-        input: DCAPIWalletRequest.OpenId4Vp,
+        input: RequestParametersFrom.DcApiRequest,
     ): KmmResult<RequestParametersFrom<AuthenticationRequestParameters>> = catching {
-        input.parseAsDcApiRequest() ?: throw InvalidRequest("parse error: $input")
+        when (input) {
+            is RequestParametersFrom.OpenId4VpSigned -> input
+            is RequestParametersFrom.OpenId4VpUnsigned -> input
+            is RequestParametersFrom.OpenId4VpMultiSigned -> input
+            is RequestParametersFrom.IsoMdoc -> throw InvalidRequest("ISO mdoc DC API requests are not OpenID4VP requests")
+        }
     }
 
     private suspend fun String.parseParameters(): RequestParametersFrom<out RequestParameters> =
@@ -90,36 +94,6 @@ class RequestParser(
         val params = joseCompliantSerializer.decodeFromString(RequestParameters.serializer(), this)
         RequestParametersFrom.Json(this, params, (parent as? RequestParametersFrom.Uri)?.url)
     }.getOrNull()
-
-    private fun DCAPIWalletRequest.OpenId4Vp.parseAsDcApiRequest(): RequestParametersFrom<AuthenticationRequestParameters>? =
-        catchingUnwrapped {
-            when (this) {
-                is DCAPIWalletRequest.OpenId4VpSigned -> RequestParametersFrom.OpenId4VpSigned(
-                    jwsTyped = this.request.request,
-                    verified = false,
-                    credentialIds = credentialIds,
-                    callingPackageName = callingPackageName,
-                    callingOrigin = callingOrigin,
-                )
-
-                is DCAPIWalletRequest.OpenId4VpUnsigned ->
-                    RequestParametersFrom.OpenId4VpUnsigned(
-                        parameters = this.request.request,
-                        jsonString = joseCompliantSerializer.encodeToString(this.request.request),
-                        credentialIds = credentialIds,
-                        callingPackageName = callingPackageName,
-                        callingOrigin = callingOrigin,
-                    )
-
-                is DCAPIWalletRequest.OpenId4VpMultiSigned -> RequestParametersFrom.OpenId4VpMultiSigned(
-                    jwsTyped = this.request.request,
-                    verified = false,
-                    credentialIds = credentialIds,
-                    callingPackageName = callingPackageName,
-                    callingOrigin = callingOrigin,
-                )
-            }
-        }.getOrNull()
 
     suspend fun extractRequest(
         parameters: JarRequestParameters,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/RequestParser.kt
@@ -94,25 +94,29 @@ class RequestParser(
     private fun DCAPIWalletRequest.OpenId4Vp.parseAsDcApiRequest(): RequestParametersFrom<AuthenticationRequestParameters>? =
         catchingUnwrapped {
             when (this) {
-                is DCAPIWalletRequest.OpenId4VpSigned -> RequestParametersFrom.DcApiSigned(
-                    this,
-                    this.request.request.payload,
-                    this.request.request.jws,
-                    false
+                is DCAPIWalletRequest.OpenId4VpSigned -> RequestParametersFrom.OpenId4VpSigned(
+                    jwsTyped = this.request.request,
+                    verified = false,
+                    credentialIds = credentialIds,
+                    callingPackageName = callingPackageName,
+                    callingOrigin = callingOrigin,
                 )
 
                 is DCAPIWalletRequest.OpenId4VpUnsigned ->
-                    RequestParametersFrom.DcApiUnsigned(
-                        this,
-                        this.request.request,
-                        joseCompliantSerializer.encodeToString(this.request.request)
+                    RequestParametersFrom.OpenId4VpUnsigned(
+                        parameters = this.request.request,
+                        jsonString = joseCompliantSerializer.encodeToString(this.request.request),
+                        credentialIds = credentialIds,
+                        callingPackageName = callingPackageName,
+                        callingOrigin = callingOrigin,
                     )
 
-                is DCAPIWalletRequest.OpenId4VpMultiSigned -> RequestParametersFrom.DcApiMultiSigned(
-                    this,
-                    this.request.request.payload,
-                    this.request.request.jws,
-                    false
+                is DCAPIWalletRequest.OpenId4VpMultiSigned -> RequestParametersFrom.OpenId4VpMultiSigned(
+                    jwsTyped = this.request.request,
+                    verified = false,
+                    credentialIds = credentialIds,
+                    callingPackageName = callingPackageName,
+                    callingOrigin = callingOrigin,
                 )
             }
         }.getOrNull()
@@ -154,4 +158,3 @@ class RequestParser(
             }
 
 }
-

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -1,6 +1,5 @@
 package at.asitplus.wallet.lib.openid
 
-import at.asitplus.dcapi.request.DCAPIWalletRequest
 import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.JarRequestParameters
@@ -80,12 +79,10 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
         }
 
         "DcApiUnsigned test $representation" {
-            val authnRequest = DCAPIWalletRequest.OpenId4VpUnsigned(
-                request = DCAPIWalletRequest.OpenId4Vp.OpenId4VpRequest.Unsigned(
-                    verifierOid4vp.createAuthnRequest(
-                        requestOptions = reqOptions
-                    )
-                ),
+            val parameters = verifierOid4vp.createAuthnRequest(requestOptions = reqOptions)
+            val authnRequest = RequestParametersFrom.OpenId4VpUnsigned(
+                parameters = parameters,
+                jsonString = joseCompliantSerializer.encodeToString(parameters),
                 credentialIds = listOf("1"),
                 callingPackageName = "com.example.app",
                 callingOrigin = "https://example.com"
@@ -125,8 +122,9 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
             val jarRequest: JarRequestParameters = Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery()
             jarRequest.clientId shouldBe clientId
             val serializedRequest = jarRequest.request.shouldNotBeNull()
-            val authnRequest = DCAPIWalletRequest.OpenId4VpSigned(
-                request = DCAPIWalletRequest.OpenId4Vp.OpenId4VpRequest.JwsCompact(JwsTyped(serializedRequest)),
+            val authnRequest = RequestParametersFrom.OpenId4VpSigned(
+                jwsTyped = JwsTyped(serializedRequest),
+                verified = false,
                 credentialIds = listOf("1"),
                 callingPackageName = "com.example.app",
                 callingOrigin = "https://example.com"

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -59,7 +59,8 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
                 .shouldBeInstanceOf<RequestParametersFrom.Uri<AuthenticationRequestParameters>>()
 
-            val serialized = joseCompliantSerializer.encodeToString(params)
+            val serialized =
+                joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(params)
             joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(serialized)
                 .shouldBe(params)
         }
@@ -72,7 +73,8 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
                 .shouldBeInstanceOf<RequestParametersFrom.Json<AuthenticationRequestParameters>>()
 
-            val serialized = joseCompliantSerializer.encodeToString(params)
+            val serialized =
+                joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(params)
             joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(serialized)
                 .shouldBe(params)
         }
@@ -90,9 +92,10 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
             )
 
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
-                .shouldBeInstanceOf<RequestParametersFrom.DcApiUnsigned<AuthenticationRequestParameters>>()
+                .shouldBeInstanceOf<RequestParametersFrom.OpenId4VpUnsigned>()
 
-            val serialized = joseCompliantSerializer.encodeToString(params)
+            val serialized =
+                joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(params)
             joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(serialized)
                 .shouldBe(params)
         }
@@ -108,7 +111,8 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
             val params = holderOid4vp.startAuthorizationResponsePreparation(serializedRequest).getOrThrow().request
                 .shouldBeInstanceOf<RequestParametersFrom.Jws<AuthenticationRequestParameters>>()
 
-            val serialized = joseCompliantSerializer.encodeToString(params)
+            val serialized =
+                joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(params)
             joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(serialized)
                 .shouldBe(params)
         }
@@ -129,9 +133,10 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
             )
 
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
-                .shouldBeInstanceOf<RequestParametersFrom.DcApiSigned<AuthenticationRequestParameters>>()
+                .shouldBeInstanceOf<RequestParametersFrom.OpenId4VpSigned>()
 
-            val serialized = joseCompliantSerializer.encodeToString(params)
+            val serialized =
+                joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(params)
             joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(serialized)
                 .shouldBe(params)
         }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -148,19 +148,19 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
             jarRequest.clientId shouldBe clientId
             val serializedRequest = jarRequest.request.shouldNotBeNull()
             val compactTyped = JwsTyped<AuthenticationRequestParameters>(serializedRequest)
-            val authnRequest = DCAPIWalletRequest.OpenId4VpMultiSigned(
-                request = DCAPIWalletRequest.OpenId4Vp.OpenId4VpRequest.JwsGeneral(
-                    JwsTyped(listOf(compactTyped.jws.toJwsFlattened()))
-                ),
+            val authnRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
+                jwsTyped = JwsTyped<AuthenticationRequestParameters>(listOf(compactTyped.jws.toJwsFlattened())),
+                verified = false,
                 credentialIds = listOf("1"),
                 callingPackageName = "com.example.app",
                 callingOrigin = "https://example.com"
             )
 
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
-                .shouldBeInstanceOf<RequestParametersFrom.DcApiMultiSigned<AuthenticationRequestParameters>>()
+                .shouldBeInstanceOf<RequestParametersFrom.OpenId4VpDcApiMultiSigned>()
 
-            val serialized = joseCompliantSerializer.encodeToString(params)
+            val serialized =
+                joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(params)
             joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(serialized)
                 .shouldBe(params)
         }

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -80,7 +80,7 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
 
         "DcApiUnsigned test $representation" {
             val parameters = verifierOid4vp.createAuthnRequest(requestOptions = reqOptions)
-            val authnRequest = RequestParametersFrom.OpenId4VpUnsigned(
+            val authnRequest = RequestParametersFrom.OpenId4VpDcApiUnsigned(
                 parameters = parameters,
                 jsonString = joseCompliantSerializer.encodeToString(parameters),
                 credentialIds = listOf("1"),
@@ -89,7 +89,7 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
             )
 
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
-                .shouldBeInstanceOf<RequestParametersFrom.OpenId4VpUnsigned>()
+                .shouldBeInstanceOf<RequestParametersFrom.OpenId4VpDcApiUnsigned>()
 
             val serialized =
                 joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(params)
@@ -122,7 +122,7 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
             val jarRequest: JarRequestParameters = Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery()
             jarRequest.clientId shouldBe clientId
             val serializedRequest = jarRequest.request.shouldNotBeNull()
-            val authnRequest = RequestParametersFrom.OpenId4VpSigned(
+            val authnRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
                 jwsTyped = JwsTyped(serializedRequest),
                 verified = false,
                 credentialIds = listOf("1"),
@@ -131,7 +131,7 @@ val AuthenticationRequestParameterFromSerializerTest by testSuite {
             )
 
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
-                .shouldBeInstanceOf<RequestParametersFrom.OpenId4VpSigned>()
+                .shouldBeInstanceOf<RequestParametersFrom.OpenId4VpDcApiSigned>()
 
             val serialized =
                 joseCompliantSerializer.encodeToString<RequestParametersFrom<AuthenticationRequestParameters>>(params)

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
@@ -3,11 +3,11 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.dcapi.OpenId4VpResponseMultiSigned
 import at.asitplus.dcapi.OpenId4VpResponseSigned
 import at.asitplus.dcapi.OpenId4VpResponseUnsigned
-import at.asitplus.dcapi.request.DCAPIWalletRequest
-import at.asitplus.dcapi.request.DCAPIWalletRequest.OpenId4Vp.OpenId4VpRequest
+import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.JwsTyped
+import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.toJwsFlattened
 import at.asitplus.testballoon.withFixtureGenerator
 import at.asitplus.wallet.lib.RequestOptionsCredential
@@ -82,16 +82,17 @@ val OpenId4VpDcApiProtocolTest by testSuite {
             )
             val authnRequest = f.verifierOid4vp.createAuthnRequest(reqOptions)
 
-            val dcApiRequest = DCAPIWalletRequest.OpenId4VpUnsigned(
-                request = OpenId4VpRequest.Unsigned(authnRequest),
+            val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiUnsigned(
+                parameters = authnRequest,
+                jsonString = joseCompliantSerializer.encodeToString(authnRequest),
                 credentialIds = listOf(credentialId),
                 callingPackageName = callingPackageName,
                 callingOrigin = callingOrigin,
             )
 
             val preparationState = f.holderOid4vp.startAuthorizationResponsePreparation(dcApiRequest).getOrThrow()
-            preparationState.request.shouldBeInstanceOf<RequestParametersFrom.DcApiUnsigned<*>>()
-                .dcApiRequest.callingOrigin shouldBe callingOrigin
+            preparationState.request.shouldBeInstanceOf<RequestParametersFrom.OpenId4VpDcApiUnsigned>()
+                .callingOrigin shouldBe callingOrigin
 
             val response = f.holderOid4vp.finalizeAuthorizationResponse(preparationState).getOrThrow()
 
@@ -107,16 +108,17 @@ val OpenId4VpDcApiProtocolTest by testSuite {
             )
             val signedRequest = f.verifierOid4vp.createAuthnRequestAsSignedRequestObject(reqOptions).getOrThrow()
 
-            val dcApiRequest = DCAPIWalletRequest.OpenId4VpSigned(
-                request = OpenId4VpRequest.JwsCompact(signedRequest),
+            val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
+                jwsTyped = signedRequest,
+                verified = false,
                 credentialIds = listOf(credentialId),
                 callingPackageName = callingPackageName,
                 callingOrigin = callingOrigin,
             )
 
             val preparationState = f.holderOid4vp.startAuthorizationResponsePreparation(dcApiRequest).getOrThrow()
-            preparationState.request.shouldBeInstanceOf<RequestParametersFrom.DcApiSigned<*>>()
-                .dcApiRequest.callingOrigin shouldBe callingOrigin
+            preparationState.request.shouldBeInstanceOf<RequestParametersFrom.OpenId4VpDcApiSigned>()
+                .callingOrigin shouldBe callingOrigin
 
             val response = f.holderOid4vp.finalizeAuthorizationResponse(preparationState).getOrThrow()
 
@@ -132,18 +134,17 @@ val OpenId4VpDcApiProtocolTest by testSuite {
             )
             val signedRequest = f.verifierOid4vp.createAuthnRequestAsSignedRequestObject(reqOptions).getOrThrow()
 
-            val dcApiRequest = DCAPIWalletRequest.OpenId4VpMultiSigned(
-                request = OpenId4VpRequest.JwsGeneral(
-                    JwsTyped(listOf(signedRequest.jws.toJwsFlattened()))
-                ),
+            val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
+                jwsTyped = JwsTyped<AuthenticationRequestParameters>(listOf(signedRequest.jws.toJwsFlattened())),
+                verified = false,
                 credentialIds = listOf(credentialId),
                 callingPackageName = callingPackageName,
                 callingOrigin = callingOrigin,
             )
 
             val preparationState = f.holderOid4vp.startAuthorizationResponsePreparation(dcApiRequest).getOrThrow()
-            preparationState.request.shouldBeInstanceOf<RequestParametersFrom.DcApiMultiSigned<*>>()
-                .dcApiRequest.callingOrigin shouldBe callingOrigin
+            preparationState.request.shouldBeInstanceOf<RequestParametersFrom.OpenId4VpDcApiMultiSigned>()
+                .callingOrigin shouldBe callingOrigin
 
             val response = f.holderOid4vp.finalizeAuthorizationResponse(preparationState).getOrThrow()
 
@@ -159,10 +160,9 @@ val OpenId4VpDcApiProtocolTest by testSuite {
             )
             val signedRequest = f.verifierOid4vp.createAuthnRequestAsSignedRequestObject(reqOptions).getOrThrow()
 
-            val dcApiRequest = DCAPIWalletRequest.OpenId4VpMultiSigned(
-                request = OpenId4VpRequest.JwsGeneral(
-                    JwsTyped(listOf(signedRequest.jws.toJwsFlattened()))
-                ),
+            val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
+                jwsTyped = JwsTyped<AuthenticationRequestParameters>(listOf(signedRequest.jws.toJwsFlattened())),
+                verified = false,
                 credentialIds = listOf(credentialId),
                 callingPackageName = callingPackageName,
                 callingOrigin = "https://evil.example.com",  // does not match expectedOrigins
@@ -181,8 +181,9 @@ val OpenId4VpDcApiProtocolTest by testSuite {
             )
             val signedRequest = f.verifierOid4vp.createAuthnRequestAsSignedRequestObject(reqOptions).getOrThrow()
 
-            val dcApiRequest = DCAPIWalletRequest.OpenId4VpSigned(
-                request = OpenId4VpRequest.JwsCompact(signedRequest),
+            val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
+                jwsTyped = signedRequest,
+                verified = false,
                 credentialIds = listOf(credentialId),
                 callingPackageName = callingPackageName,
                 callingOrigin = "https://evil.example.com",  // does not match expectedOrigins

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
@@ -1,7 +1,5 @@
 package at.asitplus.wallet.lib.openid
 
-import at.asitplus.dcapi.request.DCAPIWalletRequest
-import at.asitplus.dcapi.request.DCAPIWalletRequest.OpenId4Vp.OpenId4VpRequest
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.RequestParametersFrom
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
@@ -161,8 +159,9 @@ val OpenIdRequestParserTests by testSuite {
         }
 
         "signed request from DCAPI" { requestParser ->
-            val input = DCAPIWalletRequest.OpenId4VpSigned(
-                request = OpenId4VpRequest.JwsCompact(JwsTyped<AuthenticationRequestParameters>(jws)),
+            val input = RequestParametersFrom.OpenId4VpSigned(
+                jwsTyped = JwsTyped<AuthenticationRequestParameters>(jws),
+                verified = false,
                 credentialIds = listOf("1"),
                 callingPackageName = "com.example.app",
                 callingOrigin = "https://example.com"
@@ -181,8 +180,9 @@ val OpenIdRequestParserTests by testSuite {
         }
 
         "unsigned request from DCAPI" { requestParser ->
-            val input = DCAPIWalletRequest.OpenId4VpUnsigned(
-                request = joseCompliantSerializer.decodeFromString(authnRequestSerialized),
+            val input = RequestParametersFrom.OpenId4VpUnsigned(
+                parameters = joseCompliantSerializer.decodeFromString(authnRequestSerialized),
+                jsonString = authnRequestSerialized,
                 credentialIds = listOf("1"),
                 callingPackageName = "com.example.app",
                 callingOrigin = "https://example.com"

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
@@ -202,10 +202,9 @@ val OpenIdRequestParserTests by testSuite {
 
         "multisigned request from DCAPI" { requestParser ->
             val compactTyped = JwsCompactTyped<AuthenticationRequestParameters>(jws)
-            val input = DCAPIWalletRequest.OpenId4VpMultiSigned(
-                request = OpenId4VpRequest.JwsGeneral(
-                    JwsTyped(listOf(compactTyped.jws.toJwsFlattened()))
-                ),
+            val input = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
+                jwsTyped = JwsTyped<AuthenticationRequestParameters>(listOf(compactTyped.jws.toJwsFlattened())),
+                verified = false,
                 credentialIds = listOf("1"),
                 callingPackageName = "com.example.app",
                 callingOrigin = "https://example.com"
@@ -213,7 +212,7 @@ val OpenIdRequestParserTests by testSuite {
 
             requestParser.parseRequestParameters(input).getOrThrow().apply {
                 shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
-                shouldBeInstanceOf<RequestParametersFrom.DcApiMultiSigned<*>>()
+                shouldBeInstanceOf<RequestParametersFrom.OpenId4VpDcApiMultiSigned>()
                 parameters.assertParams()
 
                 joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
@@ -170,8 +170,8 @@ val OpenIdRequestParserTests by testSuite {
 
             requestParser.parseRequestParameters(input).getOrThrow().apply {
                 shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
-                shouldBeInstanceOf<RequestParametersFrom.DcApiSigned<*>>()
-                this.jws.toString() shouldBe jws
+                val dcApiRequest = shouldBeInstanceOf<RequestParametersFrom.OpenId4VpSigned>()
+                dcApiRequest.jwsTyped.toString() shouldBe jws
                 parameters.assertParams()
 
                 joseCompliantSerializer.decodeFromString<RequestParametersFrom<AuthenticationRequestParameters>>(
@@ -190,7 +190,7 @@ val OpenIdRequestParserTests by testSuite {
 
             requestParser.parseRequestParameters(input).getOrThrow().apply {
                 shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
-                shouldBeInstanceOf<RequestParametersFrom.DcApiUnsigned<*>>()
+                shouldBeInstanceOf<RequestParametersFrom.OpenId4VpUnsigned>()
                 //jsonString shouldBe authnRequestSerialized // TODO Don't know why this is not the same
                 parameters.assertParams()
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenIdRequestParserTests.kt
@@ -159,7 +159,7 @@ val OpenIdRequestParserTests by testSuite {
         }
 
         "signed request from DCAPI" { requestParser ->
-            val input = RequestParametersFrom.OpenId4VpSigned(
+            val input = RequestParametersFrom.OpenId4VpDcApiSigned(
                 jwsTyped = JwsTyped<AuthenticationRequestParameters>(jws),
                 verified = false,
                 credentialIds = listOf("1"),
@@ -169,7 +169,7 @@ val OpenIdRequestParserTests by testSuite {
 
             requestParser.parseRequestParameters(input).getOrThrow().apply {
                 shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
-                val dcApiRequest = shouldBeInstanceOf<RequestParametersFrom.OpenId4VpSigned>()
+                val dcApiRequest = shouldBeInstanceOf<RequestParametersFrom.OpenId4VpDcApiSigned>()
                 dcApiRequest.jwsTyped.toString() shouldBe jws
                 parameters.assertParams()
 
@@ -180,7 +180,7 @@ val OpenIdRequestParserTests by testSuite {
         }
 
         "unsigned request from DCAPI" { requestParser ->
-            val input = RequestParametersFrom.OpenId4VpUnsigned(
+            val input = RequestParametersFrom.OpenId4VpDcApiUnsigned(
                 parameters = joseCompliantSerializer.decodeFromString(authnRequestSerialized),
                 jsonString = authnRequestSerialized,
                 credentialIds = listOf("1"),
@@ -190,7 +190,7 @@ val OpenIdRequestParserTests by testSuite {
 
             requestParser.parseRequestParameters(input).getOrThrow().apply {
                 shouldBeInstanceOf<RequestParametersFrom<AuthenticationRequestParameters>>()
-                shouldBeInstanceOf<RequestParametersFrom.OpenId4VpUnsigned>()
+                shouldBeInstanceOf<RequestParametersFrom.OpenId4VpDcApiUnsigned>()
                 //jsonString shouldBe authnRequestSerialized // TODO Don't know why this is not the same
                 parameters.assertParams()
 


### PR DESCRIPTION
As discussed in #551 integrate `DCAPIRequestParameters` into `RequestParametersFrom`. 
Both classes serve the same purpose and are used as internal data models only. Since `IsoMdoc` related classes are not part of openid the placement of `RequestParameters` and `RequestParametersFrom` inside the `openid-data-classes` module is a bit awkward, but moving it to `vck` would involve a lot of wrapping as done for `IsoMdocDcApi`

(@gp-iaik pls review)