### PR TITLE
DCAPI Verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Release 7.0.0 (unreleased):
     - Fix DCQL matching for credential queries without `claims`: selectively disclosable credentials now return an explicit mandatory-claims-only result, while non-selectively disclosable credentials still return all claims.
     - Fix disclosure of SD-JWT claims from foreign issuers: match disclosure digests against the originally serialized disclosures instead of re-serializing them, since digests are computed over the exact bytes (RFC 9901, section 4.2.3), e.g. failing for disclosures serialized with whitespace.
     - Extend `DCQLCredentialQueryMatchingResult` by case `AllMandatoryClaimsMatchingResult`
+    - Consolidate interface of `OpenId4VpVerifier`: All clients should use `createAuthnRequest()`, so we deprecate methods `submitAuthnRequest()` or `createAuthnRequestAsSignedRequestObject()`
 - Verifier:
     - Add `NonceChallengeVerifier`, a thin `Verifier` wrapper that creates presentation challenges from a `NonceService` and verifies SD-JWT/VC-JWT presentations against the embedded challenge.
     - Move OpenID4VP request nonce handling out of `VerifierAgent` and consume nonces after successful response validation to prevent replay.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Release 7.0.0 (unreleased):
     - Fix disclosure of SD-JWT claims from foreign issuers: match disclosure digests against the originally serialized disclosures instead of re-serializing them, since digests are computed over the exact bytes (RFC 9901, section 4.2.3), e.g. failing for disclosures serialized with whitespace.
     - Extend `DCQLCredentialQueryMatchingResult` by case `AllMandatoryClaimsMatchingResult`
     - Consolidate interface of `OpenId4VpVerifier`: All clients should use `createAuthnRequest()`, so we deprecate methods `submitAuthnRequest()` or `createAuthnRequestAsSignedRequestObject()`
+    - Extract `DcApiVerifier` as a pendant to `OpenId4VpVerifier` which handles DCAPI requests only
+    - Move `CreationOptions` and `CreatedRequest` to upper level (`at.asitplus.wallet.lib.openid`) instead of nesting in `OpenId4VpVerifier`
 - Verifier:
     - Add `NonceChallengeVerifier`, a thin `Verifier` wrapper that creates presentation challenges from a `NonceService` and verifies SD-JWT/VC-JWT presentations against the embedded challenge.
     - Move OpenID4VP request nonce handling out of `VerifierAgent` and consume nonces after successful response validation to prevent replay.

--- a/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
+++ b/vck-openid-ktor/src/commonTest/kotlin/at/asitplus/wallet/lib/ktor/openid/OpenId4VpWalletTest.kt
@@ -64,7 +64,7 @@ import at.asitplus.wallet.lib.openid.CredentialPresentationRequestBuilder
 import at.asitplus.wallet.lib.openid.DCQLMatchingResult
 import at.asitplus.wallet.lib.openid.OpenId4VpRequestOptions
 import at.asitplus.wallet.lib.openid.OpenId4VpVerifier
-import at.asitplus.wallet.lib.openid.OpenId4VpVerifier.CreationOptions
+import at.asitplus.wallet.lib.openid.CreationOptions
 import at.asitplus.wallet.lib.openid.PresentationExchangeMatchingResult
 import at.asitplus.wallet.lib.openid.VpTokenValidationResultDCQL
 import at.asitplus.wallet.lib.openid.VpTokenValidationResultPresentationExchange

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CreatedRequest.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CreatedRequest.kt
@@ -1,0 +1,19 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.KmmResult
+import at.asitplus.openid.RequestObjectParameters
+
+data class CreatedRequest(
+    /** URL to invoke the wallet, may be rendered as a QR Code. */
+    val url: String,
+    /**
+     *  Optional content that needs to be served under the previously passed in `requestUrl`
+     *  (see [CreationOptions.RequestByReference.requestUrl] or
+     *  [CreationOptions.SignedRequestByReference.requestUrl] in call to [OpenId4VpVerifier.createAuthnRequest])
+     *  with content type `application/oauth-authz-req+jwt` (see
+     *  [at.asitplus.wallet.lib.data.MediaTypes.Application.AUTHZ_REQ_JWT]).
+     *
+     *  Pass in the [at.asitplus.openid.RequestObjectParameters] that the Wallet may have sent when requesting the request object.
+     */
+    val loadRequestObject: (suspend (RequestObjectParameters?) -> KmmResult<String>)? = null,
+)

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CreationOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CreationOptions.kt
@@ -1,0 +1,37 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.openid.JarRequestParameters
+
+/**
+ * Options for creating authorization requests (query, by value, or by reference).
+ * Use to control how the verifier delivers the request to the wallet.
+ */
+sealed class CreationOptions {
+    /**
+     * Creates authentication request with parameters encoded as URL query parameters to [walletUrl].
+     */
+    data class Query(val walletUrl: String) : CreationOptions()
+
+    /**
+     * Appends [requestUrl] to [walletUrl], callers need to call [CreatedRequest.loadRequestObject] with the
+     * Wallet's request to actually create the authn request object.
+     **/
+    data class RequestByReference(
+        val walletUrl: String,
+        val requestUrl: String,
+        val requestUrlMethod: JarRequestParameters.RequestUriMethod = JarRequestParameters.RequestUriMethod.GET,
+    ) : CreationOptions()
+
+    /** Appends authentication request as signed object to [walletUrl] */
+    data class SignedRequestByValue(val walletUrl: String) : CreationOptions()
+
+    /**
+     * Appends [requestUrl] to [walletUrl], callers need to call [CreatedRequest.loadRequestObject] with the
+     * Wallet's request to actually create the authn request object (which will be signed).
+     */
+    data class SignedRequestByReference(
+        val walletUrl: String,
+        val requestUrl: String,
+        val requestUrlMethod: JarRequestParameters.RequestUriMethod = JarRequestParameters.RequestUriMethod.GET,
+    ) : CreationOptions()
+}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
@@ -2,6 +2,10 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.KmmResult
 import at.asitplus.catching
+import at.asitplus.dcapi.DCAPIHandover
+import at.asitplus.dcapi.DigitalCredentialInterface
+import at.asitplus.dcapi.IsoMdocResponse
+import at.asitplus.dcapi.OpenID4VPDCAPIHandoverInfo
 import at.asitplus.dcapi.OpenId4VpResponse
 import at.asitplus.dcapi.SessionTranscriptContentHashable
 import at.asitplus.dif.ClaimFormat
@@ -10,9 +14,8 @@ import at.asitplus.dif.FormatContainerJwt
 import at.asitplus.dif.FormatContainerSdJwt
 import at.asitplus.dif.PresentationSubmissionDescriptor
 import at.asitplus.iso.DeviceResponse
-import at.asitplus.iso.OpenId4VpHandover
-import at.asitplus.iso.OpenId4VpHandoverInfo
 import at.asitplus.iso.SessionTranscript
+import at.asitplus.iso.serializeOrigin
 import at.asitplus.iso.sha256
 import at.asitplus.jsonpath.JsonPath
 import at.asitplus.openid.AuthenticationRequestParameters
@@ -42,7 +45,6 @@ import at.asitplus.signum.indispensable.josef.JsonWebKeySet
 import at.asitplus.signum.indispensable.josef.JweAlgorithm
 import at.asitplus.signum.indispensable.josef.JweEncryption
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
-import at.asitplus.signum.indispensable.josef.JwsHeader
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
@@ -53,10 +55,10 @@ import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.NonceChallengeVerifier
 import at.asitplus.wallet.lib.agent.Verifier
-import at.asitplus.wallet.lib.agent.Verifier.VerifyPresentationResult
 import at.asitplus.wallet.lib.agent.VerifierAgent
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.PresentationExchangeRequest
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
@@ -65,7 +67,6 @@ import at.asitplus.wallet.lib.extensions.sessionTranscriptThumbprint
 import at.asitplus.wallet.lib.jws.DecryptJwe
 import at.asitplus.wallet.lib.jws.DecryptJweFun
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
-import at.asitplus.wallet.lib.jws.JwsHeaderIdentifierFun
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.jws.SignJwtFun
@@ -95,15 +96,14 @@ import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
 /**
- * Combines Verifiable Presentations with OAuth 2.0.
- * Implements [OpenID4VP](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html) (1.0, 2025-07-09)
- * as well as [SIOP V2](https://openid.net/specs/openid-connect-self-issued-v2-1_0.html) (D13, 2023-11-28).
+ * Implements a verifier for the []Digital Credential API](https://www.w3.org/TR/digital-credentials/),
+ * similar to [OpenId4VpVerifier] for OpenID4VP.
  *
- * This class creates the Authentication Request (see [AuthenticationRequestParameters]),
+ * This class creates the Authentication Request (see [at.asitplus.openid.AuthenticationRequestParameters]),
  * clients need to send it to the holder (see [OpenId4VpHolder]) which will create the Authentication Response,
  * which will be verified here in [validateAuthnResponse].
  */
