### PR TITLE
Remote Credential Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Release 6.0.0:
    - That implies changes to `CredentialToBeIssued`, `IssuedCredential`, `StoreCredentialInput` and methods in `SubjectCredentialStore`
    - In `CredentialScheme` deprecate `claimNames` (list of strings), to be replaced with `claimDescriptions` (set of typed descriptions)
    - In `StoreEntry` deprecate property `scheme` and add suspending function `resolveScheme()` to replace it 
-   - Add `UnknownCredentialScheme` so that the `scheme` property of several classes is never null
+   - Add `UnknownCredentialScheme` so that the `scheme` property in several methods and classes is not null
    - Import data classes and data element strings from credentials into this library for [EU PID](https://github.com/a-sit-plus/eu-pid-credential), [EU PID in SD-JWT](https://github.com/a-sit-plus/eu-pid-credential-sdjwt/) and [Mobile Driving Licence](https://github.com/a-sit-plus/mobile-driving-licence-credential/)
    - Document usage of remote metadata retrieval
  - New modules:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Release 6.0.0:
    - In `StoreEntry` deprecate property `scheme` and add suspending function `resolveScheme()` to replace it 
    - Add `UnknownCredentialScheme` so that the `scheme` property of several classes is never null
    - Import data classes and data element strings from credentials into this library for [EU PID](https://github.com/a-sit-plus/eu-pid-credential), [EU PID in SD-JWT](https://github.com/a-sit-plus/eu-pid-credential-sdjwt/) and [Mobile Driving Licence](https://github.com/a-sit-plus/mobile-driving-licence-credential/)
+   - Document usage of remote metadata retrieval
  - New modules:
    - `etsi-data-classes` implements list of trusted entities from [ETSI TS 119 602](https://www.etsi.org/deliver/etsi_ts/119600_119699/119602/01.01.01_60/ts_119602v010101p.pdf)
    - `sd-jwt-type-metadata` implements SD-JWT VC Type Metadata from [draft-ietf-oauth-sd-jwt-vc-16](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Changelog
 
 Release 7.0.0 (unreleased):
- - Refactorings:
-   - `OpenId4VpHolder.getMatchingCredentials()` returns `KmmResult` instead of `Result`
+- Credential definitions:
+    - Move `CredentialScheme` out of `ConstantIndex`
+    - Provide type alias for `CredentialRepresentation`
+    - Introduce typed sub-interfaces of `CredentialScheme`: `VcJwtCredentialScheme`, `SdJwtCredentialScheme` and `IsoMdocCredentialScheme`
+    - That implies changes to `CredentialToBeIssued`, `IssuedCredential`, `StoreCredentialInput` and methods in `SubjectCredentialStore`
+    - In `CredentialScheme` deprecate `claimNames` (list of strings), to be replaced with `claimDescriptions` (set of typed descriptions)
+    - In `StoreEntry` deprecate property `scheme` and add suspending function `resolveScheme()` to replace it
+    - Add `UnknownCredentialScheme` so that the `scheme` property in several methods and classes is not null
+    - Import data classes and data element strings from credentials into this library for [EU PID](https://github.com/a-sit-plus/eu-pid-credential), [EU PID in SD-JWT](https://github.com/a-sit-plus/eu-pid-credential-sdjwt/) and [Mobile Driving Licence](https://github.com/a-sit-plus/mobile-driving-licence-credential/)
+    - Document usage of remote metadata retrieval
+- Refactorings:
+    - `OpenId4VpHolder.getMatchingCredentials()` returns `KmmResult` instead of `Result`
 
 Release 6.0.0:
  - JWS:
@@ -42,16 +52,6 @@ Release 6.0.0:
    - Remove code deprecated in 5.12.0, e.g. `CredentialSubject` as base class for JWT VC
    - Deprecate `vckJsonSerializer`, should be replaced with `joseCompliantSerializer` (Signum)
    - Deprecate `signDpop` in `OAuth2KtorClient` because DPoP need same key as instance attestation [EUDI Wallet TS3](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md)
- - Credential definitions:
-   - Move `CredentialScheme` out of `ConstantIndex`
-   - Provide type alias for `CredentialRepresentation`
-   - Introduce typed sub-interfaces of `CredentialScheme`: `VcJwtCredentialScheme`, `SdJwtCredentialScheme` and `IsoMdocCredentialScheme`
-   - That implies changes to `CredentialToBeIssued`, `IssuedCredential`, `StoreCredentialInput` and methods in `SubjectCredentialStore`
-   - In `CredentialScheme` deprecate `claimNames` (list of strings), to be replaced with `claimDescriptions` (set of typed descriptions)
-   - In `StoreEntry` deprecate property `scheme` and add suspending function `resolveScheme()` to replace it 
-   - Add `UnknownCredentialScheme` so that the `scheme` property in several methods and classes is not null
-   - Import data classes and data element strings from credentials into this library for [EU PID](https://github.com/a-sit-plus/eu-pid-credential), [EU PID in SD-JWT](https://github.com/a-sit-plus/eu-pid-credential-sdjwt/) and [Mobile Driving Licence](https://github.com/a-sit-plus/mobile-driving-licence-credential/)
-   - Document usage of remote metadata retrieval
  - New modules:
    - `etsi-data-classes` implements list of trusted entities from [ETSI TS 119 602](https://www.etsi.org/deliver/etsi_ts/119600_119699/119602/01.01.01_60/ts_119602v010101p.pdf)
    - `sd-jwt-type-metadata` implements SD-JWT VC Type Metadata from [draft-ietf-oauth-sd-jwt-vc-16](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 Release 7.0.0 (unreleased):
- - tbd
+ - Refactorings:
+   - `OpenId4VpHolder.getMatchingCredentials()` returns `KmmResult` instead of `Result`
 
 Release 6.0.0:
  - JWS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Release 6.0.0:
  - Credential definitions:
    - Move `CredentialScheme` out of `ConstantIndex`
    - Provide type alias for `CredentialRepresentation`
-   - Introudce typed sub-interfaces of `CredentialScheme`: `VcJwtCredentialScheme`, `SdJwtCredentialScheme` and `IsoMdocCredentialScheme`
+   - Introduce typed sub-interfaces of `CredentialScheme`: `VcJwtCredentialScheme`, `SdJwtCredentialScheme` and `IsoMdocCredentialScheme`
    - That implies changes to `CredentialToBeIssued`, `IssuedCredential`, `StoreCredentialInput` and methods in `SubjectCredentialStore`
    - In `CredentialScheme` deprecate `claimNames` (list of strings), to be replaced with `claimDescriptions` (set of typed descriptions)
    - In `StoreEntry` deprecate property `scheme` and add suspending function `resolveScheme()` to replace it 
@@ -63,7 +63,7 @@ Release 6.0.0:
    - Update to [Supreme 0.14.0](https://github.com/a-sit-plus/signum/pull/451)
    - Update to Ktor 3.5.0
    - Update Bouncy Castle 1.84
-   - Update to kotlinx.coroutines 1.11.0
+   - Update to `kotlinx.coroutines` 1.11.0
  - Matrix testing
 
 Release 5.12.0:
@@ -85,7 +85,7 @@ Release 5.12.0:
    - Change: Update DCQLClaimsQuery and DCQLCredentialQuery to OpenID4VP 1.0
    - Change: Do not fail when only matching credentials without submitting a presentation
    - Allow issuance and verification of `IdentifierList` Revocation Mechanism
-   - Change: Don't send response on user initiated signature cancellation
+   - Change: Don't send response on user-initiated signature cancellation
    - BREAKING CHANGE: The result type from `verifyAuthnResponse`, `AuthnResponseResult` has been reworked to a data class
    - DCQL: Add custom credential types and proper satisfaction evaluation
    - Add: DCQL submission requirements validation
@@ -213,7 +213,7 @@ Release 5.10.0:
    - Drop single `proof` in credential request
    - Support credential response encryption correctly, see changed API in `CredentialIssuer.credential()`
    - Correctly verify credential request regarding `credential_configuration_id` and `credential_identifiers`
-   - Support credential request encryption correctly, if metadata is set at Issuer
+   - Support credential request encryption correctly if metadata is set at Issuer
  - OpenID for Verifiable Presentations:
    - Update implementation to 1.0 from 2025-07-09
    - Remove code elements deprecated in 5.9.0
@@ -382,11 +382,11 @@ Release 5.8.0:
    - In `SimpleAuthorizationService` deprecate constructor parameter `dataProvider`, use `authorize()` with `OAuth2LoadUserFun` instead
    - In `AuthorizationService` deprecate `authorize()` methods, adding `authorize()` with `OAuth2LoadUserFun`
  - Credential schemes:
-   - Provide fallback credential schemes, to be used when no matching scheme is registered with this library:
+   - Provide fallback credential schemes to be used when no matching scheme is registered with this library:
      - `SdJwtFallbackCredentialScheme`
      - `VcFallbackCredentialScheme`
      - `IsoMdocFallbackCredentialScheme`
-   - Note that these schemes are not resolved automatically, and need to be used explicitly in client applications
+   - Note that these schemes are not resolved automatically and need to be used explicitly in client applications
  - SD-JWT:
    - Add data class for [SD-JWT VC Type metadata](https://www.ietf.org/archive/id/draft-ietf-oauth-sd-jwt-vc-10.html#name-sd-jwt-vc-type-metadata) in `SdJwtTypeMetadata`
    - Update signum to provide SD-JWT VC Type metadata in `vctm` in the header of a SD-JWT
@@ -446,7 +446,7 @@ Release 5.7.0:
    - Replace type aliases with functional interfaces (providing named parameters in implementations)
    - Make cryptographic verification functions suspending
  - Fully integrated crypto functionality based on Signum 3.16.2. This carries over breaking changes:
-   - All debug-only kotlinx.serialization for cryptographic datatypes like certificates, public keys, etc. was removed
+   - All debug-only `kotlinx.serialization` for cryptographic datatypes like certificates, public keys, etc. was removed
    - This finally cleans up the RSAorHMAC
      - `SignatureAlgorithm.RSAorHMAC` is now properly split into `SignatureAlgorithm` and `MessageAuthenticationCode`. Both implement `DataIntegrityAlgorithm`.
      - This split also affects `JwsAlgorithm`, which now has subtypes: `Signature` and `MAC`. Hence, `JwsAlgorithm.ES256` -> `JwsAlgorithm.Signature.ES256`
@@ -464,7 +464,7 @@ Release 5.7.0:
    - Remove `Validator.checkRevocationStatus` in favor of `Validator.checkCredentialFreshness`
    - Remove `Holder.StoredCredential.status`
    - Remove `Verifier.VerifyCredentialResult.Revoked`
-   - Add constructor parameter `Validator.acceptedTokenStatuses` to allow library client to define token statuses deemed valid
+   - Add constructor parameter `Validator.acceptedTokenStatuses` to allow library clients to define token statuses deemed valid
  - Add support for Digital Credentials API as defined in OID4VP draft 28 and ISO 18013-7 Annex C:
    - Implement `DCAPIRequest` for requests received via the Digital Credentials API, with implementations for OID4VP (`Oid4vpDCAPIRequest`), ISO 18013-7 Annex C (`IsoMdocRequest`) and a non-standardised preview protocol (`PreviewDCAPIRequest`)
    - New property of type `Oid4vpDCAPIRequest` for requests originating from the Digital Credentials API in `AuthorizationResponsePreparationState`
@@ -472,7 +472,7 @@ Release 5.7.0:
    - New optional parameter `filterById` of type `String` in `Holder.matchInputDescriptorsAgainstCredentialStore`, `HolderAgent.getValidCredentialsByPriority` `HolderAgent.matchInputDescriptorsAgainstCredentialStore` `HolderAgent.matchDCQLQueryAgainstCredentialStore` to filter credentials by id
    - New method `SubjectCredentialStore.getDcApiId` to generate an id of type `String` for a credential
    - New optional property of type `DCAPIHandover` for `SessionTranscript`
- - Return member of interface `AuthenticationResult` instead of `AuthenticationSuccess` as authorization response in `OpenId4VpWallet`. Can either be
+ - Return member of interface `AuthenticationResult` instead of `AuthenticationSuccess` as authorization response in `OpenId4VpWallet`:
    - `AuthenticationSuccess`: contains a `redirectUri` (same behaviour as in 5.6.x)
    - `AuthenticationForward`: contains the `authenticationResponseResult` for responses via the Digital Credentials API
  - Refactoring of ISO data classes:
@@ -843,7 +843,7 @@ Release 5.2.0:
     - Remove `scopePresentationDefinitionRetriever` from `OidcSiopWallet` to keep implementation simple
 - Dependency Updates:
     - Signum 3.11.1
-    - Kotlin 2.1.0  through Conventions 2.1.0+20241204
+    - Kotlin 2.1.0 through Conventions 2.1.0+20241204
 
 Release 5.1.0:
  - Drop ARIES protocol implementation, and the `vck-aries` artifact
@@ -912,7 +912,7 @@ Release 5.0.0:
    - Remove binding method for `did:key`, as it was never completely implemented, but add binding method `jwk` for JSON Web Keys.
    - Rework interface of `WalletService` to make selecting the credential configuration by its ID more explicit
    - Support requesting issuance of credential using scope values
-   - Introudce `OAuth2Client` to extract creating authentication requests and token requests from OID4VCI `WalletService`
+   - Introduce `OAuth2Client` to extract creating authentication requests and token requests from OID4VCI `WalletService`
    - Refactor `SimpleAuthorizationService` to extract actual authentication and authorization into `AuthorizationServiceStrategy`
  - Implement JWE encryption with AES-CBC-HMAC algorithms
  - SIOPv2/OpenID4VP: Support requesting and receiving claims from different credentials, i.e. a combined presentation

--- a/README.md
+++ b/README.md
@@ -116,6 +116,53 @@ As discovered in [#226](https://github.com/a-sit-plus/vck/issues/226), using the
 The actual credentials are provided as discrete artefacts and are maintained separately [over here](https://github.com/a-sit-plus/credentials-collection).
 It is fine to add credentials **and** VC-K to as project dependencies, e. g., to use a version of VC-K that is more recent than the one a certain credentials depends on.
 
+### Registering credential schemes
+
+Credential schemes are derived from [SD-JWT Type Metadata](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/)
+documents and resolved through `AttributeIndex`. Register one or more `CredentialMetadataRegistry` instances once at
+startup; on a lookup miss `AttributeIndex` consults them, builds the scheme, and caches it. Two registries coexist:
+a `StaticCredentialMetadataRegistry` for documents **bundled in code** (offline, authoritative; preloaded so they win
+on lookup), and a `RemoteCredentialMetadataRegistry` that **fetches documents over HTTP** for everything else. The
+documents are hosted in [credentials-collection](https://github.com/a-sit-plus/credentials-collection).
+
+```kotlin
+val base = "https://raw.githubusercontent.com/a-sit-plus/credentials-collection/main"
+
+// Bundled in code: EU PID (ISO), EU PID SD-JWT, mDL. The URL is the document's hosted copy (becomes schemaUri).
+LibraryInitializer.registerCredentialMetadataRegistry(
+    StaticCredentialMetadataRegistry(
+        documentRegistry = SdJwtTypeMetadataDocumentRegistry(
+            EuPidSdJwtMetadataDocument, EuPidMetadataDocument, MobileDrivingLicenceMetadataDocument,
+        ),
+        documentUrls = mapOf(
+            EuPidSdJwtMetadataDocument.first to EU_PID_SD_JWT_METADATA_URL,
+            EuPidMetadataDocument.first to EU_PID_METADATA_URL,
+            MobileDrivingLicenceMetadataDocument.first to MDL_METADATA_URL,
+        ),
+    )
+)
+
+// Fetched on demand: add one `vct -> URL` entry per published document. SD-JWT resolves directly (identifier == vct);
+// ISO mDoc has no direct vct fallback, so its docType must be aliased to the document's vct.
+LibraryInitializer.registerCredentialMetadataRegistry(
+    RemoteCredentialMetadataRegistry(
+        httpClient = httpClient, // your app's Ktor HttpClient
+        clock = Clock.System,
+        documentUrls = mutableMapOf(
+            SdJwtVcType("urn:eudi:ehic:1") to "$base/ehic.json",
+            SdJwtVcType("eu.europa.ec.av.1") to "$base/age-verification.json",
+        ),
+        aliases = mapOf(
+            CredentialMetadataLookup(ISO_MDOC, "eu.europa.ec.av.1") to SdJwtVcType("eu.europa.ec.av.1"),
+        ),
+    )
+)
+```
+
+ISO mDoc credentials with non-primitive values additionally need their CBOR/JSON value serializers registered from
+code (e.g. `LibraryInitializer.registerCredentialSerializers(EuPidJsonValueEncoder, EuPidItemValueSerializerMap)`);
+schemes whose values are all primitive (such as the all-boolean age verification) need none.
+
 ## Limitations
 
  - Several parts of the W3C VC Data Model have not been fully implemented, i.e. everything around resolving cryptographic key material.

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/IssuerSignedItemSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/IssuerSignedItemSerializer.kt
@@ -186,7 +186,7 @@ open class IssuerSignedItemSerializer(
 
         val elementValueContainer = first { (it.key as CborText).value == PROP_ELEMENT_VALUE }.value
         val elementValue = CborCredentialSerializer.lookupSerializer(namespace, elementId)?.let {
-            runCatching {
+            catchingUnwrapped {
                 coseCompliantSerializer.decodeFromByteArray(it, elementValueContainer.cbor)
             }.getOrElse {
                 decodeGenericElementValue(elementValueContainer.cbor)
@@ -197,14 +197,14 @@ open class IssuerSignedItemSerializer(
     }
 
     private fun decodeGenericElementValue(bytes: ByteArray): Any {
-        runCatching { return coseCompliantSerializer.decodeFromByteArray(LocalDate.serializer(), bytes) }
-        runCatching { return coseCompliantSerializer.decodeFromByteArray(InstantStringSerializer, bytes) }
-        runCatching { return coseCompliantSerializer.decodeFromByteArray(String.serializer(), bytes) }
-        runCatching { return coseCompliantSerializer.decodeFromByteArray(Long.serializer(), bytes) }
-        runCatching { return coseCompliantSerializer.decodeFromByteArray(Float.serializer(), bytes) }
-        runCatching { return coseCompliantSerializer.decodeFromByteArray(Double.serializer(), bytes) }
-        runCatching { return coseCompliantSerializer.decodeFromByteArray(Boolean.serializer(), bytes) }
-        runCatching { return coseCompliantSerializer.decodeFromByteArray(ByteArraySerializer(), bytes) }
+        catchingUnwrapped { return coseCompliantSerializer.decodeFromByteArray(LocalDate.serializer(), bytes) }
+        catchingUnwrapped { return coseCompliantSerializer.decodeFromByteArray(InstantStringSerializer, bytes) }
+        catchingUnwrapped { return coseCompliantSerializer.decodeFromByteArray(String.serializer(), bytes) }
+        catchingUnwrapped { return coseCompliantSerializer.decodeFromByteArray(Long.serializer(), bytes) }
+        catchingUnwrapped { return coseCompliantSerializer.decodeFromByteArray(Float.serializer(), bytes) }
+        catchingUnwrapped { return coseCompliantSerializer.decodeFromByteArray(Double.serializer(), bytes) }
+        catchingUnwrapped { return coseCompliantSerializer.decodeFromByteArray(Boolean.serializer(), bytes) }
+        catchingUnwrapped { return coseCompliantSerializer.decodeFromByteArray(ByteArraySerializer(), bytes) }
         return bytes
     }
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialRequestProofContainer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialRequestProofContainer.kt
@@ -1,5 +1,6 @@
 package at.asitplus.openid
 
+import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.josef.JsonWebToken
 import at.asitplus.signum.indispensable.josef.JwsCompact
 import at.asitplus.signum.indispensable.josef.JwsCompactStringSerializer
@@ -33,13 +34,13 @@ data class CredentialRequestProofContainer(
 
     val jwtParsed: Collection<JwsCompactTyped<JsonWebToken>>? by lazy {
         jwt?.mapNotNull {
-            runCatching<JwsCompactTyped<JsonWebToken>> { it.typed() }.getOrNull()
+            catchingUnwrapped<JwsCompactTyped<JsonWebToken>> { it.typed() }.getOrNull()
         }
     }
 
     val attestationParsed: Collection<JwsCompactTyped<KeyAttestationJwt>>? by lazy {
         attestation?.mapNotNull {
-            runCatching<JwsCompactTyped<KeyAttestationJwt>> { it.typed() }.getOrNull()
+            catchingUnwrapped<JwsCompactTyped<KeyAttestationJwt>> { it.typed() }.getOrNull()
         }
     }
 }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SupportedCredentialFormat.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SupportedCredentialFormat.kt
@@ -1,5 +1,6 @@
 package at.asitplus.openid
 
+import at.asitplus.catchingUnwrapped
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
@@ -195,7 +196,7 @@ sealed interface SupportedCredentialFormat {
             }
             val jsonObject = decoder.decodeJsonElement().jsonObject
             val formatIdentifier = jsonObject[SerialNames.FORMAT]?.jsonPrimitive
-            val format = formatIdentifier?.runCatching {
+            val format = formatIdentifier?.catchingUnwrapped {
                 CredentialFormatEnum.parse(formatIdentifier.content)
             }?.getOrNull()
 

--- a/sd-jwt-type-metadata/src/commonMain/kotlin/at/asitplus/csp2/ContentSecurityPolicySourceExpression.kt
+++ b/sd-jwt-type-metadata/src/commonMain/kotlin/at/asitplus/csp2/ContentSecurityPolicySourceExpression.kt
@@ -1,5 +1,6 @@
 package at.asitplus.csp2
 
+import at.asitplus.catchingUnwrapped
 import at.asitplus.rfc3986uri.Rfc3986UriSchemeName
 
 sealed interface ContentSecurityPolicySourceExpression {
@@ -23,22 +24,22 @@ sealed interface ContentSecurityPolicySourceExpression {
          */
         operator fun invoke(string: String): ContentSecurityPolicySourceExpression {
             if (string.isNeitherSchemeNorHostSource()) {
-                runCatching {
+                catchingUnwrapped {
                     return ContentSecurityPolicySourceExpressionKeyword(
-                        ContentSecurityPolicySourceExpressionKeywordContent.valueOf(string.removePrefix("'").removeSuffix("'"))
+                        ContentSecurityPolicySourceExpressionKeywordContent.valueOf(
+                            string.removePrefix("'").removeSuffix("'")
+                        )
                     )
                 }
-                runCatching {
+                catchingUnwrapped {
                     return ContentSecurityPolicySourceExpressionNonce.parse(string)
                 }
-                runCatching {
+                catchingUnwrapped {
                     return ContentSecurityPolicySourceExpressionHash(string)
                 }
             } else if (string.isSchemeSource()) {
-                runCatching {
-                    return ContentSecurityPolicySourceExpressionScheme(
-                        Rfc3986UriSchemeName(string.removeSuffix(":"))
-                    )
+                catchingUnwrapped {
+                    return ContentSecurityPolicySourceExpressionScheme(Rfc3986UriSchemeName(string.removeSuffix(":")))
                 }
             } else {
                 return ContentSecurityPolicySourceExpressionHost(string)

--- a/sd-jwt-type-metadata/src/commonMain/kotlin/at/asitplus/csp2/ContentSecurityPolicySourceList.kt
+++ b/sd-jwt-type-metadata/src/commonMain/kotlin/at/asitplus/csp2/ContentSecurityPolicySourceList.kt
@@ -1,5 +1,6 @@
 package at.asitplus.csp2
 
+import at.asitplus.catchingUnwrapped
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -85,9 +86,7 @@ data class ContentSecurityPolicySourceList(
             listOf()
         } else {
             it.split(*asciiWhitespaces).mapNotNull {
-                runCatching {
-                    ContentSecurityPolicySourceExpression.Companion(it)
-                }.getOrNull()
+                catchingUnwrapped { ContentSecurityPolicySourceExpression(it) }.getOrNull()
             }
         }
     }

--- a/sd-jwt-type-metadata/src/commonMain/kotlin/at/asitplus/wallet/sdjwt/W3cSubresourceIntegrityMetadata.kt
+++ b/sd-jwt-type-metadata/src/commonMain/kotlin/at/asitplus/wallet/sdjwt/W3cSubresourceIntegrityMetadata.kt
@@ -26,7 +26,7 @@ value class W3cSubresourceIntegrityMetadata(
     val expression: ContentSecurityPolicySourceExpressionHash
 ) {
     constructor(string: String): this(
-        ContentSecurityPolicySourceExpressionHash.Companion("'$string'")
+        ContentSecurityPolicySourceExpressionHash("'$string'")
     )
 
     constructor(

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/Extensions.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/Extensions.kt
@@ -1,6 +1,7 @@
 package at.asitplus.wallet.lib.ktor.openid
 
 import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.OpenIdConstants.Errors.USE_DPOP_NONCE
 import at.asitplus.wallet.lib.oidvci.OAuth2Error
 import io.ktor.client.call.*
@@ -57,9 +58,8 @@ suspend inline fun <reified T, R> IntermediateResult<R>.onSuccess(
 }
 
 /** Extracts the header `DPoP-Nonce` if the error is `use_dpop_nonce`. */
-fun OAuth2Error?.dpopNonce(response: HttpResponse) = runCatching {
-    authorizationServerProvidedNonce(response)
-        ?: resourceServerProvidedNonce(response)
+fun OAuth2Error?.dpopNonce(response: HttpResponse) = catchingUnwrapped {
+    authorizationServerProvidedNonce(response) ?: resourceServerProvidedNonce(response)
 }.getOrNull()
 
 /** [RFC 9449 8.](https://datatracker.ietf.org/doc/html/rfc9449#name-authorization-server-provid) */

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/KtorSdJwtTypeMetadataDocumentRetriever.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/KtorSdJwtTypeMetadataDocumentRetriever.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.ktor.openid
 
+import at.asitplus.catchingUnwrapped
 import at.asitplus.rfc3986uri.Rfc3986UniformResourceIdentifier
 import at.asitplus.rfc3986uri.Rfc3986UriSchemeName
 import at.asitplus.wallet.sdjwt.SdJwtTypeMetadataDefinition
@@ -32,7 +33,8 @@ class KtorSdJwtTypeMetadataDocumentRetriever(
     val json: Json = Json.Default,
     val integrityChecker: SdJwtTypeMetadataDocumentIntegrityChecker = SdJwtTypeMetadataDocumentIntegrityChecker.DEFAULT,
 ) : SdJwtTypeMetadataDocumentRetriever {
-    private val staticCache = mutableMapOf<SdJwtVcType, Pair<W3cSubresourceIntegrityMetadata, SdJwtTypeMetadataDocument>>()
+    private val staticCache =
+        mutableMapOf<SdJwtVcType, Pair<W3cSubresourceIntegrityMetadata, SdJwtTypeMetadataDocument>>()
     private val dynamicCache = mutableMapOf<SdJwtVcType, Pair<Instant, SdJwtTypeMetadataDocument>>()
 
     override suspend fun retrieve(
@@ -40,10 +42,7 @@ class KtorSdJwtTypeMetadataDocumentRetriever(
         integrityMetadata: W3cSubresourceIntegrityMetadata?,
     ): SdJwtTypeMetadataDocument? {
         val url = locateUrl(sdJwtVcType) ?: return null
-
-        val uri = runCatching {
-            Rfc3986UniformResourceIdentifier.Companion(url)
-        }.getOrNull() ?: return null
+        val uri = catchingUnwrapped { Rfc3986UniformResourceIdentifier(url) }.getOrNull() ?: return null
 
         if (uri.schemeName !in Rfc3986UriSchemeName.Common.run { listOf(HTTPS, HTTP) }) {
             return null

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OAuth2KtorClient.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.ktor.openid
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.AuthenticationResponseParameters
 import at.asitplus.openid.JarRequestParameters
@@ -615,11 +616,11 @@ private suspend fun parseTokenIntrospectionResponse(
     body: String,
     verifyTokenIntrospectionJwt: suspend (JwsCompactTyped<TokenIntrospectionResponse>) -> Boolean,
     requestedResponseFormat: TokenIntrospectionRequest.ResponseFormat?,
-): TokenIntrospectionResponse = runCatching {
+): TokenIntrospectionResponse = catchingUnwrapped {
     if (requestedResponseFormat == TokenIntrospectionRequest.ResponseFormat.JWT) {
         parseJwt(body, verifyTokenIntrospectionJwt)
     } else {
-        runCatching {
+        catchingUnwrapped {
             joseCompliantSerializer.decodeFromString(TokenIntrospectionResponse.serializer(), body)
         }.getOrElse {
             parseJwt(body, verifyTokenIntrospectionJwt)

--- a/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
+++ b/vck-openid-ktor/src/commonMain/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWallet.kt
@@ -214,7 +214,7 @@ class OpenId4VpWallet(
      */
     suspend fun getMatchingCredentials(
         preparationState: AuthorizationResponsePreparationState,
-    ) = catchingUnwrapped {
+    ) = catching {
         openId4VpHolder.getMatchingCredentials(preparationState).getOrThrow()
     }
 

--- a/vck-openid-ktor/src/commonTest/kotlin/TestConfig.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/TestConfig.kt
@@ -3,14 +3,16 @@ import at.asitplus.testballoon.matrix.MatrixTestDefaults
 import at.asitplus.wallet.eupid.EuPidItemValueSerializerMap
 import at.asitplus.wallet.eupid.EuPidJsonValueEncoder
 import at.asitplus.wallet.eupid.EuPidMetadataDocument
+import at.asitplus.wallet.eupid.EU_PID_METADATA_URL
 import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtMetadataDocument
+import at.asitplus.wallet.eupidsdjwt.EU_PID_SD_JWT_METADATA_URL
+import at.asitplus.wallet.mdl.MDL_METADATA_URL
 import at.asitplus.wallet.lib.LibraryInitializer
 import at.asitplus.wallet.lib.data.StaticCredentialMetadataRegistry
 import at.asitplus.wallet.mdl.MobileDrivingLicenceItemValueSerializerMap
 import at.asitplus.wallet.mdl.MobileDrivingLicenceJsonValueEncoder
 import at.asitplus.wallet.mdl.MobileDrivingLicenceMetadataDocument
 import at.asitplus.wallet.sdjwt.SdJwtTypeMetadataDocumentRegistry
-import at.asitplus.wallet.sdjwt.SdJwtVcType
 import de.infix.testBalloon.framework.core.TestSession
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
@@ -30,9 +32,9 @@ class TestConfig : TestSession(
                     MobileDrivingLicenceMetadataDocument,
                 ),
                 documentUrls = mapOf(
-                    SdJwtVcType(EuPidSdJwtMetadataDocument.first.string) to "https://example.com",
-                    SdJwtVcType(EuPidMetadataDocument.first.string) to "https://example.com",
-                    SdJwtVcType(MobileDrivingLicenceMetadataDocument.first.string) to "https://example.com",
+                    EuPidSdJwtMetadataDocument.first to EU_PID_SD_JWT_METADATA_URL,
+                    EuPidMetadataDocument.first to EU_PID_METADATA_URL,
+                    MobileDrivingLicenceMetadataDocument.first to MDL_METADATA_URL,
                 )
             )
         )

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/RemoteCredentialMetadataResolutionTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/RemoteCredentialMetadataResolutionTest.kt
@@ -1,0 +1,143 @@
+package at.asitplus.wallet.lib.ktor.openid
+
+import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.agent.FixedTimeClock
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
+import at.asitplus.wallet.lib.data.CredentialMetadataLookup
+import at.asitplus.wallet.lib.data.IsoMdocCredentialScheme
+import at.asitplus.wallet.lib.data.SdJwtCredentialScheme
+import at.asitplus.wallet.lib.data.toCredentialScheme
+import at.asitplus.wallet.sdjwt.SdJwtVcType
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+
+/**
+ * Verifies that SD-JWT Type Metadata documents hosted in the `credentials-collection` repository resolve through
+ * [RemoteCredentialMetadataRegistry]. The two JSON bodies below mirror `ehic.json` and `age-verification.json` from
+ * that repository; the [MockEngine] serves them at their configured URLs so the test stays hermetic (no live network).
+ */
+val RemoteCredentialMetadataResolutionTest by matrixSuite {
+
+    val base = "https://raw.githubusercontent.com/a-sit-plus/credentials-collection/main"
+    val ehicUrl = "$base/ehic.json"
+    val ageVerificationUrl = "$base/age-verification.json"
+
+    val ehicVct = SdJwtVcType("urn:eudi:ehic:1")
+    val ageVerificationVct = SdJwtVcType("eu.europa.ec.av.1")
+
+    fun registry() = RemoteCredentialMetadataRegistry(
+        httpClient = HttpClient(MockEngine { request ->
+            when (request.url.toString()) {
+                ehicUrl -> respond(
+                    content = EHIC_JSON,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.CacheControl, "max-age=60"),
+                )
+
+                ageVerificationUrl -> respond(
+                    content = AGE_VERIFICATION_JSON,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.CacheControl, "max-age=60"),
+                )
+
+                else -> respondError(HttpStatusCode.NotFound)
+            }
+        }),
+        clock = FixedTimeClock(0),
+        documentUrls = mutableMapOf(
+            ehicVct to ehicUrl,
+            ageVerificationVct to ageVerificationUrl,
+        ),
+        // ISO mDoc has no direct vct fallback, so the docType must be aliased to the document's vct.
+        aliases = mapOf(
+            CredentialMetadataLookup(ISO_MDOC, ageVerificationVct.string) to ageVerificationVct,
+        ),
+    )
+
+    "EHIC SD-JWT metadata resolves remotely" {
+        val entry = registry().findEntry(ehicVct.string, SD_JWT).shouldNotBeNull()
+        entry.metadata.vct shouldBe ehicVct
+        entry.loadedFrom shouldBe ehicUrl
+
+        val scheme = entry.toCredentialScheme().shouldBeInstanceOf<SdJwtCredentialScheme>()
+        scheme.sdJwtType shouldBe ehicVct.string
+        scheme.schemaUri shouldBe ehicUrl
+        // All 13 claims parsed, including the nested issuing_authority.* / authentic_source.* objects, all mandatory.
+        scheme.claimDescriptions.size shouldBe 13
+        scheme.claimDescriptions.count { it.mandatory == true } shouldBe 13
+    }
+
+    "Age verification ISO mDoc metadata resolves remotely through an alias" {
+        val entry = registry().findEntry(ageVerificationVct.string, ISO_MDOC).shouldNotBeNull()
+        entry.metadata.vct shouldBe ageVerificationVct
+        entry.loadedFrom shouldBe ageVerificationUrl
+
+        val scheme = entry.toCredentialScheme().shouldBeInstanceOf<IsoMdocCredentialScheme>()
+        scheme.isoDocType shouldBe ageVerificationVct.string
+        scheme.isoNamespace shouldBe ageVerificationVct.string
+        scheme.schemaUri shouldBe ageVerificationUrl
+        // 11 age-over predicates; only age_over_18 is mandatory.
+        scheme.claimDescriptions.size shouldBe 11
+        scheme.claimDescriptions.count { it.mandatory == true } shouldBe 1
+    }
+
+    "unknown vct does not resolve" {
+        registry().findEntry("urn:eudi:unknown:1", SD_JWT).shouldBeNull()
+    }
+}
+
+private val EHIC_JSON = """
+{
+  "vct": "urn:eudi:ehic:1",
+  "name": "European Health Insurance Card (EHIC)",
+  "description": "European Health Insurance Card, issued as an SD-JWT VC.",
+  "vck": { "format": "dc+sd-jwt" },
+  "claims": [
+    { "path": ["issuing_country"], "mandatory": true, "sd": "allowed" },
+    { "path": ["personal_administrative_number"], "mandatory": true, "sd": "allowed" },
+    { "path": ["issuing_authority"], "mandatory": true, "sd": "allowed" },
+    { "path": ["issuing_authority", "id"], "mandatory": true, "sd": "allowed" },
+    { "path": ["issuing_authority", "name"], "mandatory": true, "sd": "allowed" },
+    { "path": ["authentic_source"], "mandatory": true, "sd": "allowed" },
+    { "path": ["authentic_source", "id"], "mandatory": true, "sd": "allowed" },
+    { "path": ["authentic_source", "name"], "mandatory": true, "sd": "allowed" },
+    { "path": ["document_number"], "mandatory": true, "sd": "allowed" },
+    { "path": ["date_of_issuance"], "mandatory": true, "sd": "allowed" },
+    { "path": ["date_of_expiry"], "mandatory": true, "sd": "allowed" },
+    { "path": ["starting_date"], "mandatory": true, "sd": "allowed" },
+    { "path": ["ending_date"], "mandatory": true, "sd": "allowed" }
+  ]
+}
+""".trimIndent()
+
+private val AGE_VERIFICATION_JSON = """
+{
+  "vct": "eu.europa.ec.av.1",
+  "name": "Age Verification",
+  "description": "Age verification attestation, issued as an ISO/IEC 18013-5 mdoc.",
+  "vck": {
+    "format": "mso_mdoc",
+    "isoDocType": "eu.europa.ec.av.1",
+    "isoNamespace": "eu.europa.ec.av.1"
+  },
+  "claims": [
+    { "path": ["eu.europa.ec.av.1", "age_over_18"], "mandatory": true },
+    { "path": ["eu.europa.ec.av.1", "age_over_12"] },
+    { "path": ["eu.europa.ec.av.1", "age_over_13"] },
+    { "path": ["eu.europa.ec.av.1", "age_over_14"] },
+    { "path": ["eu.europa.ec.av.1", "age_over_16"] },
+    { "path": ["eu.europa.ec.av.1", "age_over_21"] },
+    { "path": ["eu.europa.ec.av.1", "age_over_25"] },
+    { "path": ["eu.europa.ec.av.1", "age_over_60"] },
+    { "path": ["eu.europa.ec.av.1", "age_over_62"] },
+    { "path": ["eu.europa.ec.av.1", "age_over_65"] },
+    { "path": ["eu.europa.ec.av.1", "age_over_68"] }
+  ]
+}
+""".trimIndent()

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/TestUtils.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/TestUtils.kt
@@ -49,6 +49,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.random.Random
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 
 object TestUtils {
 
@@ -92,7 +93,7 @@ object TestUtils {
                 PLAIN_JWT -> TODO()
                 SD_JWT -> CredentialToBeIssued.VcSd(
                     claims = attributes.map { ClaimToBeIssued(it.key, it.value) },
-                    expiration = Clock.System.now(),
+                    expiration = Clock.System.now().plus(1.minutes),
                     scheme = it.credentialScheme as SdJwtCredentialScheme,
                     subjectPublicKey = it.subjectPublicKey,
                     userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject"))
@@ -101,13 +102,13 @@ object TestUtils {
                 )
 
                 ISO_MDOC -> CredentialToBeIssued.Iso(
-                    attributes.map {
+                    issuerSignedItems = attributes.map {
                         IssuerSignedItem(digestId++, Random.nextBytes(32), it.key, it.value)
                     },
-                    Clock.System.now(),
-                    it.credentialScheme as IsoMdocCredentialScheme,
-                    it.subjectPublicKey,
-                    OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
+                    expiration = Clock.System.now().plus(1.minutes),
+                    scheme = it.credentialScheme as IsoMdocCredentialScheme,
+                    subjectPublicKey = it.subjectPublicKey,
+                    userInfo = OidcUserInfoExtended.fromOidcUserInfo(OidcUserInfo("subject")).getOrThrow(),
                     revocationKind = revocationKind,
                 )
             }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oauth2/SimpleAuthorizationService.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.oauth2
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.iso.sha256
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.AuthenticationResponseParameters
@@ -660,7 +661,7 @@ class SimpleAuthorizationService(
     ): KmmResult<TokenIntrospectionResult> = catching {
         // TODO Which client_id to pass?
         clientAuthenticationService.authenticateClient(httpRequest, null)
-        val response = runCatching {
+        val response = catchingUnwrapped {
             tokenService.verification.getTokenInfo(request.token)
         }.fold(
             onSuccess = {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialAuthorizationServiceStrategy.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.oidvci
 
+import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.AuthorizationDetails
 import at.asitplus.openid.OpenIdAuthorizationDetails
 import at.asitplus.wallet.lib.data.CredentialRepresentation
@@ -35,7 +36,7 @@ class CredentialAuthorizationServiceStrategy(
     } else {
         credentials.mapNotNull { (scheme, representation) ->
             if (credentialSchemes.contains(scheme)) {
-                runCatching { mapper.toCredentialIdentifier(scheme, representation) }.getOrNull()
+                catchingUnwrapped { mapper.toCredentialIdentifier(scheme, representation) }.getOrNull()
             } else null
         }.toSet()
     }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialIssuer.kt
@@ -2,6 +2,7 @@ package at.asitplus.wallet.lib.oidvci
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.BatchCredentialIssuanceMetadata
 import at.asitplus.openid.ClientNonceResponse
 import at.asitplus.openid.CredentialRequestParameters
@@ -73,7 +74,7 @@ class CredentialIssuer(
         publicContext = publicContext,
         requireKeyAttestation = requireKeyAttestation,
         verifyAttestationProof = {
-            val tokenStatusValid = runCatching {
+            val tokenStatusValid = catchingUnwrapped {
                 it.payload.keyStorageStatus?.status?.get(StatusListInfo.SerialNames.STATUS_LIST_INFO)?.let { statusList ->
                     Json.decodeFromJsonElement<StatusListInfo>(statusList).let { statusListInfo ->
                         if (statusListTokenResolver?.toTokenStatusResolver()
@@ -84,7 +85,7 @@ class CredentialIssuer(
                 }
             }.isSuccess
 
-            val signatureValid = runCatching {
+            val signatureValid = catchingUnwrapped {
                 VerifyJwsObject().verifyJwsSignature(it.jws, it.jws.jwsHeader.publicKey!!).isSuccess
             }.getOrDefault(false)
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialSchemeMapping.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialSchemeMapping.kt
@@ -61,15 +61,15 @@ interface CredentialSchemeMapper {
     fun decodeFromCredentialIdentifier(input: String): Pair<CredentialScheme, CredentialRepresentation>?
 }
 
-fun CredentialScheme.toIsoMdocSupportedCredentialFormat(identifier: String): Pair<String, SupportedCredentialFormat> =
+fun IsoMdocCredentialScheme.toIsoMdocSupportedCredentialFormat(identifier: String): Pair<String, SupportedCredentialFormat> =
     identifier to SupportedCredentialFormat.forIsoMdoc(
         scope = identifier,
-        docType = isoDocType!!,
+        docType = isoDocType,
         supportedBindingMethods = setOf(BINDING_METHOD_JWK, BINDING_METHOD_COSE_KEY),
         // ISO mdoc claims must be namespace-qualified. Multi-format schemes (e.g. AtomicAttribute2023) share JSON-style
         // claim descriptions across representations, so prefix the namespace unless the path already carries it (as
         // metadata-derived ISO schemes do).
-        isoClaims = claimDescriptions.map { it.qualifiedWithIsoNamespace(isoNamespace!!) }.toSet()
+        isoClaims = claimDescriptions.map { it.qualifiedWithIsoNamespace(isoNamespace) }.toSet()
     )
 
 private fun ClaimDescription.qualifiedWithIsoNamespace(isoNamespace: String): ClaimDescription {
@@ -79,20 +79,20 @@ private fun ClaimDescription.qualifiedWithIsoNamespace(isoNamespace: String): Cl
     else copy(path = OpenId4VciClaimsPathPointer(isoNamespace) + path)
 }
 
-fun CredentialScheme.toPlainJwtSupportedCredentialFormat(identifier: String): Pair<String, SupportedCredentialFormat> =
+fun VcJwtCredentialScheme.toPlainJwtSupportedCredentialFormat(identifier: String): Pair<String, SupportedCredentialFormat> =
     identifier to SupportedCredentialFormat.forVcJwt(
         scope = identifier,
         credentialDefinition = VcJwtCredentialDefinition(
-            types = setOf(VcDataModelConstants.VERIFIABLE_CREDENTIAL, vcType!!),
+            types = setOf(VcDataModelConstants.VERIFIABLE_CREDENTIAL, vcType),
         ),
         supportedBindingMethods = setOf(BINDING_METHOD_JWK, URN_TYPE_JWK_THUMBPRINT),
         vcJwtClaims = claimDescriptions
     )
 
-fun CredentialScheme.toSdJwtSupportedCredentialFormat(identifier: String): Pair<String, SupportedCredentialFormat> =
+fun SdJwtCredentialScheme.toSdJwtSupportedCredentialFormat(identifier: String): Pair<String, SupportedCredentialFormat> =
     identifier to SupportedCredentialFormat.forSdJwt(
         scope = identifier,
-        sdJwtVcType = sdJwtType!!,
+        sdJwtVcType = sdJwtType,
         supportedBindingMethods = setOf(BINDING_METHOD_JWK, URN_TYPE_JWK_THUMBPRINT),
         sdJwtClaims = claimDescriptions
     )

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialSchemeMapping.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/CredentialSchemeMapping.kt
@@ -1,8 +1,11 @@
 package at.asitplus.wallet.lib.oidvci
 
+import at.asitplus.openid.ClaimDescription
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.openid.CredentialFormatEnum.DC_SD_JWT
 import at.asitplus.openid.CredentialFormatEnum.JWT_VC
+import at.asitplus.openid.OpenId4VciClaimsPathPointer
+import at.asitplus.openid.OpenId4VciClaimsPathPointerSegmentString
 import at.asitplus.openid.OpenIdConstants.BINDING_METHOD_COSE_KEY
 import at.asitplus.openid.OpenIdConstants.BINDING_METHOD_JWK
 import at.asitplus.openid.OpenIdConstants.URN_TYPE_JWK_THUMBPRINT
@@ -63,8 +66,18 @@ fun CredentialScheme.toIsoMdocSupportedCredentialFormat(identifier: String): Pai
         scope = identifier,
         docType = isoDocType!!,
         supportedBindingMethods = setOf(BINDING_METHOD_JWK, BINDING_METHOD_COSE_KEY),
-        isoClaims = claimDescriptions
+        // ISO mdoc claims must be namespace-qualified. Multi-format schemes (e.g. AtomicAttribute2023) share JSON-style
+        // claim descriptions across representations, so prefix the namespace unless the path already carries it (as
+        // metadata-derived ISO schemes do).
+        isoClaims = claimDescriptions.map { it.qualifiedWithIsoNamespace(isoNamespace!!) }.toSet()
     )
+
+private fun ClaimDescription.qualifiedWithIsoNamespace(isoNamespace: String): ClaimDescription {
+    val firstSegment = path.firstOrNull()
+    val alreadyQualified = firstSegment is OpenId4VciClaimsPathPointerSegmentString && firstSegment.string == isoNamespace
+    return if (alreadyQualified) this
+    else copy(path = OpenId4VciClaimsPathPointer(isoNamespace) + path)
+}
 
 fun CredentialScheme.toPlainJwtSupportedCredentialFormat(identifier: String): Pair<String, SupportedCredentialFormat> =
     identifier to SupportedCredentialFormat.forVcJwt(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletService.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/WalletService.kt
@@ -187,7 +187,7 @@ class WalletService(
      * which may contain a direct [CredentialOffer] or a URI pointing to it.
      */
     suspend fun parseCredentialOffer(input: String): KmmResult<CredentialOffer> = catching {
-        catching {
+        catchingUnwrapped {
             input.extractParams().fetchCredentialOffer()
         }.getOrNull() ?: catchingUnwrapped {
             joseCompliantSerializer.decodeFromString<CredentialOffer>(input)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -2,7 +2,6 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
-import at.asitplus.catchingUnwrapped
 import at.asitplus.dif.PresentationDefinition
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.AuthenticationResponseParameters
@@ -42,6 +41,7 @@ import at.asitplus.wallet.lib.agent.Holder
 import at.asitplus.wallet.lib.agent.HolderAgent
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.agent.SubjectCredentialStore
 import at.asitplus.wallet.lib.cbor.CoseHeaderNone
 import at.asitplus.wallet.lib.cbor.SignCoseDetached
 import at.asitplus.wallet.lib.cbor.SignCoseDetachedFun
@@ -135,7 +135,7 @@ class OpenId4VpHolder(
         OAuth2AuthorizationServerMetadata(
             issuer = clientId,
             authorizationEndpoint = authorizationEndpoint,
-            responseTypesSupported = setOf(OpenIdConstants.ID_TOKEN, OpenIdConstants.VP_TOKEN),
+            responseTypesSupported = setOf(OpenIdConstants.ID_TOKEN, VP_TOKEN),
             scopesSupported = setOf(OpenIdConstants.SCOPE_OPENID),
             idTokenSigningAlgorithmsSupportedStrings = supportedJwsAlgorithms.toSet(),
             requestObjectSigningAlgorithmsSupportedStrings = supportedJwsAlgorithms.toSet(),
@@ -344,12 +344,13 @@ class OpenId4VpHolder(
 
     private fun RequestParametersFrom<AuthenticationRequestParameters>.extractLeafCertKey(): JsonWebKey? =
         (this as? RequestParametersFrom.Jws<AuthenticationRequestParameters>)?.jws?.let {
-            (it as? JwsCompact)?.jwsHeader?.certificateChain?.firstOrNull()?.decodedPublicKey?.getOrNull()?.toJsonWebKey()
+            (it as? JwsCompact)?.jwsHeader?.certificateChain?.firstOrNull()?.decodedPublicKey?.getOrNull()
+                ?.toJsonWebKey()
         }
 
     suspend fun getMatchingCredentials(
         preparationState: AuthorizationResponsePreparationState,
-    ) = catchingUnwrapped {
+    ): KmmResult<CredentialMatchingResult<SubjectCredentialStore.StoreEntry>> = catching {
         when (val presentationRequest = preparationState.credentialPresentationRequest) {
             is CredentialPresentationRequest.DCQLRequest -> holder.matchDCQLQueryAgainstCredentialStoreV2(
                 dcqlQuery = presentationRequest.dcqlQuery,

--- a/vck-openid/src/commonTest/kotlin/TestConfig.kt
+++ b/vck-openid/src/commonTest/kotlin/TestConfig.kt
@@ -3,14 +3,16 @@ import at.asitplus.testballoon.matrix.MatrixTestDefaults
 import at.asitplus.wallet.eupid.EuPidItemValueSerializerMap
 import at.asitplus.wallet.eupid.EuPidJsonValueEncoder
 import at.asitplus.wallet.eupid.EuPidMetadataDocument
+import at.asitplus.wallet.eupid.EU_PID_METADATA_URL
 import at.asitplus.wallet.eupidsdjwt.EuPidSdJwtMetadataDocument
+import at.asitplus.wallet.eupidsdjwt.EU_PID_SD_JWT_METADATA_URL
+import at.asitplus.wallet.mdl.MDL_METADATA_URL
 import at.asitplus.wallet.lib.LibraryInitializer
 import at.asitplus.wallet.lib.data.StaticCredentialMetadataRegistry
 import at.asitplus.wallet.mdl.MobileDrivingLicenceItemValueSerializerMap
 import at.asitplus.wallet.mdl.MobileDrivingLicenceJsonValueEncoder
 import at.asitplus.wallet.mdl.MobileDrivingLicenceMetadataDocument
 import at.asitplus.wallet.sdjwt.SdJwtTypeMetadataDocumentRegistry
-import at.asitplus.wallet.sdjwt.SdJwtVcType
 import de.infix.testBalloon.framework.core.TestSession
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
@@ -32,9 +34,9 @@ class TestConfig : TestSession(
                     MobileDrivingLicenceMetadataDocument,
                 ),
                 documentUrls = mapOf(
-                    SdJwtVcType(EuPidSdJwtMetadataDocument.first.string) to "https://example.com",
-                    SdJwtVcType(EuPidMetadataDocument.first.string) to "https://example.com",
-                    SdJwtVcType(MobileDrivingLicenceMetadataDocument.first.string) to "https://example.com",
+                    EuPidSdJwtMetadataDocument.first to EU_PID_SD_JWT_METADATA_URL,
+                    EuPidMetadataDocument.first to EU_PID_METADATA_URL,
+                    MobileDrivingLicenceMetadataDocument.first to MDL_METADATA_URL,
                 )
             )
         )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/CredentialSchemeMappingTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/oidvci/CredentialSchemeMappingTest.kt
@@ -1,11 +1,17 @@
 package at.asitplus.wallet.lib.oidvci
 
+import at.asitplus.openid.ClaimDescription
 import at.asitplus.openid.CredentialFormatEnum
+import at.asitplus.openid.OpenId4VciClaimsPathPointer
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
+import at.asitplus.wallet.lib.data.ExtractedIsoMdocCredentialScheme
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.maps.shouldContainKey
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
 val CredentialSchemeMappingTest by matrixSuite {
@@ -31,6 +37,28 @@ val CredentialSchemeMappingTest by matrixSuite {
         mapper.toCredentialIdentifier(AtomicAttribute2023, ISO_MDOC) shouldBe expectedKey
         mapper.map(AtomicAttribute2023).shouldContainKey(expectedKey)
         mapper.decodeFromCredentialIdentifier(expectedKey) shouldBe Pair(AtomicAttribute2023, ISO_MDOC)
+    }
+
+    test("AtomicAttribute ISO claims are namespace-qualified") {
+        val format = mapper.map(AtomicAttribute2023)[AtomicAttribute2023.isoDocType].shouldNotBeNull()
+        val paths = format.credentialMetadata?.claimDescription.shouldNotBeNull().map { it.path }
+        paths shouldContain
+                OpenId4VciClaimsPathPointer(AtomicAttribute2023.isoNamespace, AtomicAttribute2023.CLAIM_GIVEN_NAME)
+        // The un-qualified JSON-style path must not be advertised for the ISO mdoc representation.
+        paths shouldNotContain OpenId4VciClaimsPathPointer(AtomicAttribute2023.CLAIM_GIVEN_NAME)
+    }
+
+    test("already namespace-qualified ISO claims are not double-prefixed") {
+        val namespace = "org.iso.18013.5.1"
+        val scheme = ExtractedIsoMdocCredentialScheme(
+            schemaUri = "https://example.com",
+            isoDocType = "org.iso.18013.5.1.mDL",
+            isoNamespace = namespace,
+            claimDescriptions = setOf(ClaimDescription(OpenId4VciClaimsPathPointer(namespace, "given_name"))),
+        )
+        val (_, format) = scheme.toIsoMdocSupportedCredentialFormat("identifier")
+        format.credentialMetadata?.claimDescription.shouldNotBeNull().map { it.path } shouldBe
+                listOf(OpenId4VciClaimsPathPointer(namespace, "given_name"))
     }
 
     test("unknown scheme in plain JWT") {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidCredential.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidCredential.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.eupid
 
+import at.asitplus.catchingUnwrapped
 import at.asitplus.wallet.lib.data.LocalDateOrInstant
 import io.matthewnelson.encoding.base64.Base64
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
@@ -168,13 +169,13 @@ data class EuPidCredential(
     /** One or more alpha-2 country codes as specified in ISO 3166-1, representing the nationality of the user to whom
      *  the person identification data relates.*/
     val nationality: String? by lazy {
-        nationalityElement?.let { runCatching { it.jsonPrimitive.content }.getOrNull() }
+        nationalityElement?.let { catchingUnwrapped { it.jsonPrimitive.content }.getOrNull() }
     }
 
     /** One or more alpha-2 country codes as specified in ISO 3166-1, representing the nationality of the user to whom
      *  the person identification data relates.*/
     val nationalities: Collection<String>? by lazy {
-        nationalityElement?.let { runCatching { it.jsonArray.map { it.jsonPrimitive.content } }.getOrNull() }
+        nationalityElement?.let { catchingUnwrapped { it.jsonArray.map { it.jsonPrimitive.content } }.getOrNull() }
     }
 
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
@@ -28,6 +28,10 @@ object EuPidScheme
 /** `eu.europa.ec.eudi.pid.1` */
 const val EU_PID_DOCTYPE: String = "eu.europa.ec.eudi.pid.1"
 
+/** Canonical hosted location of [EuPidMetadataDocument], used as the resolved scheme's `schemaUri`. */
+const val EU_PID_METADATA_URL: String =
+    "https://raw.githubusercontent.com/a-sit-plus/credentials-collection/main/eu-pid.json"
+
 val EuPidMetadataDocument: Pair<SdJwtVcType, SdJwtTypeMetadataDocument> =
     SdJwtVcType("EuPid2023") to SdJwtTypeMetadataDocument(
         originalBytes = ByteArray(0),

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/eupid/EuPidScheme.kt
@@ -23,7 +23,13 @@ import kotlinx.serialization.json.encodeToJsonElement
     "Replace with type metadata document",
     level = DeprecationLevel.ERROR
 )
-object EuPidScheme
+object EuPidScheme {
+    @Deprecated(
+        "Replace with EuPidDataElements",
+        ReplaceWith("EuPidDataElements")
+    )
+    object Attributes
+}
 
 /** `eu.europa.ec.eudi.pid.1` */
 const val EU_PID_DOCTYPE: String = "eu.europa.ec.eudi.pid.1"

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/eupidsdjwt/EuPidSdJwtScheme.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/eupidsdjwt/EuPidSdJwtScheme.kt
@@ -11,7 +11,13 @@ import at.asitplus.wallet.sdjwt.SdJwtVcType
     "Replace with type metadata document",
     level = DeprecationLevel.ERROR
 )
-object EuPidSdJwtScheme
+object EuPidSdJwtScheme {
+    @Deprecated(
+        "Replace with EuPidSdJwtDataElements",
+        ReplaceWith("EuPidSdJwtDataElements")
+    )
+    object SdJwtAttributes
+}
 
 /** `urn:eudi:pid:1` */
 const val EU_PID_SD_JWT_VCT: String = "urn:eudi:pid:1"

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/eupidsdjwt/EuPidSdJwtScheme.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/eupidsdjwt/EuPidSdJwtScheme.kt
@@ -16,6 +16,10 @@ object EuPidSdJwtScheme
 /** `urn:eudi:pid:1` */
 const val EU_PID_SD_JWT_VCT: String = "urn:eudi:pid:1"
 
+/** Canonical hosted location of [EuPidSdJwtMetadataDocument], used as the resolved scheme's `schemaUri`. */
+const val EU_PID_SD_JWT_METADATA_URL: String =
+    "https://raw.githubusercontent.com/a-sit-plus/credentials-collection/main/eu-pid-sdjwt.json"
+
 val EuPidSdJwtMetadataDocument: Pair<SdJwtVcType, SdJwtTypeMetadataDocument> =
     SdJwtVcType(EU_PID_SD_JWT_VCT) to SdJwtTypeMetadataDocument(
         originalBytes = ByteArray(0),

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -20,6 +20,7 @@ import at.asitplus.wallet.lib.data.CredentialPresentation
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.CredentialToJsonConverter
 import at.asitplus.wallet.lib.data.KeyBindingJws
+import at.asitplus.wallet.lib.data.VcDataModelConstants.VERIFIABLE_CREDENTIAL
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
 import at.asitplus.wallet.lib.data.dif.PresentationExchangeInputEvaluator
 import at.asitplus.wallet.lib.data.dif.PresentationSubmissionValidator
@@ -313,9 +314,22 @@ class HolderAgent(
         fallbackFormatHolder = fallbackFormatHolder,
         credentialClaimStructure = CredentialToJsonConverter.toJsonElement(credential),
         credentialFormat = credential.credentialFormat,
-        credentialScheme = credential.schemeIdentifier,
+        credentialScheme = credential.schemeIdentifierForMatching,
         pathAuthorizationValidator = pathAuthorizationValidator,
     )
+
+    /**
+     * Scheme identifier used to match input descriptors. Store entries serialized before [StoreEntry.schemeIdentifier]
+     * was introduced keep it `null`, so fall back to the identifier carried by the credential itself (the mdoc
+     * docType, the SD-JWT `vct`, or the W3C VC type). Otherwise `MSO_MDOC` input descriptors keyed by docType would
+     * never match legacy entries.
+     */
+    private val StoreEntry.schemeIdentifierForMatching: String?
+        get() = schemeIdentifier ?: when (this) {
+            is StoreEntry.Iso -> issuerSigned.issuerAuth.payload?.docType
+            is StoreEntry.SdJwt -> sdJwt.verifiableCredentialType
+            is StoreEntry.Vc -> vc.vc.type.firstOrNull { it != VERIFIABLE_CREDENTIAL }
+        }
 
     override suspend fun matchDCQLQueryAgainstCredentialStoreV2(
         dcqlQuery: DCQLQuery,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/HolderAgent.kt
@@ -102,8 +102,7 @@ class HolderAgent(
     private fun Holder.StoreCredentialInput.Iso.extractIssuerKey(): CoseKey? =
         issuerSigned.issuerAuth.unprotectedHeader?.certificateChain?.firstOrNull()?.let {
             catchingUnwrapped { X509Certificate.decodeFromDer(it) }.getOrNull()?.decodedPublicKey?.getOrNull()
-                ?.toCoseKey()
-                ?.getOrNull()
+                ?.toCoseKey()?.getOrNull()
         }
 
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -183,6 +183,7 @@ interface SubjectCredentialStore {
             override suspend fun resolveScheme(): CredentialScheme =
                 schemeIdentifier?.let { AttributeIndex.resolveIdentifier(it, ISO_MDOC) }
                     ?: issuerSigned.issuerAuth.payload?.docType?.let { AttributeIndex.resolveIdentifier(it, ISO_MDOC) }
+                    ?: issuerSigned.issuerAuth.payload?.docType?.let { IsoMdocFallbackCredentialScheme(it) }
                     ?: UnknownCredentialScheme(ISO_MDOC)
 
             override val credentialFormat: CredentialFormatEnum = CredentialFormatEnum.MSO_MDOC

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -10,21 +10,9 @@ import at.asitplus.openid.OAuth2AuthorizationServerMetadata
 import at.asitplus.openid.SupportedCredentialFormat
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
-import at.asitplus.wallet.lib.data.AttributeIndex
+import at.asitplus.wallet.lib.data.*
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
-import at.asitplus.wallet.lib.data.CredentialScheme
-import at.asitplus.wallet.lib.data.IsoMdocCredentialScheme
-import at.asitplus.wallet.lib.data.IsoMdocFallbackCredentialScheme
-import at.asitplus.wallet.lib.data.SdJwtCredentialScheme
-import at.asitplus.wallet.lib.data.SdJwtFallbackCredentialScheme
-import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
-import at.asitplus.wallet.lib.data.UnknownCredentialScheme
 import at.asitplus.wallet.lib.data.VcDataModelConstants.VERIFIABLE_CREDENTIAL
-import at.asitplus.wallet.lib.data.VcFallbackCredentialScheme
-import at.asitplus.wallet.lib.data.VcJwtCredentialScheme
-import at.asitplus.wallet.lib.data.VerifiableCredential
-import at.asitplus.wallet.lib.data.VerifiableCredentialJws
-import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import io.ktor.utils.io.core.toByteArray
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -114,7 +102,10 @@ interface SubjectCredentialStore {
             @SerialName("scheme-identifier")
             override val schemeIdentifier: String? = null,
         ) : StoreEntry {
-            @Deprecated("Use resolveScheme() instead to support fetching remote definitions")
+            @Deprecated(
+                "Use resolveScheme() instead to support fetching remote definitions",
+                ReplaceWith("resolveScheme()")
+            )
             override val scheme: CredentialScheme
                 get() = schemeIdentifier?.let { AttributeIndex.resolveAttributeType(it) }
                     ?: vc.vc.type.firstOrNull { it != VERIFIABLE_CREDENTIAL }
@@ -149,7 +140,10 @@ interface SubjectCredentialStore {
             @SerialName("scheme-identifier")
             override val schemeIdentifier: String? = null,
         ) : StoreEntry {
-            @Deprecated("Use resolveScheme() instead to support fetching remote definitions")
+            @Deprecated(
+                "Use resolveScheme() instead to support fetching remote definitions",
+                ReplaceWith("resolveScheme()")
+            )
             override val scheme: CredentialScheme
                 get() = schemeIdentifier?.let { AttributeIndex.resolveSdJwtAttributeType(it) }
                     ?: AttributeIndex.resolveSdJwtAttributeType(sdJwt.verifiableCredentialType)
@@ -176,7 +170,10 @@ interface SubjectCredentialStore {
             @SerialName("scheme-identifier")
             override val schemeIdentifier: String? = null,
         ) : StoreEntry {
-            @Deprecated("Use resolveScheme() instead to support fetching remote definitions")
+            @Deprecated(
+                "Use resolveScheme() instead to support fetching remote definitions",
+                ReplaceWith("resolveScheme()")
+            )
             override val scheme: CredentialScheme
                 get() = schemeIdentifier?.let { AttributeIndex.resolveIsoDoctype(it) }
                     ?: issuerSigned.issuerAuth.payload?.docType?.let { AttributeIndex.resolveIsoDoctype(it) }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/ConstantIndex.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/ConstantIndex.kt
@@ -1,8 +1,6 @@
 package at.asitplus.wallet.lib.data
 
-import at.asitplus.data.NonEmptyList.Companion.toNonEmptyList
 import at.asitplus.openid.ClaimDescription
-import at.asitplus.openid.DisplayProperties
 import at.asitplus.openid.OpenId4VciClaimsPathPointer
 import at.asitplus.openid.OpenId4VciClaimsPathPointerSegment
 import at.asitplus.openid.OpenId4VciClaimsPathPointerSegmentIndex
@@ -51,19 +49,28 @@ object ConstantIndex {
     }
 
     @Suppress("DEPRECATION")
-    @Deprecated("Use type check for SdJwtCredentialScheme")
+    @Deprecated(
+        "Use type check for SdJwtCredentialScheme",
+        ReplaceWith("this is SdJwtCredentialScheme")
+    )
     val at.asitplus.wallet.lib.data.CredentialScheme.supportsSdJwt
         get() = (this is SdJwtCredentialScheme) ||
                 (supportedRepresentations.contains(SD_JWT) && sdJwtType != null)
 
     @Suppress("DEPRECATION")
-    @Deprecated("Use type check for VcJwtCredentialScheme")
+    @Deprecated(
+        "Use type check for VcJwtCredentialScheme",
+        ReplaceWith("this is VcJwtCredentialScheme")
+    )
     val at.asitplus.wallet.lib.data.CredentialScheme.supportsVcJwt
         get() = (this is VcJwtCredentialScheme) ||
                 (supportedRepresentations.contains(PLAIN_JWT) && vcType != null)
 
     @Suppress("DEPRECATION")
-    @Deprecated("Use type check for IsoMdocCredentialScheme")
+    @Deprecated(
+        "Use type check for IsoMdocCredentialScheme",
+        ReplaceWith("this is IsoMdocCredentialScheme")
+    )
     val at.asitplus.wallet.lib.data.CredentialScheme.supportsIso
         get() = (this is IsoMdocCredentialScheme) ||
                 (supportedRepresentations.contains(ISO_MDOC) && isoNamespace != null && isoDocType != null)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialToJsonConverter.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialToJsonConverter.kt
@@ -32,6 +32,9 @@ object CredentialToJsonConverter {
             if (credential.schemeIdentifier != null) {
                 put("type", JsonPrimitive(credential.schemeIdentifier))
             } else {
+                // Legacy entries (serialized before schemeIdentifier existed) expose the full VC type array. A scalar
+                // `$.type` filter (see RequestOptions.toVcConstraint()) matches any element of it, so array-typed VC-JWT
+                // credentials still satisfy the type constraint.
                 put("type", credential.vc.vc.type.toJsonElement())
             }
             val vcAsJsonElement = joseCompliantSerializer.encodeToJsonElement(credential.vc.vc.credentialSubject)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/UnknownCredentialScheme.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/UnknownCredentialScheme.kt
@@ -1,5 +1,9 @@
 package at.asitplus.wallet.lib.data
 
+/**
+ * Fallback for any credential identifier that we don't recognize but still need to parse.
+ * May not be the ideal solution, but this prevents a lot of nullable return types and should make life for apps easier.
+ */
 data class UnknownCredentialScheme(val representation: CredentialRepresentation) : CredentialScheme {
     override val schemaUri: String = "https://wallet.a-sit.at/schemas/1.0.0/unknown.json"
     override val supportedRepresentations: Collection<CredentialRepresentation> = listOf(representation)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/PresentationExchangeInputEvaluator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/dif/PresentationExchangeInputEvaluator.kt
@@ -13,6 +13,7 @@ import at.asitplus.jsonpath.JsonPath
 import at.asitplus.jsonpath.core.NodeList
 import at.asitplus.jsonpath.core.NodeListEntry
 import at.asitplus.jsonpath.core.NormalizedJsonPath
+import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.openid.CredentialFormatEnum
 import io.github.aakira.napier.Napier
 import kotlinx.serialization.json.JsonArray
@@ -158,15 +159,32 @@ object PresentationExchangeInputEvaluator {
     ): NodeList = constraintField.path.flatMap { jsonPath ->
         credential.candidates(jsonPath).filter { candidate ->
             pathAuthorizationValidator(candidate.normalizedJsonPath) &&
-                    constraintField.filter?.let { candidate.value.matchConstraints(it) } ?: true
+                    constraintField.filter?.let {
+                        candidate.value.matchConstraints(it, allowVcTypeArrayMatch = candidate.isVcTypeNode())
+                    } ?: true
         }
     }
 
     private fun JsonElement.candidates(jsonPath: String): NodeList =
         JsonPath(jsonPath).query(this)
+
+    /** The resolved node addresses a VC `type` member, whose value is conventionally an array of type strings. */
+    private fun NodeListEntry.isVcTypeNode(): Boolean =
+        (normalizedJsonPath.segments.lastOrNull() as? NormalizedJsonPathSegment.NameSegment)?.memberName == "type"
 }
 
-internal fun JsonElement.matchConstraints(filter: ConstraintFilter): Boolean {
+internal fun JsonElement.matchConstraints(
+    filter: ConstraintFilter,
+    allowVcTypeArrayMatch: Boolean = false,
+): Boolean {
+    // A scalar filter (const/pattern/enum) matches an array node when any element matches: VC-JWT credentials commonly
+    // carry `type` as an array, while verifiers filter `$.type` for a single type string. Scoped to the `type` field
+    // so a genuine scalar constraint on another field (e.g. `$.status`) is not silently satisfied by an array value.
+    if (allowVcTypeArrayMatch && this is JsonArray && filter.type != "array" &&
+        (filter.const != null || filter.pattern != null || filter.enum != null)
+    ) {
+        return any { it.matchConstraints(filter) }
+    }
     if (!matchType(filter)) {
         return false
     }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/mdl/MobileDrivingLicenceScheme.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/mdl/MobileDrivingLicenceScheme.kt
@@ -30,6 +30,10 @@ const val MDL_DOCTYPE: String = "org.iso.18013.5.1.mDL"
 /** `org.iso.18013.5.1` */
 const val MDL_NAMESPACE: String = "org.iso.18013.5.1"
 
+/** Canonical hosted location of [MobileDrivingLicenceMetadataDocument], used as the resolved scheme's `schemaUri`. */
+const val MDL_METADATA_URL: String =
+    "https://raw.githubusercontent.com/a-sit-plus/credentials-collection/main/mdl.json"
+
 val MobileDrivingLicenceMetadataDocument: Pair<SdJwtVcType, SdJwtTypeMetadataDocument> =
     SdJwtVcType(MDL_DOCTYPE) to SdJwtTypeMetadataDocument(
         originalBytes = ByteArray(0),

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -12,6 +12,7 @@ package at.asitplus.wallet.lib.agent
  * see the "LICENSE" file for more details
  */
 
+import at.asitplus.catchingUnwrapped
 import at.asitplus.openid.OidcUserInfo
 import at.asitplus.openid.OidcUserInfoExtended
 import at.asitplus.signum.indispensable.cosef.io.Base16Strict
@@ -239,7 +240,7 @@ val AgentRevocationTest by matrixSuite {
         }
 
         "identifier list JWT should not be issued" {
-            runCatching {
+            catchingUnwrapped {
                 it.statusListIssuer.issueStatusListJwt(kind = RevocationList.Kind.IDENTIFIER_LIST)
             }.isFailure shouldBe true
         }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/LegacyIsoSchemeMatchingTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/LegacyIsoSchemeMatchingTest.kt
@@ -1,0 +1,80 @@
+package at.asitplus.wallet.lib.agent
+
+import at.asitplus.dif.Constraint
+import at.asitplus.dif.ConstraintField
+import at.asitplus.dif.DifInputDescriptor
+import at.asitplus.jsonpath.core.NormalizedJsonPath
+import at.asitplus.jsonpath.core.NormalizedJsonPathSegment.NameSegment
+import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
+import at.asitplus.wallet.lib.data.rfc3986.toUri
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+/**
+ * Regression test: ISO mdoc store entries serialized before [SubjectCredentialStore.StoreEntry.schemeIdentifier]
+ * existed keep that field `null`. Input-descriptor matching must still derive the docType from `issuerAuth` so that
+ * `MSO_MDOC` input descriptors keyed by docType continue to match those legacy entries.
+ */
+val LegacyIsoSchemeMatchingTest by matrixSuite {
+
+    suspend fun legacyIsoEntryWithoutSchemeIdentifier(): SubjectCredentialStore.StoreEntry.Iso {
+        val holderKeyMaterial = EphemeralKeyWithSelfSignedCert()
+        val issuer = IssuerAgent(
+            keyMaterial = EphemeralKeyWithSelfSignedCert(),
+            identifier = "https://issuer.example.com/".toUri(),
+            randomSource = RandomSource.Default,
+        )
+        val issued = issuer.issueCredential(
+            DummyCredentialDataProvider.getCredential(holderKeyMaterial.publicKey, AtomicAttribute2023, ISO_MDOC)
+                .getOrThrow()
+        ).getOrThrow().shouldBeInstanceOf<Issuer.IssuedCredential.Iso>()
+
+        @Suppress("DEPRECATION")
+        return SubjectCredentialStore.StoreEntry.Iso(
+            issuerSigned = issued.issuerSigned,
+            schemaUri = AtomicAttribute2023.schemaUri,
+            schemeIdentifier = null, // entry serialized before scheme-identifier was introduced
+        )
+    }
+
+    fun isoInputDescriptor(id: String) = DifInputDescriptor(
+        id = id,
+        constraints = Constraint(
+            fields = setOf(
+                ConstraintField(
+                    path = listOf(
+                        NormalizedJsonPath(
+                            NameSegment(AtomicAttribute2023.isoNamespace),
+                            NameSegment(CLAIM_GIVEN_NAME),
+                        ).toString()
+                    )
+                )
+            )
+        )
+    )
+
+    "legacy ISO entry without scheme identifier matches its docType input descriptor" {
+        val holder = HolderAgent(EphemeralKeyWithSelfSignedCert(), InMemorySubjectCredentialStore())
+        val entry = legacyIsoEntryWithoutSchemeIdentifier()
+
+        holder.evaluateInputDescriptorAgainstCredential(
+            inputDescriptor = isoInputDescriptor(AtomicAttribute2023.isoDocType),
+            credential = entry,
+            fallbackFormatHolder = null,
+        ) { true }.isSuccess shouldBe true
+    }
+
+    "legacy ISO entry without scheme identifier is rejected for a mismatched docType" {
+        val holder = HolderAgent(EphemeralKeyWithSelfSignedCert(), InMemorySubjectCredentialStore())
+        val entry = legacyIsoEntryWithoutSchemeIdentifier()
+
+        holder.evaluateInputDescriptorAgainstCredential(
+            inputDescriptor = isoInputDescriptor("org.example.other.doctype"),
+            credential = entry,
+            fallbackFormatHolder = null,
+        ) { true }.isSuccess shouldBe false
+    }
+}

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/data/LegacyVcTypeConstraintTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/data/LegacyVcTypeConstraintTest.kt
@@ -1,0 +1,107 @@
+package at.asitplus.wallet.lib.data
+
+import at.asitplus.dif.Constraint
+import at.asitplus.dif.ConstraintField
+import at.asitplus.dif.ConstraintFilter
+import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.agent.DummyCredentialDataProvider
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
+import at.asitplus.wallet.lib.agent.HolderAgent
+import at.asitplus.wallet.lib.agent.InMemorySubjectCredentialStore
+import at.asitplus.wallet.lib.agent.IssuerAgent
+import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.agent.SubjectCredentialStore
+import at.asitplus.wallet.lib.agent.toStoreCredentialInput
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.PLAIN_JWT
+import at.asitplus.wallet.lib.data.dif.PresentationExchangeInputEvaluator
+import at.asitplus.wallet.lib.data.rfc3986.toUri
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * A scalar `$.type` filter (see [at.asitplus.wallet.lib.RequestOptions]) must match VC-JWT credentials whose `type` is
+ * an array — both legacy store entries (serialized before [SubjectCredentialStore.StoreEntry.schemeIdentifier] existed,
+ * so the full `type` array is exposed) and any VC carrying multiple types.
+ */
+val LegacyVcTypeConstraintTest by matrixSuite {
+
+    fun typeConstraint(type: String) = Constraint(
+        fields = setOf(
+            ConstraintField(
+                path = listOf("$.type"),
+                filter = ConstraintFilter(type = "string", const = JsonPrimitive(type)),
+            )
+        )
+    )
+
+    "scalar type filter matches an entry of the VC type array" {
+        val credential = buildJsonObject {
+            put("type", JsonArray(listOf(JsonPrimitive("VerifiableCredential"), JsonPrimitive("AtomicAttribute2023"))))
+        }
+        PresentationExchangeInputEvaluator
+            .evaluateInputDescriptorConstraint(typeConstraint("AtomicAttribute2023"), credential) { true }
+            .isSuccess shouldBe true
+    }
+
+    "scalar type filter does not match a type absent from the array" {
+        val credential = buildJsonObject {
+            put("type", JsonArray(listOf(JsonPrimitive("VerifiableCredential"), JsonPrimitive("AtomicAttribute2023"))))
+        }
+        PresentationExchangeInputEvaluator
+            .evaluateInputDescriptorConstraint(typeConstraint("SomeOtherCredential"), credential) { true }
+            .isSuccess shouldBe false
+    }
+
+    // The array relaxation must stay scoped to the VC `type` field: a scalar constraint on another field must not be
+    // silently satisfied by an array value (see PR #571 review).
+    "scalar filter on a non-type field is not satisfied by an array value" {
+        val statusConstraint = Constraint(
+            fields = setOf(
+                ConstraintField(
+                    path = listOf("$.status"),
+                    filter = ConstraintFilter(type = "string", const = JsonPrimitive("active")),
+                )
+            )
+        )
+        val credential = buildJsonObject {
+            put("status", JsonArray(listOf(JsonPrimitive("active"), JsonPrimitive("revoked"))))
+        }
+        PresentationExchangeInputEvaluator
+            .evaluateInputDescriptorConstraint(statusConstraint, credential) { true }
+            .isSuccess shouldBe false
+    }
+
+    "legacy VC entry without scheme identifier matches the VC type constraint" {
+        val holderKeyMaterial = EphemeralKeyWithSelfSignedCert()
+        val issuer = IssuerAgent(
+            keyMaterial = EphemeralKeyWithSelfSignedCert(),
+            identifier = "https://issuer.example.com/".toUri(),
+            randomSource = RandomSource.Default,
+        )
+        val holder = HolderAgent(holderKeyMaterial, InMemorySubjectCredentialStore())
+        holder.storeCredential(
+            issuer.issueCredential(
+                DummyCredentialDataProvider.getCredential(holderKeyMaterial.publicKey, AtomicAttribute2023, PLAIN_JWT)
+                    .getOrThrow()
+            ).getOrThrow().toStoreCredentialInput()
+        ).getOrThrow()
+        val legacyEntry = holder.getCredentials()!!
+            .filterIsInstance<SubjectCredentialStore.StoreEntry.Vc>()
+            .single()
+            .copy(schemeIdentifier = null) // simulate an entry serialized before scheme-identifier existed
+
+        val json = CredentialToJsonConverter.toJsonElement(legacyEntry).jsonObject
+        // The full type array is exposed; the scalar filter matches an entry of it.
+        json["type"].shouldBeInstanceOf<JsonArray>() shouldContain JsonPrimitive(AtomicAttribute2023.vcType)
+        PresentationExchangeInputEvaluator
+            .evaluateInputDescriptorConstraint(typeConstraint(AtomicAttribute2023.vcType), json) { true }
+            .isSuccess shouldBe true
+    }
+}

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/data/PresentationExchangeInputEvaluatorTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/data/PresentationExchangeInputEvaluatorTest.kt
@@ -77,9 +77,25 @@ val PresentationExchangeInputEvaluatorTest by matrixSuite {
             }
         }
 
-        test("array credential does not match constraint field with string filter and const") {
+        test("array-valued VC type matches a scalar const filter when an element matches") {
+            // VC-JWT credentials commonly carry `type` as an array; a scalar const filter on `$.type` matches when any
+            // element matches. The relaxation is scoped to the VC `type` field (see LegacyVcTypeConstraintTest for the
+            // negative case on other fields).
+            val typeArrayCredential = buildJsonObject {
+                put("type", buildJsonArray { add(JsonPrimitive(it.elementValue)) })
+            }
             PresentationExchangeInputEvaluator.matchConstraintFieldPaths(
-                constraintField = stringConstFilter(it.elementIdentifier, it.elementValue),
+                constraintField = stringConstFilter("type", it.elementValue),
+                credential = typeArrayCredential,
+                pathAuthorizationValidator = { true }
+            ).apply {
+                shouldHaveSize(1)
+            }
+        }
+
+        test("array credential does not match constraint field with string filter and non-matching const") {
+            PresentationExchangeInputEvaluator.matchConstraintFieldPaths(
+                constraintField = stringConstFilter(it.elementIdentifier, "value-not-present-in-array"),
                credential = it.arrayCredential,
                 pathAuthorizationValidator = { true }
             ).apply {


### PR DESCRIPTION
Finishes the work of #566 and #567 for now.

Metadata documents are available at https://github.com/a-sit-plus/credentials-collection/pull/1

Next up: Integration into Relying Party, Issuing Backend and Valera.