### PR TITLE
DCQL: Fix disclosing unknown claims from foreign issuers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Release 7.0.0 (unreleased):
     - Document usage of remote metadata retrieval
 - OpenID for Verifiable Presentations:
     - Fix SD-JWT presentation validation for Digital Credentials API responses by checking the key binding JWT audience against the request origin (`origin:<origin>`) instead of the verifier client identifier.
+    - Fix DCQL matching for credential queries without `claims`: selectively disclosable credentials now return an explicit mandatory-claims-only result, while non-selectively disclosable credentials still return all claims.
 - JVM interoperability:
     - Add `@JvmOverloads` to public API constructors with default parameters across the published modules.
 - Refactorings:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Release 7.0.0 (unreleased):
 - OpenID for Verifiable Presentations:
     - Fix SD-JWT presentation validation for Digital Credentials API responses by checking the key binding JWT audience against the request origin (`origin:<origin>`) instead of the verifier client identifier.
     - Fix DCQL matching for credential queries without `claims`: selectively disclosable credentials now return an explicit mandatory-claims-only result, while non-selectively disclosable credentials still return all claims.
+    - Fix disclosure of SD-JWT claims from foreign issuers: match disclosure digests against the originally serialized disclosures instead of re-serializing them, since digests are computed over the exact bytes (RFC 9901, section 4.2.3), e.g. failing for disclosures serialized with whitespace.
+    - Extend `DCQLCredentialQueryMatchingResult` by case `AllMandatoryClaimsMatchingResult`
 - JVM interoperability:
     - Add `@JvmOverloads` to public API constructors with default parameters across the published modules.
 - Refactorings:

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
@@ -260,7 +260,7 @@ sealed interface DCQLCredentialQuery {
         ).getOrThrow()
 
         return matchClaimsQueriesAgainstClaimStructure(
-            credential.claimStructure,
+            credentialStructure = credential.claimStructure,
             satisfiesSelectiveDisclosure = credential.isSelectivelyDisclosable,
         )
     }