-class OpenId4VpVerifier @JvmOverloads constructor(
+class DcApiVerifier @JvmOverloads constructor(
     /** Scheme to use for our client identifier. */
     private val clientIdScheme: ClientIdScheme,
     /** Key material to sign the authentication request with [signAuthnRequest]. */
@@ -152,12 +152,6 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         kbJwtAlgorithmStrings = supportedJwsAlgorithms.toSet()
     )
 
-    @Deprecated("Moved to upper level", ReplaceWith("CreationOptions", "at.asitplus.wallet.lib.openid.CreationOptions"))
-    typealias CreationOptions = at.asitplus.wallet.lib.openid.CreationOptions
-
-    @Deprecated("Moved to upper level", ReplaceWith("CreatedRequest", "at.asitplus.wallet.lib.openid.CreatedRequest"))
-    typealias CreatedRequest = at.asitplus.wallet.lib.openid.CreatedRequest
-
     /**
      * Creates the [at.asitplus.openid.RelyingPartyMetadata], without encryption (see [metadataWithEncryption])
      */
@@ -203,8 +197,8 @@ class OpenId4VpVerifier @JvmOverloads constructor(
      */
     suspend fun createAuthnRequest(
         requestOptions: OpenId4VpRequestOptions,
-        creationOptions: at.asitplus.wallet.lib.openid.CreationOptions,
-    ): KmmResult<at.asitplus.wallet.lib.openid.CreatedRequest> = catching {
+        creationOptions: CreationOptions,
+    ): KmmResult<CreatedRequest> = catching {
         when (creationOptions) {
             is CreationOptions.Query -> {
                 require(clientIdScheme !is ClientIdScheme.CertificateSanDns) // per OpenID4VP d23 5.10.4
@@ -260,18 +254,12 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         }
     }
 
-    private fun String.toCreatedRequest() = at.asitplus.wallet.lib.openid.CreatedRequest(this)
+    private fun String.toCreatedRequest() = CreatedRequest(this)
     private fun String.toCreatedRequest(
         loadRequestObject: suspend (RequestObjectParameters?) -> KmmResult<String>,
-    ) = at.asitplus.wallet.lib.openid.CreatedRequest(this, loadRequestObject)
+    ) = CreatedRequest(this, loadRequestObject)
 
-    @Deprecated("Use createAuthnRequest instead with CreationOptions.SignedRequestByReference")
-    suspend fun createAuthnRequestAsSignedRequestObject(
-        requestOptions: OpenId4VpRequestOptions,
-        requestObjectParameters: RequestObjectParameters? = null,
-    ): KmmResult<JwsCompactTyped<AuthenticationRequestParameters>> =
-        createSignedRequestObject(requestOptions, requestObjectParameters)
-
+    // TODO Should be called by DCAPI Verifier only
     internal suspend fun createSignedRequestObject(
         requestOptions: OpenId4VpRequestOptions,
         requestObjectParameters: RequestObjectParameters? = null,
@@ -292,17 +280,13 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         ).getOrThrow()
     }
 
-    @Deprecated("Use createAuthnRequest instead with CreationOptions.SignedRequestByValue")
-    suspend fun createAuthnRequest(
-        requestOptions: OpenId4VpRequestOptions,
-        requestObjectParameters: RequestObjectParameters? = null,
-    ) = createPlainAuthnRequest(requestOptions, requestObjectParameters)
-
     internal suspend fun createPlainAuthnRequest(
         requestOptions: OpenId4VpRequestOptions,
         requestObjectParameters: RequestObjectParameters? = null,
     ) = requestOptions.toAuthnRequest(requestObjectParameters)
-        .also { storeAuthnRequest(it) }
+        .also {
+            storeAuthnRequest(it, requestOptions.state)
+        }
 
     private suspend fun OpenId4VpRequestOptions.toAuthnRequest(
         requestObjectParameters: RequestObjectParameters?,
@@ -318,7 +302,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         clientMetadata = clientMetadata(),
         idTokenType = if (isSiop) IdTokenType.SUBJECT_SIGNED.text else null,
         responseMode = responseMode,
-        state = state,
+        state = null,
         dcqlQuery = (presentationRequest as? DCQLRequest)?.dcqlQuery,
         presentationDefinition = (presentationRequest as? PresentationExchangeRequest)?.presentationDefinition?.run {
             copy(
@@ -345,17 +329,13 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         )
     )
 
-    @Deprecated("Should not be necessary at all, simply call [createAuthnRequest]")
-    suspend fun submitAuthnRequest(
-        authenticationRequestParameters: AuthenticationRequestParameters,
-        externalId: String? = null,
-    ) = storeAuthnRequest(authenticationRequestParameters)
-
     internal suspend fun storeAuthnRequest(
         authenticationRequestParameters: AuthenticationRequestParameters,
+        externalId: String? = null,
     ) = stateToAuthnRequestStore.put(
-        key = authenticationRequestParameters.state
-            ?: throw IllegalArgumentException("No state has been provided"),
+        key = externalId
+            ?: authenticationRequestParameters.state
+            ?: throw IllegalArgumentException("Neither externalId nor state has been provided"),
         value = authenticationRequestParameters,
     )
 
@@ -373,49 +353,53 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     }
 
     /**
-     * Validates an Authentication Response from the Wallet, where [input] is either:
-     * - a URL, containing parameters in the fragment, e.g. `https://example.com#id_token=...`
-     * - a URL, containing parameters in the query, e.g. `https://example.com?id_token=...`
-     * - parameters encoded as a POST body, e.g. `id_token=...&vp_token=...`
+     * Validates an Authentication Response from the Wallet, where [input] is a signed or unsigned DC API response.
+     *
+     * The [externalId] will be used to load the corresponding [AuthenticationRequestParameters] from the store.
      */
     suspend fun validateAuthnResponse(
         input: String,
-    ): KmmResult<AuthnResponseResult> = catching {
-        val response = responseParser.parseAuthnResponse(input)
-        validateAuthnResponse(response).getOrThrow()
-    }
-
-    @Suppress("DEPRECATION")
-    @Deprecated("OpenID4VP doesn't support externalId, the state is always available")
-    suspend fun validateAuthnResponse(
-        input: String,
-        externalId: String? = null,
-    ): KmmResult<AuthnResponseResult> = catching {
-        val response = responseParser.parseAuthnResponse(input)
-        validateAuthnResponse(response, externalId).getOrThrow()
-    }
-
-    @Suppress("DEPRECATION")
-    @Deprecated("Use DCAPI Verifier for that")
-    suspend fun validateAuthnResponse(
-        input: OpenId4VpResponse,
         externalId: String,
     ): KmmResult<AuthnResponseResult> = catching {
-        val response = responseParser.parseAuthnResponse(input)
-        validateAuthnResponse(response, externalId).getOrThrow()
+        validateAuthnResponse(
+            input = joseCompliantSerializer.decodeFromString<DigitalCredentialInterface>(input),
+            externalId = externalId
+        ).getOrThrow()
+    }
+
+    /**
+     * Validates an Authentication Response from the Wallet, where [input] is a signed or unsigned DC API response.
+     *
+     * The [externalId] will be used to load the corresponding [AuthenticationRequestParameters] from the store.
+     */
+    suspend fun validateAuthnResponse(
+        input: DigitalCredentialInterface,
+        externalId: String,
+    ): KmmResult<AuthnResponseResult> = catching {
+        when (input) {
+            is IsoMdocResponse -> TODO()
+            else -> validateAuthnResponse(
+                input = responseParser.parseAuthnResponse(input as OpenId4VpResponse),
+                externalId = externalId
+            ).getOrThrow()
+        }
     }
 
     /**
      * Validates an Authentication Response from the Wallet,
      * in case it has been parsed into [ResponseParametersFrom] with [ResponseParser].
+     *
+     * The [externalId] will be used to load the corresponding [AuthenticationRequestParameters] from the store,
+     * in case a `state` parameter was not available in the request (e.g., when using DCAPI).
      */
-    suspend fun validateAuthnResponse(
+    internal suspend fun validateAuthnResponse(
         input: ResponseParametersFrom,
-    ) = catching {
+        externalId: String
+    ): KmmResult<AuthnResponseResult> = catching {
         Napier.d("validateAuthnResponse: $input")
-        val authnRequest = loadAuthnRequest(input)
+        val authnRequest = loadAuthnRequest(input, externalId)
 
-        val responseType = authnRequest.responseType?.let { ResponseType(it) }
+        val responseType = authnRequest.responseType?.let { ResponseType.Companion(it) }
         require(responseType != null) {
             "No response type was specified in the original authentication request."
         }
@@ -450,12 +434,6 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         }
     }
 
-    @Deprecated("OpenID4VP doesn't support externalId, the state is always available")
-    suspend fun validateAuthnResponse(
-        input: ResponseParametersFrom,
-        externalId: String? = null,
-    ): KmmResult<AuthnResponseResult> = validateAuthnResponse(input)
-
     private fun AuthnResponseResult.isFullyValid(): Boolean =
         idTokenValidationResult?.isFailure != true &&
                 vpTokenValidationResult?.isFailure != true &&
@@ -468,9 +446,11 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     @Throws(IllegalArgumentException::class, CancellationException::class)
     private suspend fun loadAuthnRequest(
         input: ResponseParametersFrom,
+        externalId: String?,
     ): AuthenticationRequestParameters {
-        val storedId = input.parameters.state
-            ?: throw IllegalArgumentException("No state in input parameters")
+        val storedId = externalId
+            ?: input.parameters.state
+            ?: throw IllegalArgumentException("Neither externalId nor state given")
         val authnRequest = stateToAuthnRequestStore.get(storedId)
             ?: throw IllegalArgumentException("No authn request found for $storedId")
         if (authnRequest.responseMode?.requiresEncryption == true)
@@ -533,9 +513,11 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         val vpToken = responseParameters.parameters.vpToken
             ?: throw IllegalArgumentException("vp_token not present in ${responseParameters.parameters}")
         val clientIdRequired = responseParameters.clientIdRequired
+
         val originalResponseParameters = responseParameters.originalResponseParameters
-        require(originalResponseParameters !is ResponseParametersFrom.DcApi) {
-            "DCAPI verification is not supported, use DcApiVerifier"
+
+        (originalResponseParameters as? ResponseParametersFrom.DcApi)?.let {
+            authnRequest.verifyExpectedOrigin(it.origin)
         }
 
         authnRequest.presentationDefinition?.let {
@@ -552,7 +534,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
                     responseUrl = authnRequest.responseUrl ?: authnRequest.redirectUrlExtracted,
                     transactionData = authnRequest.transactionData,
                     clientIdRequired = clientIdRequired,
-                    origin = null,
+                    origin = (originalResponseParameters as? ResponseParametersFrom.DcApi)?.origin,
                 )
             }
 
@@ -577,7 +559,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
                             ?: authnRequest.redirectUrlExtracted,
                         transactionData = authnRequest.transactionData,
                         clientIdRequired = clientIdRequired,
-                        origin = null,
+                        origin = (originalResponseParameters as? ResponseParametersFrom.DcApi)?.origin,
                         requireCryptographicHolderBinding = query.credentialQuery(credentialQueryId)?.requireCryptographicHolderBinding,
                     )
                 }
@@ -634,7 +616,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         clientIdRequired: Boolean,
         origin: String?,
         requireCryptographicHolderBinding: Boolean? = null,
-    ): KmmResult<VerifyPresentationResult> = catching {
+    ): KmmResult<Verifier.VerifyPresentationResult> = catching {
         when (claimFormat) {
             ClaimFormat.SD_JWT -> {
                 val sdJwt = SdJwtSigned.parseCatching(relatedPresentation.extractContent()).getOrElse {
@@ -660,7 +642,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
                 nonceAwareVerifier.verifyUnsignedVcJws(
                     input = relatedPresentation.extractContent()
                 ).map {
-                    VerifyPresentationResult.SuccessUnsigned(it.vc)
+                    Verifier.VerifyPresentationResult.SuccessUnsigned(it.vc)
                 }
             }
 
@@ -695,31 +677,40 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     ): SessionTranscript {
         require((!clientIdRequired || clientId != null)) { "Missing required parameter: clientId" }
         require(responseUrl != null) { "Missing required parameter: responseUrl" }
-        require(input.originalResponseParameters !is ResponseParametersFrom.DcApi) {
-            "DCAPI verification is not supported, use DcApiVerifier"
+        require(input.originalResponseParameters is ResponseParametersFrom.DcApi) {
+            "Unsupported response mechanism: ${input.originalResponseParameters}"
         }
-
-        return SessionTranscript.forOpenId(
-            OpenId4VpHandover(
-                type = OpenId4VpHandover.TYPE_OPENID4VP,
-                hash = coseCompliantSerializer.encodeToByteArray<OpenId4VpHandoverInfo>(
-                    OpenId4VpHandoverInfo(
-                        clientId = clientId,
-                        nonce = expectedNonce,
-                        jwkThumbprint = if (hasBeenEncrypted) {
-                            decryptionKeyMaterial.jsonWebKey.sessionTranscriptThumbprint()
-                        } else null,
-                        responseUrl = responseUrl,
-                    )
-                ).sha256(),
+        require(origin != null) { "Missing required parameter: origin" }
+        val serializedOrigin = requireNotNull(origin.serializeOrigin()) {
+            "Invalid parameter: origin"
+        }
+        return createDcApiSessionTranscript(
+            OpenID4VPDCAPIHandoverInfo(
+                // Device signatures are bound to the HTML-serialized origin used by OpenID4VP/DCAPI.
+                // Hashing the raw URL would make `https://example.com/` differ from `https://example.com`.
+                origin = serializedOrigin,
+                nonce = expectedNonce,
+                jwkThumbprint = if (hasBeenEncrypted) {
+                    decryptionKeyMaterial.jsonWebKey.sessionTranscriptThumbprint()
+                } else null,
             )
         )
     }
 
+    /**
+     * Performs calculation of the [SessionTranscript] for DC API according to OID4VP
+     */
     override fun createDcApiSessionTranscript(
         toBeHashed: SessionTranscriptContentHashable,
-    ): SessionTranscript =
-        throw IllegalArgumentException("DCAPI verification is not supported, use DcApiVerifier")
+    ): SessionTranscript = SessionTranscript.forDcApi(
+        DCAPIHandover(
+            type = DCAPIHandover.TYPE_OPENID4VP,
+            hash = coseCompliantSerializer.encodeToByteArray<OpenID4VPDCAPIHandoverInfo>(
+                toBeHashed as? OpenID4VPDCAPIHandoverInfo
+                    ?: throw IllegalArgumentException("Unsupported DCAPIHandoverInfo")
+            ).sha256(),
+        )
+    )
 
     // To be reconsidered when supporting [DCQLCredentialQueryInstance.multiple]
     private fun JsonElement.extractContent(): String = when (this) {
@@ -743,20 +734,3 @@ private val PresentationSubmissionDescriptor.cumulativeJsonPath: String
         }
         return cummulativeJsonPath
     }
-
-
-class JwsHeaderClientIdScheme(val clientIdScheme: ClientIdScheme) : JwsHeaderIdentifierFun {
-    override suspend operator fun invoke(
-        it: JwsHeader,
-        keyMaterial: KeyMaterial,
-    ) = when (clientIdScheme) {
-        is ClientIdScheme.CertificateHash -> it.copy(certificateChain = clientIdScheme.chain)
-        is ClientIdScheme.CertificateSanDns -> it.copy(certificateChain = clientIdScheme.chain)
-        is ClientIdScheme.VerifierAttestation -> it.copy(
-            jsonWebKey = keyMaterial.jsonWebKey,
-            attestationJwt = clientIdScheme.attestationJwt.jws
-        )
-
-        else -> it.copy(jsonWebKey = keyMaterial.jsonWebKey)
-    }
-}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpHolder.kt
@@ -72,6 +72,7 @@ import kotlin.time.Clock
  * show the information to the user,
  * and create the response in [finalizeAuthorizationResponse], and send it back to the verifier.
  */
+// TODO Maybe also one for DCAPI?
 class OpenId4VpHolder @JvmOverloads constructor(
     /** Key material used to encrypt responses and sign ID tokens. */
     private val keyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -62,7 +62,8 @@ import at.asitplus.wallet.lib.agent.Verifier.VerifyPresentationResult
 import at.asitplus.wallet.lib.agent.VerifierAgent
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
-import at.asitplus.wallet.lib.data.CredentialPresentationRequest
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest.PresentationExchangeRequest
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
 import at.asitplus.wallet.lib.data.toBase64UrlJsonString
 import at.asitplus.wallet.lib.extensions.sessionTranscriptThumbprint
@@ -187,7 +188,6 @@ class OpenId4VpVerifier @JvmOverloads constructor(
      * Creates the [RelyingPartyMetadata], but with parameters set to request encryption of pushed authentication
      * responses, see [RelyingPartyMetadata.encryptedResponseEncValues].
      */
-    @Suppress("DEPRECATION")
     val metadataWithEncryption by lazy {
         metadata.copy(
             encryptedResponseEncValuesSupportedString = supportedJweEncryptionAlgorithms.map { it.identifier }.toSet(),
@@ -378,8 +378,8 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         idTokenType = if (isSiop) IdTokenType.SUBJECT_SIGNED.text else null,
         responseMode = responseMode,
         state = if (!isAnyDcApi) state else null,
-        dcqlQuery = (presentationRequest as? CredentialPresentationRequest.DCQLRequest)?.dcqlQuery,
-        presentationDefinition = (presentationRequest as? CredentialPresentationRequest.PresentationExchangeRequest)?.presentationDefinition?.run {
+        dcqlQuery = (presentationRequest as? DCQLRequest)?.dcqlQuery,
+        presentationDefinition = (presentationRequest as? PresentationExchangeRequest)?.presentationDefinition?.run {
             copy(
                 inputDescriptors = inputDescriptors.map {
                     when (val inputDescriptor = it) {
@@ -426,7 +426,6 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         value = authenticationRequestParameters,
     )
 
-    @Suppress("DEPRECATION")
     private fun OpenId4VpRequestOptions.clientMetadata(): RelyingPartyMetadata? = when (verifierMetadataMode) {
         VerifierMetadataMode.OMIT_IF_OUT_OF_BAND -> null
         VerifierMetadataMode.AUTO -> when (clientIdScheme) {
@@ -508,11 +507,11 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         Napier.d("validateAuthnResponse: $input")
         val authnRequest = loadAuthnRequest(input, externalId)
 
-        val responseType = authnRequest.responseType?.let {
-            ResponseType(it)
-        } ?: throw IllegalStateException(
+        val responseType = authnRequest.responseType?.let { ResponseType(it) }
+        require(responseType != null) {
             "No response type was specified in the original authentication request."
-        )
+        }
+
         val expectedNonce = authnRequest.nonce
             ?: throw IllegalArgumentException("nonce not present in $authnRequest")
         val idTokenValidationResult = if (OpenIdConstants.ID_TOKEN in responseType) {
@@ -526,8 +525,8 @@ class OpenId4VpVerifier @JvmOverloads constructor(
             null
         }
 
-        if (listOfNotNull(idTokenValidationResult, vpTokenValidationResult).isEmpty()) {
-            throw IllegalStateException("Unsupported response type: $responseType")
+        require(listOfNotNull(idTokenValidationResult, vpTokenValidationResult).isNotEmpty()) {
+            "Unsupported response type: $responseType"
         }
 
         AuthnResponseResult(
@@ -536,9 +535,8 @@ class OpenId4VpVerifier @JvmOverloads constructor(
             request = authnRequest,
         ).also {
             if (it.isFullyValid()) {
-                if (!nonceAwareVerifier.verifyAndRemoveNonce(expectedNonce)) {
-                    throw IllegalArgumentException("nonce")
-                        .also { Napier.d("nonce not valid: $expectedNonce, not known to us") }
+                require(nonceAwareVerifier.verifyAndRemoveNonce(expectedNonce)) {
+                    "nonce not valid: $expectedNonce, not known to us"
                 }
             }
         }
@@ -584,28 +582,27 @@ class OpenId4VpVerifier @JvmOverloads constructor(
                 .also { Napier.w { "JWS of idToken not verified: $idTokenJws" } }
         }
         val idToken = jwsSigned.payload
-        if (idToken.issuer != idToken.subject)
-            throw IllegalArgumentException("idToken.iss")
-                .also { Napier.d("Wrong issuer: ${idToken.issuer}, expected: ${idToken.subject}") }
-        if (idToken.audience != clientIdScheme.clientId)
-            throw IllegalArgumentException("idToken.aud")
-                .also { Napier.d("audience not valid: ${idToken.audience}") }
-        if (idToken.expiration < (clock.now() - timeLeeway))
-            throw IllegalArgumentException("idToken.exp")
-                .also { Napier.d("expirationDate before now: ${idToken.expiration}") }
-        if (idToken.issuedAt > (clock.now() + timeLeeway))
-            throw IllegalArgumentException("idToken.iat")
-                .also { Napier.d("issuedAt after now: ${idToken.issuedAt}") }
-        if (idToken.nonce != expectedNonce || !nonceAwareVerifier.verifyNonce(expectedNonce)) {
-            throw IllegalArgumentException("idToken.nonce")
-                .also { Napier.d("nonce not valid: ${idToken.nonce}, expected $expectedNonce") }
+        require(idToken.issuer == idToken.subject) {
+            "Wrong issuer: ${idToken.issuer}, expected: ${idToken.subject}"
         }
-        if (idToken.subjectJwk == null)
-            throw IllegalArgumentException("idToken.sub_jwk")
-                .also { Napier.d("sub_jwk is null") }
-        if (idToken.subject != idToken.subjectJwk!!.jwkThumbprint)
-            throw IllegalArgumentException("idToken.sub")
-                .also { Napier.d("subject does not equal thumbprint of sub_jwk: ${idToken.subject}") }
+        require(idToken.audience == clientIdScheme.clientId) {
+            "audience not valid: ${idToken.audience}"
+        }
+        require(idToken.expiration >= (clock.now() - timeLeeway)) {
+            "expirationDate before now: ${idToken.expiration}"
+        }
+        require(idToken.issuedAt <= (clock.now() + timeLeeway)) {
+            "issuedAt after now: ${idToken.issuedAt}"
+        }
+        require(idToken.nonce == expectedNonce && nonceAwareVerifier.verifyNonce(expectedNonce)) {
+            "nonce not valid: ${idToken.nonce}, expected $expectedNonce"
+        }
+        require(idToken.subjectJwk != null) {
+            "sub_jwk is null"
+        }
+        require(idToken.subject == idToken.subjectJwk!!.jwkThumbprint) {
+            "subject does not equal thumbprint of sub_jwk: ${idToken.subject}"
+        }
         idToken
     }
 
@@ -631,7 +628,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
             authnRequest.verifyExpectedOrigin(it.origin)
         }
 
-        authnRequest.presentationDefinition?.let { presentationDefinition ->
+        authnRequest.presentationDefinition?.let {
             val presentationSubmission = responseParameters.parameters.presentationSubmission?.descriptorMap
                 ?: throw IllegalArgumentException("Presentation Exchange need to present a presentation submission.")
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -119,7 +119,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     override val decryptionKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
     /** Decrypts encrypted responses from holders. */
     private val decryptJwe: DecryptJweFun = DecryptJwe(decryptionKeyMaterial),
-    /** Signs authentication requests in [createAuthnRequestAsSignedRequestObject]. */
+    /** Signs authentication requests in [createSignedRequestObject]. */
     private val signAuthnRequest: SignJwtFun<AuthenticationRequestParameters> =
         SignJwt(keyMaterial, JwsHeaderClientIdScheme(clientIdScheme)),
     /** Validates signed responses from holders. */
@@ -232,16 +232,23 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     }
 
     data class CreatedRequest(
-        /** URL to invoke the wallet/holder */
+        /** URL to invoke the wallet, may be rendered as a QR Code. */
         val url: String,
         /**
          *  Optional content that needs to be served under the previously passed in `requestUrl`
-         *  with content type `application/oauth-authz-req+jwt`
+         *  (see [CreationOptions.RequestByReference.requestUrl] or
+         *  [CreationOptions.SignedRequestByReference.requestUrl] in call to [createAuthnRequest])
+         *  with content type `application/oauth-authz-req+jwt` (see
+         *  [at.asitplus.wallet.lib.data.MediaTypes.Application.AUTHZ_REQ_JWT]).
+         *
          *  Pass in the [RequestObjectParameters] that the Wallet may have sent when requesting the request object.
          */
         val loadRequestObject: (suspend (RequestObjectParameters?) -> KmmResult<String>)? = null,
     )
 
+    /**
+     * Creates a new authentication request conforming to OpenID4VP.
+     */
     suspend fun createAuthnRequest(
         requestOptions: OpenId4VpRequestOptions,
         creationOptions: CreationOptions,
@@ -250,7 +257,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
             is CreationOptions.Query -> {
                 require(clientIdScheme !is ClientIdScheme.CertificateSanDns) // per OpenID4VP d23 5.10.4
                 URLBuilder(creationOptions.walletUrl).apply {
-                    createAuthnRequest(requestOptions).encodeToParameters()
+                    createPlainAuthnRequest(requestOptions).encodeToParameters()
                         .forEach { parameters.append(it.key, it.value) }
                 }.buildString().toCreatedRequest()
             }
@@ -266,7 +273,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
                         .forEach { parameters.append(it.key, it.value) }
                 }.buildString().toCreatedRequest {
                     catching {
-                        joseCompliantSerializer.encodeToString(createAuthnRequest(requestOptions, it))
+                        joseCompliantSerializer.encodeToString(createPlainAuthnRequest(requestOptions, it))
                     }
                 }
             }
@@ -276,7 +283,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
                 URLBuilder(creationOptions.walletUrl).apply {
                     JarRequestParameters(
                         clientId = clientIdScheme.clientId,
-                        request = createAuthnRequestAsSignedRequestObject(requestOptions).getOrThrow().toString(),
+                        request = createSignedRequestObject(requestOptions).getOrThrow().toString(),
                     ).encodeToParameters()
                         .forEach { parameters.append(it.key, it.value) }
                 }.buildString().toCreatedRequest()
@@ -294,7 +301,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
                 }.buildString()
                     .toCreatedRequest {
                         catching {
-                            createAuthnRequestAsSignedRequestObject(requestOptions, it).getOrThrow().toString()
+                            createSignedRequestObject(requestOptions, it).getOrThrow().toString()
                         }
                     }
             }
@@ -306,25 +313,19 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         loadRequestObject: suspend (RequestObjectParameters?) -> KmmResult<String>,
     ) = CreatedRequest(this, loadRequestObject)
 
-
-    /**
-     * Creates an JWS Authorization Request (JAR, RFC9101), wrapping the usual [AuthenticationRequestParameters].
-     *
-     * To use this for an Authentication Request with `request_uri`, use the following code,
-     * `jar` being the result of this function:
-     * ```
-     * val urlToSendToWallet = io.ktor.http.URLBuilder(walletUrl).apply {
-     *    parameters.append("client_id", clientId)
-     *    parameters.append("request_uri", requestUrl)
-     * }.buildString()
-     * // on an GET to requestUrl, return `jar.serialize()`
-     * ```
-     */
+    @Deprecated("Use createAuthnRequest instead with CreationOptions.SignedRequestByReference")
     suspend fun createAuthnRequestAsSignedRequestObject(
         requestOptions: OpenId4VpRequestOptions,
         requestObjectParameters: RequestObjectParameters? = null,
+    ): KmmResult<JwsCompactTyped<AuthenticationRequestParameters>> =
+        createSignedRequestObject(requestOptions, requestObjectParameters)
+
+    // TODO Should be called by DCAPI Verifier only
+    internal suspend fun createSignedRequestObject(
+        requestOptions: OpenId4VpRequestOptions,
+        requestObjectParameters: RequestObjectParameters? = null,
     ): KmmResult<JwsCompactTyped<AuthenticationRequestParameters>> = catching {
-        val requestObject = createAuthnRequest(requestOptions, requestObjectParameters)
+        val requestObject = createPlainAuthnRequest(requestOptions, requestObjectParameters)
         val siopClientId = "https://self-issued.me/v2"
         val issuer = when (clientIdScheme) {
             is ClientIdScheme.PreRegistered -> clientIdScheme.issuerUri ?: clientIdScheme.clientId
@@ -340,28 +341,19 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         ).getOrThrow()
     }
 
-    /**
-     * Creates [AuthenticationRequestParameters], to be encoded in the URL of the wallet somehow,
-     * see [createAuthnRequest]
-     */
+    @Deprecated("Use createAuthnRequest instead with CreationOptions.SignedRequestByValue")
     suspend fun createAuthnRequest(
         requestOptions: OpenId4VpRequestOptions,
         requestObjectParameters: RequestObjectParameters? = null,
-    ) = prepareAuthnRequest(
-        requestOptions = requestOptions,
-        requestObjectParameters = requestObjectParameters,
-    ).also {
-        submitAuthnRequest(it, requestOptions.state)
-    }
+    ) = createPlainAuthnRequest(requestOptions, requestObjectParameters)
 
-    /**
-     * Creates [AuthenticationRequestParameters], to be encoded in the URL of the wallet somehow,
-     * see [createAuthnRequest]
-     */
-    suspend fun prepareAuthnRequest(
+    internal suspend fun createPlainAuthnRequest(
         requestOptions: OpenId4VpRequestOptions,
         requestObjectParameters: RequestObjectParameters? = null,
     ) = requestOptions.toAuthnRequest(requestObjectParameters)
+        .also {
+            storeAuthnRequest(it, requestOptions.state)
+        }
 
     private suspend fun OpenId4VpRequestOptions.toAuthnRequest(
         requestObjectParameters: RequestObjectParameters?,
@@ -382,8 +374,8 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         presentationDefinition = (presentationRequest as? PresentationExchangeRequest)?.presentationDefinition?.run {
             copy(
                 inputDescriptors = inputDescriptors.map {
-                    when (val inputDescriptor = it) {
-                        is DifInputDescriptor -> inputDescriptor.replaceAvailableFormatHolders()
+                    when (it) {
+                        is DifInputDescriptor -> it.replaceAvailableFormatHolders()
                     }
                 }
             )
@@ -398,25 +390,20 @@ class OpenId4VpVerifier @JvmOverloads constructor(
      */
     private fun DifInputDescriptor.replaceAvailableFormatHolders() = copy(
         format = format?.copy(
-            jwtVp = format?.jwtVp?.let {
-                containerJwt
-            },
-            sdJwt = format?.sdJwt?.let {
-                containerSdJwt
-            },
-            msoMdoc = format?.msoMdoc?.let {
-                containerJwt
-            },
+            jwtVp = format?.jwtVp?.let { containerJwt },
+            sdJwt = format?.sdJwt?.let { containerSdJwt },
+            msoMdoc = format?.msoMdoc?.let { containerJwt },
         )
     )
 
-    /**
-     * Remembers [authenticationRequestParameters] to link responses to requests in [validateAuthnResponse].
-     *
-     * Parameter [externalId] may be used in cases the [authenticationRequestParameters] do not have a `state`
-     * parameter, e.g., when using DCAPI. Otherwise the value of [AuthenticationRequestParameters.state] will be used.
-     */
+    @Deprecated("Should not be necessary at all, simply call [createAuthnRequest]")
     suspend fun submitAuthnRequest(
+        authenticationRequestParameters: AuthenticationRequestParameters,
+        externalId: String? = null,
+    ) = storeAuthnRequest(authenticationRequestParameters, externalId)
+
+    // TODO Check if externalId is still necessary for DCAPI
+    internal suspend fun storeAuthnRequest(
         authenticationRequestParameters: AuthenticationRequestParameters,
         externalId: String? = null,
     ) = stateToAuthnRequestStore.put(
@@ -439,12 +426,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         }
     }
 
-    /**
-     * Validates an Authentication Response from the Wallet, where [input] is either:
-     * - a URL, containing parameters in the fragment, e.g. `https://example.com#id_token=...`
-     * - a URL, containing parameters in the query, e.g. `https://example.com?id_token=...`
-     * - parameters encoded as a POST body, e.g. `id_token=...&vp_token=...`
-     */
+    @Deprecated("Use validateAuthnResponse with externalId instead")
     suspend fun validateAuthnResponse(
         input: String,
     ): KmmResult<AuthnResponseResult> = validateAuthnResponse(
@@ -474,6 +456,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
      *
      * The [externalId] will be used to load the corresponding [AuthenticationRequestParameters] from the store.
      */
+    @Deprecated("Use DCAPI Verifier for that")
     suspend fun validateAuthnResponse(
         input: OpenId4VpResponse,
         externalId: String,
@@ -482,10 +465,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
         validateAuthnResponse(response, externalId).getOrThrow()
     }
 
-    /**
-     * Validates an Authentication Response from the Wallet,
-     * in case it has been parsed into [ResponseParametersFrom] with [ResponseParser].
-     */
+    @Deprecated("Use validateAuthnResponse with externalId instead")
     suspend fun validateAuthnResponse(
         input: ResponseParametersFrom,
     ) = validateAuthnResponse(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ResponseParser.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/ResponseParser.kt
@@ -28,16 +28,17 @@ class ResponseParser @JvmOverloads constructor(
     private val verifyJwsObject: VerifyJwsObjectFun = VerifyJwsObject(),
 ) {
     /**
-     * Parses [at.asitplus.openid.AuthenticationResponseParameters], where [input] is either:
+     * Parses [AuthenticationResponseParameters], where [input] is either:
      * - a URL, containing parameters in the fragment, e.g. `https://example.com#id_token=...`
      * - a URL, containing parameters in the query, e.g. `https://example.com?id_token=...`
      * - parameters encoded as a POST body, e.g. `id_token=...&vp_token=...`
      */
     @Throws(IllegalArgumentException::class, CancellationException::class)
-    suspend fun parseAuthnResponse(input: String) = input.parseResponseParameters().extractFromJar()
+    suspend fun parseAuthnResponse(input: String): ResponseParametersFrom =
+        input.parseResponseParameters().extractFromJar()
 
     /**
-     * Parses [at.asitplus.openid.AuthenticationResponseParameters], where [input] is a signed or unsigned DC API
+     * Parses [AuthenticationResponseParameters], where [input] is a signed or unsigned DC API
      * response.
      */
     @Throws(IllegalArgumentException::class, CancellationException::class)

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -62,7 +62,7 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
 
         "Json test $representation" {
             val authnRequest = joseCompliantSerializer.encodeToString(
-                verifierOid4vp.createAuthnRequest(requestOptions = reqOptions)
+                verifierOid4vp.createPlainAuthnRequest(reqOptions)
             )
             authnRequest.shouldNotContain(DifInputDescriptor::class.simpleName!!)
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
@@ -75,7 +75,7 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
         }
 
         "DcApiUnsigned test $representation" {
-            val parameters = verifierOid4vp.createAuthnRequest(requestOptions = reqOptions)
+            val parameters = verifierOid4vp.createPlainAuthnRequest(reqOptions)
             val authnRequest = RequestParametersFrom.OpenId4VpDcApiUnsigned(
                 parameters = parameters,
                 jsonString = joseCompliantSerializer.encodeToString(parameters),

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/AuthenticationRequestParameterFromSerializerTest.kt
@@ -48,7 +48,7 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
         "URL test $representation" {
             val authnRequest = verifierOid4vp.createAuthnRequest(
                 reqOptions,
-                OpenId4VpVerifier.CreationOptions.Query(walletUrl)
+                CreationOptions.Query(walletUrl)
             ).getOrThrow().url
 
             val params = holderOid4vp.startAuthorizationResponsePreparation(authnRequest).getOrThrow().request
@@ -95,7 +95,7 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
 
         "JwsSigned test $representation" {
             val authnRequestUrl = verifierOid4vp.createAuthnRequest(
-                reqOptions, OpenId4VpVerifier.CreationOptions.SignedRequestByValue(walletUrl)
+                reqOptions, CreationOptions.SignedRequestByValue(walletUrl)
             ).getOrThrow().url
 
             val jarRequest: JarRequestParameters = Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery()
@@ -112,7 +112,7 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
 
         "DcApiSigned test $representation" {
             val authnRequestUrl = verifierOid4vp.createAuthnRequest(
-                reqOptions, OpenId4VpVerifier.CreationOptions.SignedRequestByValue(walletUrl)
+                reqOptions, CreationOptions.SignedRequestByValue(walletUrl)
             ).getOrThrow().url
 
             val jarRequest: JarRequestParameters = Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery()
@@ -137,7 +137,7 @@ val AuthenticationRequestParameterFromSerializerTest by matrixSuite {
 
         "DcApiMultiSigned test $representation" {
             val authnRequestUrl = verifierOid4vp.createAuthnRequest(
-                reqOptions, OpenId4VpVerifier.CreationOptions.SignedRequestByValue(walletUrl)
+                reqOptions, CreationOptions.SignedRequestByValue(walletUrl)
             ).getOrThrow().url
 
             val jarRequest: JarRequestParameters = Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/JarmTest.kt
@@ -60,7 +60,7 @@ val JarmTest by matrixSuite {
          * Incorrect behaviour arises when the [RelyingPartyMetadata.jsonWebKeySet] cannot be retrieved.
          */
         "DirectPostJwt must either be signed or encrypted" {
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
                 OpenId4VpRequestOptions(
                     presentationRequest = CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
@@ -93,9 +93,9 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
                     ).toDCQLRequest()
                 )
@@ -111,9 +111,9 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
                     ).toDCQLRequest(),
                 )
@@ -145,9 +145,9 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT)
                     ).toDCQLRequest()?.let {
                         CredentialPresentationRequest.DCQLRequest(
@@ -187,9 +187,9 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, it.mdlScheme)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
                     ).toPresentationExchangeRequest()
                 )
@@ -205,9 +205,9 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, it.mdlScheme)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
                     ).toPresentationExchangeRequest(),
                 ),
@@ -228,9 +228,9 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, it.mdlScheme)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.prepareAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
                     ).toDCQLRequest(),
                 ),
@@ -247,17 +247,16 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, it.mdlScheme)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, SD_JWT)
                     ).toDCQLRequest(),
                 ),
             )
 
-            val authnResponse =
-                it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
-                    .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
 
             it.verifierOid4vp.validateAuthnResponse(authnResponse.url).getOrThrow()
                 .vpTokenValidationResult.shouldNotBeNull().getOrThrow()
@@ -274,9 +273,9 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, it.mdlScheme)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
                     ).toPresentationExchangeRequest(),
                 ),
@@ -292,9 +291,9 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, it.mdlScheme)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
                     ).toPresentationExchangeRequest(),
                 ),
@@ -314,9 +313,9 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, it.mdlScheme)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
                     ).toDCQLRequest(),
                 ),
@@ -333,17 +332,16 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, it.mdlScheme)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
                     ).toDCQLRequest(),
                 ),
             )
 