@@ -269,11 +269,13 @@ sealed interface DCQLCredentialQuery {
         credentialStructure: DCQLCredentialClaimStructure,
         satisfiesSelectiveDisclosure: Boolean,
     ): KmmResult<DCQLCredentialQueryMatchingResult> = catching {
-        val claimQueries = claims ?: if (satisfiesSelectiveDisclosure) {
-            return KmmResult.success(DCQLCredentialQueryMatchingResult.ClaimsQueryResults(listOf()))
-        } else {
-            return KmmResult.success(DCQLCredentialQueryMatchingResult.AllClaimsMatchingResult)
-        }
+        val claimQueries = claims ?: return KmmResult.success(
+            if (satisfiesSelectiveDisclosure) {
+                DCQLCredentialQueryMatchingResult.AllMandatoryClaimsMatchingResult
+            } else {
+                DCQLCredentialQueryMatchingResult.AllClaimsMatchingResult
+            }
+        )
 
         val requestedClaimsQueryCombinations = claimSets?.let {
             val claimQueryLookup = claimQueries.associateBy {

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQueryMatchingResult.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQueryMatchingResult.kt
@@ -1,8 +1,22 @@
 package at.asitplus.openid.dcql
 
 sealed interface DCQLCredentialQueryMatchingResult {
+    /**
+     * OpenID4VP 1.0, section 6.4.1: for formats without selective disclosure,
+     * absent `claims` requests the full credential because all claims are mandatory.
+     */
     data object AllClaimsMatchingResult : DCQLCredentialQueryMatchingResult
 
+    /**
+     * OpenID4VP 1.0, section 6.4.1: for selectively disclosable credentials,
+     * absent `claims` requests no selectively disclosable claims, only mandatory claims.
+     */
+    data object AllMandatoryClaimsMatchingResult : DCQLCredentialQueryMatchingResult
+
+    /**
+     * OpenID4VP 1.0, section 6.4.1: present `claims` requests the listed claims,
+     * optionally constrained by `claim_sets`.
+     */
     data class ClaimsQueryResults(
         val claimsQueryResults: List<DCQLClaimsQueryResult>,
     ) : DCQLCredentialQueryMatchingResult

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLCredentialQueryTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/openid/dcql/DCQLCredentialQueryTest.kt
@@ -4,6 +4,7 @@ import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.testballoon.matrix.matrixSuite
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
@@ -23,6 +24,44 @@ val DCQLCredentialQueryTest by matrixSuite {
             DCQLCredentialQuery.SerialNames.META shouldBe "meta"
             DCQLCredentialQuery.SerialNames.CLAIM_SETS shouldBe "claim_sets"
             DCQLCredentialQuery.SerialNames.CLAIMS shouldBe "claims"
+        }
+    }
+    "claims matching" - {
+        val query = DCQLSdJwtCredentialQuery(
+            id = DCQLCredentialQueryIdentifier("query"),
+            format = CredentialFormatEnum.DC_SD_JWT,
+            meta = DCQLSdJwtCredentialMetadataAndValidityConstraints(vctValues = listOf("vct")),
+        )
+        val claimStructure = DCQLCredentialClaimStructure.JsonBasedStructure(buildJsonObject {
+            put("family_name", JsonPrimitive("Musterfrau"))
+        })
+
+        "absent claims request only mandatory claims for selectively disclosable credentials" {
+            query.matchClaimsQueriesAgainstClaimStructure(
+                credentialStructure = claimStructure,
+                satisfiesSelectiveDisclosure = true,
+            ).getOrThrow() shouldBe DCQLCredentialQueryMatchingResult.AllMandatoryClaimsMatchingResult
+        }
+        "absent claims request all claims for non-selectively disclosable credentials" {
+            query.matchClaimsQueriesAgainstClaimStructure(
+                credentialStructure = claimStructure,
+                satisfiesSelectiveDisclosure = false,
+            ).getOrThrow() shouldBe DCQLCredentialQueryMatchingResult.AllClaimsMatchingResult
+        }
+        "present claims request exactly the listed claims" {
+            val result = query.copy(
+                claims = DCQLClaimsQueryList(
+                    DCQLJsonClaimsQuery(path = DCQLClaimsPathPointer("family_name"))
+                )
+            ).matchClaimsQueriesAgainstClaimStructure(
+                credentialStructure = claimStructure,
+                satisfiesSelectiveDisclosure = true,
+            ).getOrThrow()
+
+            result.shouldBeInstanceOf<DCQLCredentialQueryMatchingResult.ClaimsQueryResults>()
+                .claimsQueryResults.single()
+                .shouldBeInstanceOf<DCQLClaimsQueryResult.JsonResult>()
+                .nodeList.single().value shouldBe JsonPrimitive("Musterfrau")
         }
     }
     "serialization" {

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -263,9 +263,10 @@ class VerifiablePresentationFactory(
         requestedClaims: Collection<NormalizedJsonPath>
     ): Set<String> {
         val digest = sdJwt.selectiveDisclosureAlgorithm?.toDigest() ?: Digest.SHA256
-        val disclosuresByDigest = disclosures.entries.mapNotNull { disclosure ->
-            disclosure.asHashedDisclosure(digest)?.let { it to disclosure }
-        }.toMap()
+        // Hash the original serialized disclosure (the map key): re-serializing the parsed item may
+        // produce different bytes than the issuer signed, e.g. for foreign issuers serializing with
+        // whitespace, and digests are computed over the exact bytes (RFC 9901, section 4.2.3)
+        val disclosuresByDigest = disclosures.entries.associateBy { it.key.hashDisclosure(digest) }
         val issuerSignedJwsSerialized = vcSerialized.substringBefore("~")
         val payload = JwsCompact(issuerSignedJwsSerialized).getPayload<JsonObject>()
             .getOrElse { throw PresentationException(it) }
@@ -362,9 +363,6 @@ class VerifiablePresentationFactory(
 
     private fun JsonElement.asArrayDisclosureDigest(): String? =
         (this as? JsonObject)?.get("...")?.let { it as? JsonPrimitive }?.content
-
-    private fun Map.Entry<String, SelectiveDisclosureItem?>.asHashedDisclosure(digest: Digest): String? =
-        value?.toDisclosure()?.hashDisclosure(digest)
 
     private fun JsonObject.sdElements(): JsonArray? = (get(NAME_SD) as? JsonArray?)
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -29,6 +29,7 @@ import at.asitplus.jsonpath.core.NormalizedJsonPathSegment
 import at.asitplus.openid.dcql.DCQLClaimsQueryResult
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult.AllClaimsMatchingResult
+import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult.AllMandatoryClaimsMatchingResult
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult.ClaimsQueryResults
 import at.asitplus.openid.truncateToSeconds
 import at.asitplus.signum.indispensable.Digest
@@ -127,6 +128,8 @@ class VerifiablePresentationFactory(
     private fun DCQLCredentialQueryMatchingResult.toRequestedSdJwtClaims(
         credential: StoreEntry.SdJwt
     ): List<NormalizedJsonPath> = when (this) {
+        AllMandatoryClaimsMatchingResult -> emptyList()
+
         AllClaimsMatchingResult -> credential.disclosures.entries.map {
             NormalizedJsonPath() + it.value!!.claimName!!
         }
@@ -143,6 +146,8 @@ class VerifiablePresentationFactory(
     private fun DCQLCredentialQueryMatchingResult.toRequestedIsoClaims(
         credential: StoreEntry.Iso,
     ) = when (this) {
+        AllMandatoryClaimsMatchingResult -> emptyList()
+
         AllClaimsMatchingResult -> credential.issuerSigned.namespaces!!.entries.flatMap { namespace ->
             namespace.value.entries.map {
                 NormalizedJsonPath() + namespace.key + it.value.elementIdentifier
@@ -249,6 +254,7 @@ class VerifiablePresentationFactory(
     private fun StoreEntry.SdJwt.loadDisclosures(
         disclosedAttributes: DCQLCredentialQueryMatchingResult
     ): Set<String> = when (disclosedAttributes) {
+        AllMandatoryClaimsMatchingResult -> emptySet()
         AllClaimsMatchingResult -> disclosures.keys
         is ClaimsQueryResults -> loadDisclosures(disclosedAttributes.toRequestedSdJwtClaims(this))
     }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactoryTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactoryTest.kt
@@ -11,6 +11,7 @@ import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.cosef.CoseAlgorithm
 import at.asitplus.signum.indispensable.cosef.CoseHeader
 import at.asitplus.signum.indispensable.cosef.CoseSigned
+import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.data.ConstantIndex
@@ -20,17 +21,32 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_PORTRAIT
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
+import at.asitplus.wallet.lib.data.SelectiveDisclosureItem
+import at.asitplus.wallet.lib.data.SelectiveDisclosureItem.Companion.hashDisclosure
+import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.rfc3986.toUri
+import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
+import at.asitplus.wallet.lib.jws.JwsHeaderNone
+import at.asitplus.wallet.lib.jws.SignJwt
 import com.benasher44.uuid.uuid4
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlin.random.Random
 import kotlinx.serialization.builtins.ByteArraySerializer
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 val VerifiablePresentationFactoryTest by matrixSuite {
 
@@ -100,6 +116,44 @@ val VerifiablePresentationFactoryTest by matrixSuite {
                 .disclosedClaimNames().apply {
                     this shouldBe setOfDefaultSdJwtClaims
                 }
+        }
+
+        "sd-jwt createVerifiablePresentation discloses claims of foreign credentials with non-canonical disclosures" {
+            // A foreign issuer may serialize disclosures with whitespace: digests are computed over
+            // the exact bytes (RFC 9901, section 4.2.3), not over a re-serialization of the parsed item
+            val salt = Random.nextBytes(16).encodeToString(Base64UrlStrict)
+            val rawDisclosure = """["$salt", "family_name", "Musterfrau"]"""
+                .encodeToByteArray().encodeToString(Base64UrlStrict)
+            val issuerSignedJws = SignJwt<JsonObject>(EphemeralKeyWithoutCert(), JwsHeaderNone())(
+                JwsContentTypeConstants.SD_JWT,
+                buildJsonObject {
+                    put("vct", "https://example.com/credentials/unknown")
+                    put("_sd", buildJsonArray { add(rawDisclosure.hashDisclosure()) })
+                    put("_sd_alg", "sha-256")
+                },
+                JsonObject.serializer(),
+            ).getOrThrow()
+
+            val credential = SubjectCredentialStore.StoreEntry.SdJwt(
+                vcSerialized = "${issuerSignedJws.jws}~$rawDisclosure~",
+                sdJwt = VerifiableCredentialSdJwt(
+                    verifiableCredentialType = "https://example.com/credentials/unknown",
+                ),
+                disclosures = mapOf(
+                    rawDisclosure to SelectiveDisclosureItem(
+                        salt = salt.decodeToByteArray(Base64UrlStrict),
+                        claimName = "family_name",
+                        claimValue = JsonPrimitive("Musterfrau"),
+                    )
+                ),
+            )
+
+            it.verifiablePresentationFactory.createVerifiablePresentation(
+                request = presentationRequest(),
+                credential = credential,
+                disclosedAttributes = listOf(NormalizedJsonPath() + "family_name"),
+            ).getOrThrow().shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
+                .disclosedClaimNames() shouldContain "family_name"
         }
 
         "sd-jwt createVerifiablePresentation uses disclosedAttributes (dcql all claims)" {

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactoryTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactoryTest.kt
@@ -5,6 +5,7 @@ import at.asitplus.jsonpath.core.NormalizedJsonPath
 import at.asitplus.openid.dcql.DCQLClaimsQueryResult.IsoMdocResult
 import at.asitplus.openid.dcql.DCQLClaimsQueryResult.JsonResult
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult.AllClaimsMatchingResult
+import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult.AllMandatoryClaimsMatchingResult
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult.ClaimsQueryResults
 import at.asitplus.signum.indispensable.CryptoSignature
 import at.asitplus.signum.indispensable.cosef.CoseAlgorithm
@@ -113,6 +114,15 @@ val VerifiablePresentationFactoryTest by matrixSuite {
                 }
         }
 
+        "sd-jwt createVerifiablePresentation uses disclosedAttributes (dcql mandatory claims)" {
+            it.verifiablePresentationFactory.createVerifiablePresentation(
+                request = presentationRequest(),
+                credential = it.sdJwtCredential,
+                disclosedAttributes = AllMandatoryClaimsMatchingResult,
+            ).getOrThrow().shouldBeInstanceOf<CreatePresentationResult.SdJwt>()
+                .disclosedClaimNames() shouldBe setOfDefaultSdJwtClaims
+        }
+
         "sd-jwt createVerifiablePresentation uses disclosedAttributes (dcql query results)" {
             it.verifiablePresentationFactory.createVerifiablePresentation(
                 request = presentationRequest(),
@@ -189,6 +199,18 @@ val VerifiablePresentationFactoryTest by matrixSuite {
                 disclosedIsoClaimNames(namespace).apply {
                     this shouldBe setOf(CLAIM_GIVEN_NAME, CLAIM_FAMILY_NAME, CLAIM_DATE_OF_BIRTH, CLAIM_PORTRAIT)
                 }
+            }
+        }
+
+        "iso createVerifiablePresentation uses disclosedAttributes (dcql mandatory claims)" {
+            val namespace = ConstantIndex.AtomicAttribute2023.isoNamespace.shouldNotBeNull()
+
+            it.verifiablePresentationFactory.createVerifiablePresentation(
+                request = presentationRequest(),
+                credential = it.isoCredential,
+                disclosedAttributes = AllMandatoryClaimsMatchingResult,
+            ).getOrThrow().shouldBeInstanceOf<CreatePresentationResult.DeviceResponse>().apply {
+                disclosedIsoClaimNames(namespace).shouldBeEmpty()
             }
         }
 


### PR DESCRIPTION
As uncovered by getting a credential from <https://eudiw.regtest.nic.cz/domains> and presenting at at <https://verifier.regtest.nic.cz/custom-request/create> with query

```
{
    "type": "vp_token",
    "dcql_query": {
        "credentials": [
            {
                "id": "query_1",
                "format": "dc+sd-jwt",
                "meta": {
                    "vct_values": [
                        "urn:domain.ownership"
                    ]
                },
                "claims": [
                    {
                        "path": [
                            "domain_name"
                        ]
                    },
                    {
                        "path": [
                            "expiration_date"
                        ]
                    }
                ]
            }
        ]
    },
    "nonce": "39513077-0e53-44e6-8d12-ab05b2477eeb",
    "request_uri_method": "get"
}
```