-            val authnResponse =
-                it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
-                    .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
+            val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
+                .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()
 
             it.verifierOid4vp.validateAuthnResponse(authnResponse.url).getOrThrow()
                 .vpTokenValidationResult.shouldNotBeNull().getOrThrow()
@@ -361,11 +359,7 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
                 RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
             ).toDCQLRequest().shouldNotBeNull()
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = dcqlRequest,
-                ),
-            )
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(OpenId4VpRequestOptions(dcqlRequest))
 
             val preparationState =
                 it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize()).getOrThrow()
@@ -399,11 +393,7 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
                 RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
             ).toDCQLRequest().shouldNotBeNull()
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = originalDcqlRequest,
-                ),
-            )
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(OpenId4VpRequestOptions(originalDcqlRequest))
 
             val preparationState =
                 it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize()).getOrThrow()
@@ -458,11 +448,7 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
                 RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, ISO_MDOC)
             ).toDCQLRequest().shouldNotBeNull()
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = dcqlRequest,
-                ),
-            )
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(OpenId4VpRequestOptions(dcqlRequest))
 
             val preparationState =
                 it.holderOid4vp.startAuthorizationResponsePreparation(authnRequest.serialize()).getOrThrow()
@@ -490,9 +476,9 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
             it.holderAgent.storeJwtCredential(it.holderKeyMaterial, ConstantIndex.AtomicAttribute2023)
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, it.mdlScheme)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(ConstantIndex.AtomicAttribute2023, PLAIN_JWT),
                         RequestOptionsCredential(it.mdlScheme, ISO_MDOC)
                     ).toPresentationExchangeRequest(),
@@ -528,7 +514,7 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
                     )
                 ).toPresentationExchangeRequest(),
             )
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(requestOptions)
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(requestOptions)
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest.serialize()).getOrThrow()
                 .shouldBeInstanceOf<AuthenticationResponseResult.Redirect>()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTwoStepTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTwoStepTest.kt
@@ -56,9 +56,9 @@ val OpenId4VpCombinedProtocolTwoStepTest by matrixSuite {
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, AtomicAttribute2023)
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
                     ).toPresentationExchangeRequest(),
                 )
@@ -89,9 +89,9 @@ val OpenId4VpCombinedProtocolTwoStepTest by matrixSuite {
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, AtomicAttribute2023)
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
                     ).toPresentationExchangeRequest(),
                 )
@@ -142,9 +142,9 @@ val OpenId4VpCombinedProtocolTwoStepTest by matrixSuite {
         test("submission requirements need to match: not all optional claims need to be presented") {
             it.holderAgent.storeIsoCredential(it.holderKeyMaterial, AtomicAttribute2023)
 
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(
                             credentialScheme = AtomicAttribute2023,
                             representation = ISO_MDOC,
@@ -204,9 +204,9 @@ val OpenId4VpCombinedProtocolTwoStepTest by matrixSuite {
             it.holderAgent.storeSdJwtCredential(it.holderKeyMaterial, AtomicAttribute2023)
 
             val sdJwtMatches = run {
-                val authnRequestSdJwt = it.verifierOid4vp.createAuthnRequest(
-                    requestOptions = OpenId4VpRequestOptions(
-                        presentationRequest = CredentialPresentationRequestBuilder(
+                val authnRequestSdJwt = it.verifierOid4vp.createPlainAuthnRequest(
+                    OpenId4VpRequestOptions(
+                        CredentialPresentationRequestBuilder(
                             RequestOptionsCredential(AtomicAttribute2023, SD_JWT)
                         ).toPresentationExchangeRequest(),
                     )
@@ -236,10 +236,9 @@ val OpenId4VpCombinedProtocolTwoStepTest by matrixSuite {
                 }
             }
 
-
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions = OpenId4VpRequestOptions(
-                    presentationRequest = CredentialPresentationRequestBuilder(
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(
+                OpenId4VpRequestOptions(
+                    CredentialPresentationRequestBuilder(
                         RequestOptionsCredential(AtomicAttribute2023, ISO_MDOC)
                     ).toPresentationExchangeRequest(),
                 )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpComplexSdJwtProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpComplexSdJwtProtocolTest.kt
@@ -106,7 +106,7 @@ val OpenId4VpComplexSdJwtProtocolTest by matrixSuite {
             }
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptions,
-                OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
@@ -55,7 +55,6 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 )
             }
             object {
-                val holderAgent: Holder = holderAgent
                 val holderOid4vp: OpenId4VpHolder = OpenId4VpHolder(
                     keyMaterial = holderKeyMaterial,
                     holder = holderAgent,
@@ -80,7 +79,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 expectedOrigins = listOf(callingOrigin),
                 // client_id is populated, but the Wallet MUST ignore it for unsigned DC API requests
             )
-            val authnRequest = f.verifierOid4vp.createAuthnRequest(reqOptions)
+            val authnRequest = f.verifierOid4vp.createPlainAuthnRequest(reqOptions)
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiUnsigned(
                 parameters = authnRequest,
@@ -103,7 +102,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
         test("DC API unsigned: SD-JWT response validates with origin audience") { f ->
             val rpOrigin = "https://wallet-rp.a-sit.plus"
             val transactionId = uuid4().toString()
-            val authnRequest = f.verifierOid4vp.createAuthnRequest(
+            val authnRequest = f.verifierOid4vp.createPlainAuthnRequest(
                 OpenId4VpRequestOptions(
                     presentationRequest = dcqlRequest,
                     responseMode = OpenIdConstants.ResponseMode.DcApi,
@@ -142,7 +141,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.verifierOid4vp.createAuthnRequestAsSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.verifierOid4vp.createSignedRequestObject(reqOptions).getOrThrow()
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
                 jwsTyped = signedRequest,
@@ -168,7 +167,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.verifierOid4vp.createAuthnRequestAsSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.verifierOid4vp.createSignedRequestObject(reqOptions).getOrThrow()
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
                 jwsTyped = JwsTyped<AuthenticationRequestParameters>(listOf(signedRequest.jws.toJwsFlattened())),
@@ -194,7 +193,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.verifierOid4vp.createAuthnRequestAsSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.verifierOid4vp.createSignedRequestObject(reqOptions).getOrThrow()
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
                 jwsTyped = JwsTyped<AuthenticationRequestParameters>(listOf(signedRequest.jws.toJwsFlattened())),
@@ -215,7 +214,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.verifierOid4vp.createAuthnRequestAsSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.verifierOid4vp.createSignedRequestObject(reqOptions).getOrThrow()
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
                 jwsTyped = signedRequest,
@@ -236,7 +235,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.verifierOid4vp.createAuthnRequestAsSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.verifierOid4vp.createSignedRequestObject(reqOptions).getOrThrow()
 
             // Simulate a (third-party) signed request that omits expected_origins entirely.
             val withoutExpectedOrigins = JwsTyped(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
@@ -61,7 +61,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                     randomSource = RandomSource.Default,
                 )
                 val clientId: String = "dc-api-rp-${uuid4()}"
-                val verifierOid4vp: OpenId4VpVerifier = OpenId4VpVerifier(
+                val dcApiVerifier = DcApiVerifier(
                     keyMaterial = EphemeralKeyWithoutCert(),
                     clientIdScheme = ClientIdScheme.PreRegistered(
                         clientId = clientId,
@@ -79,7 +79,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 expectedOrigins = listOf(callingOrigin),
                 // client_id is populated, but the Wallet MUST ignore it for unsigned DC API requests
             )
-            val authnRequest = f.verifierOid4vp.createPlainAuthnRequest(reqOptions)
+            val authnRequest = f.dcApiVerifier.createPlainAuthnRequest(reqOptions)
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiUnsigned(
                 parameters = authnRequest,
@@ -102,7 +102,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
         test("DC API unsigned: SD-JWT response validates with origin audience") { f ->
             val rpOrigin = "https://wallet-rp.a-sit.plus"
             val transactionId = uuid4().toString()
-            val authnRequest = f.verifierOid4vp.createPlainAuthnRequest(
+            val authnRequest = f.dcApiVerifier.createPlainAuthnRequest(
                 OpenId4VpRequestOptions(
                     presentationRequest = dcqlRequest,
                     responseMode = OpenIdConstants.ResponseMode.DcApi,
@@ -127,7 +127,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 .params.shouldBeInstanceOf<OpenId4VpResponseUnsigned>()
                 .copy(origin = rpOrigin)
 
-            val validation = f.verifierOid4vp.validateAuthnResponse(response, transactionId).getOrThrow()
+            val validation = f.dcApiVerifier.validateAuthnResponse(response, transactionId).getOrThrow()
                 .vpTokenValidationResult!!.getOrThrow()
                 .shouldBeInstanceOf<VpTokenValidationResultDCQL>()
                 .credentialQueryResponseValidations.values.single().single()
@@ -141,7 +141,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.verifierOid4vp.createSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.dcApiVerifier.createSignedRequestObject(reqOptions).getOrThrow()
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
                 jwsTyped = signedRequest,
@@ -167,7 +167,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.verifierOid4vp.createSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.dcApiVerifier.createSignedRequestObject(reqOptions).getOrThrow()
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
                 jwsTyped = JwsTyped<AuthenticationRequestParameters>(listOf(signedRequest.jws.toJwsFlattened())),
@@ -193,7 +193,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.verifierOid4vp.createSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.dcApiVerifier.createSignedRequestObject(reqOptions).getOrThrow()
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
                 jwsTyped = JwsTyped<AuthenticationRequestParameters>(listOf(signedRequest.jws.toJwsFlattened())),
@@ -214,7 +214,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.verifierOid4vp.createSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.dcApiVerifier.createSignedRequestObject(reqOptions).getOrThrow()
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
                 jwsTyped = signedRequest,
@@ -235,7 +235,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.verifierOid4vp.createSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.dcApiVerifier.createSignedRequestObject(reqOptions).getOrThrow()
 
             // Simulate a (third-party) signed request that omits expected_origins entirely.
             val withoutExpectedOrigins = JwsTyped(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEuRefInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpEuRefInteropTest.kt
@@ -365,7 +365,7 @@ val OpenId4VpEuRefInteropTest by matrixSuite {
                     responseMode = OpenIdConstants.ResponseMode.DirectPost,
                     responseUrl = "https://example.com/response",
                 ),
-                OpenId4VpVerifier.CreationOptions.SignedRequestByReference("https://wallet.a-sit.at/mobile", requestUrl)
+                CreationOptions.SignedRequestByReference("https://wallet.a-sit.at/mobile", requestUrl)
             ).getOrThrow()
             jar.shouldNotBeNull()
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpInteropTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpInteropTest.kt
@@ -136,7 +136,7 @@ val OpenId4VpInteropTest by matrixSuite {
                     responseMode = OpenIdConstants.ResponseMode.DirectPost,
                     responseUrl = "https://verifier.example.com/response/$responseNonce",
                 ),
-                OpenId4VpVerifier.CreationOptions.SignedRequestByReference("haip://", requestUrl)
+                CreationOptions.SignedRequestByReference("haip://", requestUrl)
             ).getOrThrow()
             requestObject.shouldNotBeNull()
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpIsoProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpIsoProtocolTest.kt
@@ -20,7 +20,7 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.oidvci.formUrlEncode
-import at.asitplus.wallet.lib.openid.OpenId4VpVerifier.CreationOptions.Query
+import at.asitplus.wallet.lib.openid.CreationOptions.Query
 import at.asitplus.wallet.mdl.MDL_DOCTYPE
 import at.asitplus.wallet.mdl.MobileDrivingLicenceDataElements.FAMILY_NAME
 import at.asitplus.wallet.mdl.MobileDrivingLicenceDataElements.GIVEN_NAME

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpSdJwtProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpSdJwtProtocolTest.kt
@@ -86,7 +86,7 @@ val OpenId4VpSdJwtProtocolTest by matrixSuite {
                         )
                     ).toDCQLRequest(),
                 ),
-                OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             authnRequest shouldContain requestedClaim
@@ -116,7 +116,7 @@ val OpenId4VpSdJwtProtocolTest by matrixSuite {
                         )
                     ).toDCQLRequest(),
                 ),
-                OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
@@ -143,7 +143,7 @@ val OpenId4VpSdJwtProtocolTest by matrixSuite {
                         )
                     ).toDCQLRequest(),
                 ),
-                OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509HashTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509HashTest.kt
@@ -17,7 +17,6 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.oidvci.formUrlEncode
-import at.asitplus.wallet.lib.openid.OpenId4VpVerifier.CreationOptions
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.types.shouldBeInstanceOf

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509SanDnsTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpX509SanDnsTest.kt
@@ -99,7 +99,7 @@ val OpenId4VpX509SanDnsTest by matrixSuite {
                     responseMode = OpenIdConstants.ResponseMode.DirectPost,
                     responseUrl = "https://example.com/response",
                 ),
-                OpenId4VpVerifier.CreationOptions.SignedRequestByReference("haip://", requestUrl)
+                CreationOptions.SignedRequestByReference("haip://", requestUrl)
             ).getOrThrow()
             jar.shouldNotBeNull()
 
@@ -140,7 +140,7 @@ val OpenId4VpX509SanDnsTest by matrixSuite {
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = "https://example.com/response",
                 ),
-                OpenId4VpVerifier.CreationOptions.SignedRequestByReference("haip://", requestUrl)
+                CreationOptions.SignedRequestByReference("haip://", requestUrl)
             ).getOrThrow()
             jar.shouldNotBeNull()
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -111,7 +111,7 @@ val PreRegisteredClientTest by matrixSuite {
                     ).toPresentationExchangeRequest(),
                     responseMode = OpenIdConstants.ResponseMode.Fragment,
                 ),
-                OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
@@ -130,7 +130,7 @@ val PreRegisteredClientTest by matrixSuite {
                 .vp.freshVerifiableCredentials.shouldNotBeEmpty()
 
             it.verifierOid4vp.createAuthnRequest(
-                it.defaultRequestOptions, OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                it.defaultRequestOptions, CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url.let { newAuthnRequestUrl ->
                 verifySecondProtocolRun(
                     it.verifierOid4vp, newAuthnRequestUrl, it.holderOid4vp
@@ -148,7 +148,7 @@ val PreRegisteredClientTest by matrixSuite {
                     responseMode = OpenIdConstants.ResponseMode.Query,
                     state = expectedState,
                 ),
-                OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
@@ -186,7 +186,7 @@ val PreRegisteredClientTest by matrixSuite {
                 responseType = OpenIdConstants.ID_TOKEN,
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                requestOptions, OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                requestOptions, CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
@@ -207,7 +207,7 @@ val PreRegisteredClientTest by matrixSuite {
                 },
             )
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
-                it.defaultRequestOptions, OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                it.defaultRequestOptions, CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
@@ -218,7 +218,7 @@ val PreRegisteredClientTest by matrixSuite {
 
         "test with QR Code" {
             val authnRequestUrl = it.verifierOid4vp.createAuthnRequest(
-                it.defaultRequestOptions, OpenId4VpVerifier.CreationOptions.SignedRequestByValue(it.walletUrl)
+                it.defaultRequestOptions, CreationOptions.SignedRequestByValue(it.walletUrl)
             ).getOrThrow().url
             val authnRequest: JarRequestParameters =
                 Url(authnRequestUrl).encodedQuery.decodeFromUrlQuery()
@@ -248,7 +248,7 @@ val PreRegisteredClientTest by matrixSuite {
                     responseMode = OpenIdConstants.ResponseMode.DirectPost,
                     responseUrl = it.redirectUrl
                 ),
-                OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
@@ -273,7 +273,7 @@ val PreRegisteredClientTest by matrixSuite {
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = it.redirectUrl
                 ),
-                OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
@@ -305,7 +305,7 @@ val PreRegisteredClientTest by matrixSuite {
                     responseMode = OpenIdConstants.ResponseMode.DirectPostJwt,
                     responseUrl = it.redirectUrl
                 ),
-                OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             shouldThrow<OAuth2Exception> {
@@ -341,7 +341,7 @@ val PreRegisteredClientTest by matrixSuite {
         "test specific credential" {
             val authnRequest = it.verifierOid4vp.createAuthnRequest(
                 requestOptionsAtomicAttribute(),
-                OpenId4VpVerifier.CreationOptions.Query(it.walletUrl)
+                CreationOptions.Query(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequest).getOrThrow()
@@ -365,7 +365,7 @@ val PreRegisteredClientTest by matrixSuite {
 
         "test with request object" {
             val authnRequestWithRequestObject = it.verifierOid4vp.createAuthnRequest(
-                requestOptionsAtomicAttribute(), OpenId4VpVerifier.CreationOptions.SignedRequestByValue(it.walletUrl)
+                requestOptionsAtomicAttribute(), CreationOptions.SignedRequestByValue(it.walletUrl)
             ).getOrThrow().url
 
             val authnResponse = it.holderOid4vp.createAuthnResponse(authnRequestWithRequestObject).getOrThrow()
@@ -392,7 +392,7 @@ val PreRegisteredClientTest by matrixSuite {
             val requestUrl = "https://www.example.com/request/${uuid4()}"
             val (authRequestUrlWithRequestUri, jar) = it.verifierOid4vp.createAuthnRequest(
                 requestOptionsAtomicAttribute(),
-                OpenId4VpVerifier.CreationOptions.SignedRequestByReference(it.walletUrl, requestUrl)
+                CreationOptions.SignedRequestByReference(it.walletUrl, requestUrl)
             ).getOrThrow()
             jar.shouldNotBeNull()
 
@@ -428,7 +428,7 @@ val PreRegisteredClientTest by matrixSuite {
             val requestUrl = "https://www.example.com/request/${uuid4()}"
             val (authRequestUrlWithRequestUri, jar) = it.verifierOid4vp.createAuthnRequest(
                 requestOptionsAtomicAttribute(),
-                OpenId4VpVerifier.CreationOptions.RequestByReference(it.walletUrl, requestUrl)
+                CreationOptions.RequestByReference(it.walletUrl, requestUrl)
             ).getOrThrow()
             jar.shouldNotBeNull()
 
@@ -466,7 +466,7 @@ val PreRegisteredClientTest by matrixSuite {
             val requestUrl = "https://www.example.com/request/${uuid4()}"
             val (authRequestUrlWithRequestUri, jar) = it.verifierOid4vp.createAuthnRequest(
                 requestOptionsAtomicAttribute(),
-                OpenId4VpVerifier.CreationOptions.SignedRequestByReference(it.walletUrl, requestUrl)
+                CreationOptions.SignedRequestByReference(it.walletUrl, requestUrl)
             ).getOrThrow()
             jar.shouldNotBeNull()
 

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/PreRegisteredClientTest.kt
@@ -314,7 +314,7 @@ val PreRegisteredClientTest by matrixSuite {
         }
 
         "test with deserializing" {
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(it.defaultRequestOptions)
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(it.defaultRequestOptions)
             val authnRequestUrlParams = authnRequest.encodeToParameters().formUrlEncode()
 
             val parsedAuthnRequest: AuthenticationRequestParameters =

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
@@ -34,7 +34,6 @@ import at.asitplus.wallet.lib.data.rfc3986.toUri
 import at.asitplus.wallet.lib.oidvci.decodeFromUrlQuery
 import at.asitplus.wallet.lib.oidvci.encodeToParameters
 import at.asitplus.wallet.lib.oidvci.formUrlEncode
-import at.asitplus.wallet.lib.openid.OpenId4VpVerifier.CreationOptions
 import at.asitplus.wallet.lib.utils.MapStore
 import com.benasher44.uuid.uuid4
 import io.kotest.assertions.throwables.shouldNotThrowAny

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/RedirectUriClientTest.kt
@@ -292,7 +292,7 @@ val RedirectUriClientTest by matrixSuite {
         }
 
         "test with deserializing" {
-            val authnRequest = it.verifierOid4vp.createAuthnRequest(defaultRequestOptions)
+            val authnRequest = it.verifierOid4vp.createPlainAuthnRequest(defaultRequestOptions)
             val authnRequestUrlParams = authnRequest.encodeToParameters().formUrlEncode()
 
             val parsedAuthnRequest: AuthenticationRequestParameters =

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/VerifierAttestationTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/VerifierAttestationTest.kt
@@ -91,7 +91,7 @@ val VerifierAttestationTest by matrixSuite {
                 clientIdScheme = ClientIdScheme.VerifierAttestation(attestationJwt, it.redirectUrl),
             )
             val authnRequestWithRequestObject = verifierOid4vp.createAuthnRequest(
-                requestOptionsAtomicAttribute(), OpenId4VpVerifier.CreationOptions.SignedRequestByValue(it.walletUrl)
+                requestOptionsAtomicAttribute(), CreationOptions.SignedRequestByValue(it.walletUrl)
             ).getOrThrow().url
 
             val holderOid4vp = OpenId4VpHolder(
@@ -127,7 +127,7 @@ val VerifierAttestationTest by matrixSuite {
                 clientIdScheme = ClientIdScheme.VerifierAttestation(attestationJwt, it.redirectUrl)
             )
             val authnRequestWithRequestObject = verifierOid4vp.createAuthnRequest(
-                requestOptionsAtomicAttribute(), OpenId4VpVerifier.CreationOptions.SignedRequestByValue(it.walletUrl)
+                requestOptionsAtomicAttribute(), CreationOptions.SignedRequestByValue(it.walletUrl)
             ).getOrThrow().url
 
             val holderOid4vp = OpenId4VpHolder(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/KeyBindingTests.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/KeyBindingTests.kt
@@ -202,7 +202,7 @@ val KeyBindingTests by matrixSuite {
                 stateToAuthnRequestStore = it.externalMapStore
             )
             val requestOptions = buildRequestOptions(transactionDataHashAlgorithms = null)
-            val authnRequest = verifierOid4Vp.createAuthnRequest(requestOptions)
+            val authnRequest = verifierOid4Vp.createPlainAuthnRequest(requestOptions)
 
             val authnRequestUrl = URLBuilder(it.walletUrl).apply {
                 authnRequest.encodeToParameters()
@@ -237,7 +237,7 @@ val KeyBindingTests by matrixSuite {
                 stateToAuthnRequestStore = it.externalMapStore
             )
             val requestOptions = buildRequestOptions(transactionDataHashAlgorithms = setOf(SdJwtConstants.SHA_384))
-            val authnRequest = verifierOid4Vp.createAuthnRequest(requestOptions)
+            val authnRequest = verifierOid4Vp.createPlainAuthnRequest(requestOptions)
 
             val authnRequestUrl = URLBuilder(it.walletUrl).apply {
                 authnRequest.encodeToParameters()
@@ -272,7 +272,7 @@ val KeyBindingTests by matrixSuite {
             )
             val requestOptions =
                 buildRequestOptions(OpenIdConstants.ResponseMode.DirectPost, setOf(SdJwtConstants.SHA_256))
-            val authnRequest = verifierOid4Vp.createAuthnRequest(requestOptions)
+            val authnRequest = verifierOid4Vp.createPlainAuthnRequest(requestOptions)
 
             val malignResponse = it.holderOid4vp.createAuthnResponse(
                 joseCompliantSerializer.encodeToString(
@@ -302,7 +302,7 @@ val KeyBindingTests by matrixSuite {
             )
 
             val requestOptions = buildRequestOptions(OpenIdConstants.ResponseMode.DirectPost, null)
-            val authnRequest = lenientVerifier.createAuthnRequest(requestOptions)
+            val authnRequest = lenientVerifier.createPlainAuthnRequest(requestOptions)
 
             val malignResponse = it.holderOid4vp.createAuthnResponse(
                 joseCompliantSerializer.encodeToString(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptionsTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/rqes/RqesRequestOptionsTest.kt
@@ -42,7 +42,7 @@ val RqesRequestOptionsTest by matrixSuite {
 
         test("Authentication request contains transactionData") {
             val requestOptions = buildRequestOptions(transactionDataHashAlgorithms = setOf(SdJwtConstants.SHA_256))
-            it.verifierOid4Vp.createAuthnRequest(requestOptions = requestOptions).apply {
+            it.verifierOid4Vp.createPlainAuthnRequest(requestOptions).apply {
                 val inputDescriptor = presentationDefinition.shouldNotBeNull().inputDescriptors.first()
                 transactionData.shouldNotBeNull().first().toTransactionData().apply {
                     transactionDataHashAlgorithms shouldNotBe null


### PR DESCRIPTION
Part 2 of a better interface for DCAPI: Dedicated `DcApiVerifier` to streamline the `OpenId4VpVerifier`. Next step: Integrate `Iso180137AnnexCVerifier` into that.

Previous PR: https://github.com/a-sit-plus/vck/pull/589
Next PR: https://github.com/a-sit-plus/vck/pull/591