### PR TITLE
Integrate ISO 18013-7 Annex C into DCAPI 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Release 7.0.0 (unreleased):
     - Fix disclosure of SD-JWT claims from foreign issuers: match disclosure digests against the originally serialized disclosures instead of re-serializing them, since digests are computed over the exact bytes (RFC 9901, section 4.2.3), e.g. failing for disclosures serialized with whitespace.
     - Extend `DCQLCredentialQueryMatchingResult` by case `AllMandatoryClaimsMatchingResult`
     - Consolidate interface of `OpenId4VpVerifier`: All clients should use `createAuthnRequest()`, so we deprecate methods `submitAuthnRequest()` or `createAuthnRequestAsSignedRequestObject()`
-    - Extract `DcApiVerifier` as a pendant to `OpenId4VpVerifier` which handles DCAPI requests only
+    - Extract `DcApiVerifier` as a pendant to `OpenId4VpVerifier` which handles DCAPI requests only, deprecating `Iso180137AnnexCVerifier`
     - Move `CreationOptions` and `CreatedRequest` to upper level (`at.asitplus.wallet.lib.openid`) instead of nesting in `OpenId4VpVerifier`
 - Verifier:
     - Add `NonceChallengeVerifier`, a thin `Verifier` wrapper that creates presentation challenges from a `NonceService` and verifies SD-JWT/VC-JWT presentations against the embedded challenge.

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQueryToIsoDeviceRequest.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLQueryToIsoDeviceRequest.kt
@@ -1,0 +1,34 @@
+package at.asitplus.openid.dcql
+
+import at.asitplus.iso.DeviceRequest
+import at.asitplus.iso.DocRequest
+import at.asitplus.iso.ItemsRequest
+import at.asitplus.iso.ItemsRequestList
+import at.asitplus.iso.SingleItemsRequest
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
+
+/**
+ * Renders this DCQL query as an ISO 18013-5 [DeviceRequest],
+ * to be used for ISO/IEC 18013-7 Annex C flows over the W3C Digital Credentials API.
+ *
+ * All credential queries must be [DCQLIsoMdocCredentialQuery] with explicitly enumerated
+ * [DCQLIsoMdocCredentialQuery.claims]: DCQL's `claims == null` (requesting all claims)
+ * cannot be expressed in an ISO device request.
+ */
+fun DCQLQuery.toIso180137AnnexCDeviceRequest(): DeviceRequest = DeviceRequest(
+    version = "1.0",
+    docRequests = credentials.map { it.toDocRequest() }.toTypedArray(),
+)
+
+private fun DCQLCredentialQuery.toDocRequest(): DocRequest {
+    require(this is DCQLIsoMdocCredentialQuery) {
+        "Only mso_mdoc credential queries are supported for ISO 18013-7 Annex C, got $format"
+    }
+    val namespaces = requireNotNull(claims) {
+        "ISO device requests require explicitly enumerated claims"
+    }.groupBy(
+        keySelector = { it.namespace },
+        valueTransform = { SingleItemsRequest(it.claimName, it.intentToRetain ?: false) },
+    ).mapValues { (_, items) -> ItemsRequestList(items) }
+    return DocRequest(ByteStringWrapper(ItemsRequest(meta.doctypeValue, namespaces)))
+}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -12,7 +12,7 @@ data class AuthnResponseResult(
     val idTokenValidationResult: KmmResult<IdToken>?,
     val vpTokenValidationResult: KmmResult<VpTokenValidationResult>?,
     val request: AuthenticationRequestParameters?,
-) {
+) : DcApiResponseResult() {
     val state
         get() = request?.state
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -2,13 +2,14 @@ package at.asitplus.wallet.lib.openid
 
 import at.asitplus.KmmResult
 import at.asitplus.openid.AuthenticationRequestParameters
+import at.asitplus.openid.IdToken
 
 /**
  * Result of validating an OpenID authentication response.
  * Use to inspect how a wallet response was parsed and whether presentation validation succeeded.
  */
 data class AuthnResponseResult(
-    val idTokenValidationResult: KmmResult<at.asitplus.openid.IdToken>?,
+    val idTokenValidationResult: KmmResult<IdToken>?,
     val vpTokenValidationResult: KmmResult<VpTokenValidationResult>?,
     val request: AuthenticationRequestParameters?,
 ) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CredentialPresentationRequestBuilder.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/CredentialPresentationRequestBuilder.kt
@@ -8,11 +8,6 @@ import at.asitplus.dif.FormatContainerSdJwt
 import at.asitplus.dif.FormatHolder
 import at.asitplus.dif.InputDescriptor
 import at.asitplus.dif.PresentationDefinition
-import at.asitplus.iso.DeviceRequest
-import at.asitplus.iso.DocRequest
-import at.asitplus.iso.ItemsRequest
-import at.asitplus.iso.ItemsRequestList
-import at.asitplus.iso.SingleItemsRequest
 import at.asitplus.openid.dcql.DCQLClaimsPathPointer
 import at.asitplus.openid.dcql.DCQLClaimsPathPointerSegment.NameSegment
 import at.asitplus.openid.dcql.DCQLClaimsQueryList
@@ -28,10 +23,10 @@ import at.asitplus.openid.dcql.DCQLJwtVcCredentialQuery
 import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.openid.dcql.DCQLSdJwtCredentialMetadataAndValidityConstraints
 import at.asitplus.openid.dcql.DCQLSdJwtCredentialQuery
-import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
 import at.asitplus.wallet.lib.RequestOptionsCredential
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.*
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest
+import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.toIsoMdocClaimPath
 import com.benasher44.uuid.uuid4
 
@@ -66,8 +61,8 @@ data class CredentialPresentationRequestBuilder(
         ISO_MDOC -> FormatHolder(msoMdoc = FormatContainerJwt())
     }
 
-    fun toDCQLRequest(): CredentialPresentationRequest.DCQLRequest? {
-        return CredentialPresentationRequest.DCQLRequest(
+    fun toDCQLRequest(): DCQLRequest? {
+        return DCQLRequest(
             DCQLQuery(
                 credentials = DCQLCredentialQueryList(
                     credentials.mapNotNull {
@@ -78,26 +73,6 @@ data class CredentialPresentationRequestBuilder(
                 ),
             )
         )
-    }
-
-    fun toIso180137AnnexCDeviceRequest() = credentials.map {
-        if (it.representation != ISO_MDOC) {
-            throw UnsupportedOperationException("Wrong representation: Only ISO MDoc is supported")
-        }
-        val docType = it.credentialScheme.isoDocType ?: throw IllegalStateException("Missing doc type")
-        val itemsRequestList = it.effectiveRequestedAttributePaths().map { reqAttr ->
-            val (namespace, claimName) = reqAttr.toIsoMdocClaimPath(it.credentialScheme)
-                .toIsoMdocNamespaceAndClaimName()
-            namespace to SingleItemsRequest(claimName, false)
-        }.groupBy(
-            keySelector = { (namespace, _) -> namespace },
-            valueTransform = { (_, itemRequest) -> itemRequest }
-        ).mapValues { (_, itemRequests) ->
-            ItemsRequestList(itemRequests)
-        }
-        DocRequest(ByteStringWrapper(ItemsRequest(docType, itemsRequestList)))
-    }.toTypedArray().let {
-        DeviceRequest("1.0", it)
     }
 
     private fun RequestOptionsCredential.toQuery(): DCQLCredentialQuery? = when (representation) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiCreationOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiCreationOptions.kt
@@ -19,5 +19,11 @@ sealed class DcApiCreationOptions {
      */
     data object OpenId4VpSigned : DcApiCreationOptions()
 
-    // TODO: OpenId4VpMultiSigned (`openid4vp-v1-multisigned`) and Iso18013AnnexC (`org-iso-mdoc`)
+    /**
+     * ISO 18013-7 Annex C request, i.e. protocol `org-iso-mdoc`,
+     * see [at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest.IsoMdoc].
+     */
+    data object Iso180137AnnexC : DcApiCreationOptions()
+
+    // TODO: OpenId4VpMultiSigned (`openid4vp-v1-multisigned`)
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiCreationOptions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiCreationOptions.kt
@@ -1,0 +1,23 @@
+package at.asitplus.wallet.lib.openid
+
+/**
+ * Options for creating requests for the W3C Digital Credentials API in [DcApiVerifier.createAuthnRequest],
+ * reflecting the exchange protocols available over that API,
+ * see [at.asitplus.dcapi.request.ExchangeProtocolIdentifier].
+ */
+sealed class DcApiCreationOptions {
+
+    /**
+     * Unsigned OpenID4VP 1.0 request, i.e. protocol `openid4vp-v1-unsigned`,
+     * see [at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest.OpenId4VpUnsigned].
+     */
+    data object OpenId4VpUnsigned : DcApiCreationOptions()
+
+    /**
+     * Signed OpenID4VP 1.0 request, i.e. protocol `openid4vp-v1-signed`,
+     * see [at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest.OpenId4VpSigned].
+     */
+    data object OpenId4VpSigned : DcApiCreationOptions()
+
+    // TODO: OpenId4VpMultiSigned (`openid4vp-v1-multisigned`) and Iso18013AnnexC (`org-iso-mdoc`)
+}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
@@ -5,23 +5,27 @@ import at.asitplus.catching
 import at.asitplus.dcapi.DCAPIHandover
 import at.asitplus.dcapi.DCAPIHandover.Companion.TYPE_DCAPI
 import at.asitplus.dcapi.DCAPIInfo
+import at.asitplus.dcapi.DCAPIResponse
 import at.asitplus.dcapi.DigitalCredentialInterface
 import at.asitplus.dcapi.IsoMdocResponse
 import at.asitplus.dcapi.OpenID4VPDCAPIHandoverInfo
 import at.asitplus.dcapi.OpenId4VpResponse
 import at.asitplus.dcapi.SessionTranscriptContentHashable
+import at.asitplus.dcapi.request.IsoMdocRequest
 import at.asitplus.dcapi.request.verifier.CredentialRequestOptions
-import at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest
+import at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest.*
+import at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest.OpenId4Vp.SignedDataElement
 import at.asitplus.dif.ClaimFormat
 import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.dif.FormatContainerJwt
 import at.asitplus.dif.FormatContainerSdJwt
 import at.asitplus.dif.PresentationSubmissionDescriptor
 import at.asitplus.iso.DeviceResponse
+import at.asitplus.iso.EncryptionInfo
+import at.asitplus.iso.EncryptionParameters
 import at.asitplus.iso.SessionTranscript
 import at.asitplus.iso.serializeOrigin
 import at.asitplus.iso.sha256
-import at.asitplus.jsonpath.JsonPath
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.CredentialFormatEnum
 import at.asitplus.openid.IdTokenType
@@ -36,10 +40,14 @@ import at.asitplus.openid.VpFormatsSupported
 import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
 import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.openid.dcql.DCQLQueryResponse
+import at.asitplus.openid.dcql.toIso180137AnnexCDeviceRequest
 import at.asitplus.rfc6749OAuth2AuthorizationFramework.ResponseType
+import at.asitplus.signum.indispensable.CryptoPrivateKey
+import at.asitplus.signum.indispensable.SecretExposure
 import at.asitplus.signum.indispensable.SignatureAlgorithm
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.cosef.toCoseAlgorithm
+import at.asitplus.signum.indispensable.cosef.toCoseKey
 import at.asitplus.signum.indispensable.io.Base64UrlStrict
 import at.asitplus.signum.indispensable.josef.JsonWebKey
 import at.asitplus.signum.indispensable.josef.JsonWebKeySet
@@ -61,6 +69,7 @@ import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.PresentationExchangeRequest
+import at.asitplus.wallet.lib.data.IsoDocumentParsed
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
 import at.asitplus.wallet.lib.data.toBase64UrlJsonString
 import at.asitplus.wallet.lib.extensions.sessionTranscriptThumbprint
@@ -76,6 +85,7 @@ import at.asitplus.wallet.lib.procedures.dcql.DCQLQueryAdapter
 import at.asitplus.wallet.lib.utils.DefaultMapStore
 import at.asitplus.wallet.lib.utils.MapStore
 import io.github.aakira.napier.Napier
+import io.ktor.utils.io.core.*
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
@@ -124,8 +134,15 @@ class DcApiVerifier @JvmOverloads constructor(
     override val nonceService: NonceService = DefaultNonceService(),
     /** Used to store issued authn requests to verify the authn response to it */
     private val stateToAuthnRequestStore: MapStore<String, AuthenticationRequestParameters> = DefaultMapStore(),
+    /** Used to store issued requests to verify the response to it */
+    private val stateToIsoMdocRequestStore: MapStore<String, IsoMdocRequest> = DefaultMapStore(),
     /** Algorithms supported to decrypt responses from wallets, for [metadataWithEncryption]. */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption> = JweEncryption.entries.toSet(),
+    /**
+     * Workaround until signum is ready. Required for ISO 18013-7 Annex decryption.
+     * Parameters: Serialized ephemeral key, cipher text, decryption key, encoded session transcript
+     */
+    private val decryptHpke: (suspend (ByteArray, ByteArray, CryptoPrivateKey.EC.WithPublicKey, ByteArray) -> ByteArray)? = null,
 ) : AbstractMdocVerifier() {
 
     private val nonceAwareVerifier = NonceChallengeVerifier(
@@ -200,15 +217,19 @@ class DcApiVerifier @JvmOverloads constructor(
         CredentialRequestOptions.create(
             listOf(
                 when (creationOptions) {
-                    is DcApiCreationOptions.OpenId4VpUnsigned -> DigitalCredentialGetRequest.OpenId4VpUnsigned(
+                    is DcApiCreationOptions.OpenId4VpUnsigned -> OpenId4VpUnsigned(
                         // client_id MUST be omitted in unsigned requests, per OpenID4VP 1.0 Appendix A.3.1
                         createPlainAuthnRequest(requestOptions.copy(populateClientId = false))
                     )
 
-                    is DcApiCreationOptions.OpenId4VpSigned -> DigitalCredentialGetRequest.OpenId4VpSigned(
-                        DigitalCredentialGetRequest.OpenId4Vp.SignedDataElement(
+                    is DcApiCreationOptions.OpenId4VpSigned -> OpenId4VpSigned(
+                        SignedDataElement(
                             createSignedRequestObject(requestOptions).getOrThrow().jws
                         )
+                    )
+
+                    DcApiCreationOptions.Iso180137AnnexC -> IsoMdoc(
+                        createIsoMdocRequest(requestOptions)
                     )
                 }
             )
@@ -240,6 +261,21 @@ class DcApiVerifier @JvmOverloads constructor(
         .also {
             storeAuthnRequest(it, requestOptions.state)
         }
+
+    private suspend fun createIsoMdocRequest(
+        requestOptions: OpenId4VpRequestOptions,
+    ): IsoMdocRequest {
+        val deviceRequest = ((requestOptions.presentationRequest as? DCQLRequest)?.dcqlQuery
+            ?: throw IllegalArgumentException("ISO 18013-7 Annex C requires a DCQL presentation request"))
+            .toIso180137AnnexCDeviceRequest()
+
+        val encryptionParameters = EncryptionParameters(
+            nonceService.provideNonce().toByteArray(),
+            decryptionKeyMaterial.publicKey.toCoseKey().getOrThrow()
+        )
+        return IsoMdocRequest(deviceRequest, EncryptionInfo(TYPE_DCAPI, encryptionParameters))
+            .also { stateToIsoMdocRequestStore.put(requestOptions.state, it) }
+    }
 
     private suspend fun OpenId4VpRequestOptions.toAuthnRequest(): AuthenticationRequestParameters =
         AuthenticationRequestParameters(
@@ -311,7 +347,7 @@ class DcApiVerifier @JvmOverloads constructor(
     suspend fun validateAuthnResponse(
         input: String,
         externalId: String,
-    ): KmmResult<AuthnResponseResult> = catching {
+    ): KmmResult<DcApiResponseResult> = catching {
         validateAuthnResponse(
             input = joseCompliantSerializer.decodeFromString<DigitalCredentialInterface>(input),
             externalId = externalId
@@ -326,9 +362,14 @@ class DcApiVerifier @JvmOverloads constructor(
     suspend fun validateAuthnResponse(
         input: DigitalCredentialInterface,
         externalId: String,
-    ): KmmResult<AuthnResponseResult> = catching {
+    ): KmmResult<DcApiResponseResult> = catching {
         when (input) {
-            is IsoMdocResponse -> TODO()
+            is IsoMdocResponse -> validateResponse(
+                receivedData = input.data,
+                externalId = externalId,
+                expectedOrigin = "TODO"
+            ).getOrThrow()
+
             else -> validateAuthnResponse(
                 input = responseParser.parseAuthnResponse(input as OpenId4VpResponse),
                 externalId = externalId
@@ -375,6 +416,46 @@ class DcApiVerifier @JvmOverloads constructor(
         }
     }
 
+    @OptIn(SecretExposure::class)
+    suspend fun validateResponse(
+        receivedData: DCAPIResponse,
+        externalId: String,
+        expectedOrigin: String
+    ): KmmResult<Iso180137AnnexCWrapper> = catching {
+        val isoMdocRequest = stateToIsoMdocRequestStore.get(externalId)!!
+        val privateKey = decryptionKeyMaterial.exportPrivateKey().getOrThrow()
+                as? CryptoPrivateKey.EC.WithPublicKey
+            ?: throw IllegalStateException("Expected EC private key")
+
+        val encryptedResponseData = receivedData.response.encryptedResponseData
+        val serializedOrigin = expectedOrigin.serializeOrigin()
+            ?: throw IllegalStateException("Expected origin invalid")
+
+        val sessionTranscript = createDcApiSessionTranscriptAnnexC(
+            DCAPIInfo(
+                encryptionInfo = isoMdocRequest.encryptionInfo,
+                serializedOrigin = serializedOrigin,
+            )
+        )
+        val encodedSessionTranscript = coseCompliantSerializer.encodeToByteArray(sessionTranscript)
+        val encodedDeviceResponse = decryptHpke!!(
+            encryptedResponseData.enc,
+            encryptedResponseData.cipherText,
+            privateKey,
+            encodedSessionTranscript
+        )
+        val deviceResponse = coseCompliantSerializer.decodeFromByteArray<DeviceResponse>(encodedDeviceResponse)
+
+        Iso180137AnnexCWrapper(
+            verifier.verifyPresentationIsoMdoc(
+                input = deviceResponse,
+                verifyDocument = verifyDocument(
+                    sessionTranscript = sessionTranscript
+                )
+            ).getOrThrow().documents
+        )
+    }
+
     private fun AuthnResponseResult.isFullyValid(): Boolean =
         idTokenValidationResult?.isFailure != true &&
                 vpTokenValidationResult?.isFailure != true &&
@@ -416,35 +497,13 @@ class DcApiVerifier @JvmOverloads constructor(
         val vpToken = responseParameters.parameters.vpToken
             ?: throw IllegalArgumentException("vp_token not present in ${responseParameters.parameters}")
         val clientIdRequired = responseParameters.clientIdRequired
-
         val originalResponseParameters = responseParameters.originalResponseParameters
-
-        (originalResponseParameters as? ResponseParametersFrom.DcApi)?.let {
-            authnRequest.verifyExpectedOrigin(it.origin)
+        require(originalResponseParameters is ResponseParametersFrom.DcApi) {
+            "Unsupported response parameters: $originalResponseParameters"
         }
+        authnRequest.verifyExpectedOrigin(originalResponseParameters.origin)
 
-        authnRequest.presentationDefinition?.let {
-            val presentationSubmission = responseParameters.parameters.presentationSubmission?.descriptorMap
-                ?: throw IllegalArgumentException("Presentation Exchange need to present a presentation submission.")
-
-            val presentation = presentationSubmission.associate { descriptor ->
-                descriptor.id to verifyPresentationResult(
-                    claimFormat = descriptor.format,
-                    relatedPresentation = descriptor.relatedPresentation(vpToken),
-                    expectedNonce = expectedNonce,
-                    input = responseParameters,
-                    clientId = authnRequest.clientId,
-                    responseUrl = authnRequest.responseUrl ?: authnRequest.redirectUrlExtracted,
-                    transactionData = authnRequest.transactionData,
-                    clientIdRequired = clientIdRequired,
-                    origin = (originalResponseParameters as? ResponseParametersFrom.DcApi)?.origin,
-                )
-            }
-
-            VpTokenValidationResultPresentationExchange(
-                inputDescriptorResponseValidations = presentation,
-            )
-        } ?: authnRequest.dcqlQuery?.let { query ->
+        authnRequest.dcqlQuery?.let { query ->
             val presentation = vpToken.jsonObject.mapKeys {
                 DCQLCredentialQueryIdentifier(it.key)
             }.mapValues { (credentialQueryId, relatedPresentation) ->
@@ -462,7 +521,7 @@ class DcApiVerifier @JvmOverloads constructor(
                             ?: authnRequest.redirectUrlExtracted,
                         transactionData = authnRequest.transactionData,
                         clientIdRequired = clientIdRequired,
-                        origin = (originalResponseParameters as? ResponseParametersFrom.DcApi)?.origin,
+                        origin = originalResponseParameters.origin,
                         requireCryptographicHolderBinding = query.credentialQuery(credentialQueryId)?.requireCryptographicHolderBinding,
                     )
                 }
@@ -489,9 +548,6 @@ class DcApiVerifier @JvmOverloads constructor(
 
     private fun DCQLQuery.credentialQuery(id: DCQLCredentialQueryIdentifier) =
         credentials.associateBy { it.id }[id]
-
-    private fun PresentationSubmissionDescriptor.relatedPresentation(vpToken: JsonElement) =
-        JsonPath(cumulativeJsonPath).query(vpToken).first().value
 
     private fun CredentialFormatEnum.toClaimFormat(): ClaimFormat = when (this) {
         CredentialFormatEnum.JWT_VC -> ClaimFormat.JWT_VP
@@ -648,3 +704,9 @@ private val PresentationSubmissionDescriptor.cumulativeJsonPath: String
         }
         return cummulativeJsonPath
     }
+
+sealed class DcApiResponseResult {
+
+}
+
+data class Iso180137AnnexCWrapper(val documents: Collection<IsoDocumentParsed>) : DcApiResponseResult()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
@@ -3,11 +3,15 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.dcapi.DCAPIHandover
+import at.asitplus.dcapi.DCAPIHandover.Companion.TYPE_DCAPI
+import at.asitplus.dcapi.DCAPIInfo
 import at.asitplus.dcapi.DigitalCredentialInterface
 import at.asitplus.dcapi.IsoMdocResponse
 import at.asitplus.dcapi.OpenID4VPDCAPIHandoverInfo
 import at.asitplus.dcapi.OpenId4VpResponse
 import at.asitplus.dcapi.SessionTranscriptContentHashable
+import at.asitplus.dcapi.request.verifier.CredentialRequestOptions
+import at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest
 import at.asitplus.dif.ClaimFormat
 import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.dif.FormatContainerJwt
@@ -20,12 +24,9 @@ import at.asitplus.iso.sha256
 import at.asitplus.jsonpath.JsonPath
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.CredentialFormatEnum
-import at.asitplus.openid.IdToken
 import at.asitplus.openid.IdTokenType
-import at.asitplus.openid.JarRequestParameters
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RelyingPartyMetadata
-import at.asitplus.openid.RequestObjectParameters
 import at.asitplus.openid.ResponseParametersFrom
 import at.asitplus.openid.SupportedAlgorithmsContainerIso
 import at.asitplus.openid.SupportedAlgorithmsContainerJwt
@@ -58,7 +59,6 @@ import at.asitplus.wallet.lib.agent.Verifier
 import at.asitplus.wallet.lib.agent.VerifierAgent
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
-import at.asitplus.wallet.lib.data.CredentialPresentationRequest
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.PresentationExchangeRequest
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
@@ -72,12 +72,10 @@ import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.jws.SignJwtFun
 import at.asitplus.wallet.lib.jws.VerifyJwsObject
 import at.asitplus.wallet.lib.jws.VerifyJwsObjectFun
-import at.asitplus.wallet.lib.oidvci.encodeToParameters
 import at.asitplus.wallet.lib.procedures.dcql.DCQLQueryAdapter
 import at.asitplus.wallet.lib.utils.DefaultMapStore
 import at.asitplus.wallet.lib.utils.MapStore
 import io.github.aakira.napier.Napier
-import io.ktor.http.*
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
@@ -91,16 +89,15 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmOverloads
-import kotlin.time.Clock
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 /**
- * Implements a verifier for the []Digital Credential API](https://www.w3.org/TR/digital-credentials/),
+ * Implements a verifier for the [Digital Credentials API](https://www.w3.org/TR/digital-credentials/),
  * similar to [OpenId4VpVerifier] for OpenID4VP.
  *
- * This class creates the Authentication Request (see [at.asitplus.openid.AuthenticationRequestParameters]),
- * clients need to send it to the holder (see [OpenId4VpHolder]) which will create the Authentication Response,
+ * This class creates the request for the Digital Credentials API in [createAuthnRequest]
+ * (see [at.asitplus.dcapi.request.verifier.CredentialRequestOptions]), which the relying party's frontend
+ * needs to pass to the browser (`navigator.credentials.get()`). The browser forwards it to the holder
+ * (see [OpenId4VpHolder]), which will create the Authentication Response,
  * which will be verified here in [validateAuthnResponse].
  */
 class DcApiVerifier @JvmOverloads constructor(
@@ -123,10 +120,6 @@ class DcApiVerifier @JvmOverloads constructor(
     private val supportedAlgorithms: Set<SignatureAlgorithm> = setOf(SignatureAlgorithm.ECDSAwithSHA256),
     /** Used to verify session transcripts from mDoc responses. */
     override val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray> = VerifyCoseSignatureWithKey(),
-    /** Leeway for time validity checks. */
-    timeLeewaySeconds: Long = 300L,
-    /** Clock for time validity checks. */
-    private val clock: Clock = Clock.System,
     /** Creates and validates OpenID4VP request nonces. */
     override val nonceService: NonceService = DefaultNonceService(),
     /** Used to store issued authn requests to verify the authn response to it */
@@ -145,7 +138,6 @@ class DcApiVerifier @JvmOverloads constructor(
     private val supportedCoseAlgorithms = supportedAlgorithms
         .mapNotNull { it.toCoseAlgorithm().getOrNull()?.coseValue }
     private val responseParser = ResponseParser(decryptJwe, verifyJwsObject)
-    private val timeLeeway = timeLeewaySeconds.toDuration(DurationUnit.SECONDS)
     private val containerJwt = FormatContainerJwt(algorithmStrings = supportedJwsAlgorithms)
     private val containerSdJwt = FormatContainerSdJwt(
         sdJwtAlgorithmStrings = supportedJwsAlgorithms.toSet(),
@@ -193,78 +185,40 @@ class DcApiVerifier @JvmOverloads constructor(
     }
 
     /**
-     * Creates a new authentication request conforming to OpenID4VP.
+     * Creates a new authentication request for the W3C Digital Credentials API, i.e. the object that the
+     * relying party's frontend needs to pass to the browser in `navigator.credentials.get()`.
+     *
+     * [requestOptions] must use [OpenIdConstants.ResponseMode.DcApi] or [OpenIdConstants.ResponseMode.DcApiJwt].
      */
     suspend fun createAuthnRequest(
         requestOptions: OpenId4VpRequestOptions,
-        creationOptions: CreationOptions,
-    ): KmmResult<CreatedRequest> = catching {
-        when (creationOptions) {
-            is CreationOptions.Query -> {
-                require(clientIdScheme !is ClientIdScheme.CertificateSanDns) // per OpenID4VP d23 5.10.4
-                URLBuilder(creationOptions.walletUrl).apply {
-                    createPlainAuthnRequest(requestOptions).encodeToParameters()
-                        .forEach { parameters.append(it.key, it.value) }
-                }.buildString().toCreatedRequest()
-            }
-
-            is CreationOptions.RequestByReference -> {
-                require(clientIdScheme !is ClientIdScheme.CertificateSanDns) // per OpenID4VP d23 5.10.4
-                URLBuilder(creationOptions.walletUrl).apply {
-                    JarRequestParameters(
-                        clientId = clientIdScheme.clientId,
-                        requestUri = creationOptions.requestUrl,
-                        requestUriMethod = creationOptions.requestUrlMethod,
-                    ).encodeToParameters()
-                        .forEach { parameters.append(it.key, it.value) }
-                }.buildString().toCreatedRequest {
-                    catching {
-                        joseCompliantSerializer.encodeToString(createPlainAuthnRequest(requestOptions, it))
-                    }
-                }
-            }
-
-            is CreationOptions.SignedRequestByValue -> {
-                require(clientIdScheme !is ClientIdScheme.RedirectUri) // per OpenID4VP d23 5.10.4
-                URLBuilder(creationOptions.walletUrl).apply {
-                    JarRequestParameters(
-                        clientId = clientIdScheme.clientId,
-                        request = createSignedRequestObject(requestOptions).getOrThrow().toString(),
-                    ).encodeToParameters()
-                        .forEach { parameters.append(it.key, it.value) }
-                }.buildString().toCreatedRequest()
-            }
-
-            is CreationOptions.SignedRequestByReference -> {
-                require(clientIdScheme !is ClientIdScheme.RedirectUri) // per OpenID4VP d23 5.10.4
-                URLBuilder(creationOptions.walletUrl).apply {
-                    JarRequestParameters(
-                        clientId = clientIdScheme.clientId,
-                        requestUri = creationOptions.requestUrl,
-                        requestUriMethod = creationOptions.requestUrlMethod,
-                    ).encodeToParameters()
-                        .forEach { parameters.append(it.key, it.value) }
-                }.buildString()
-                    .toCreatedRequest {
-                        catching {
-                            createSignedRequestObject(requestOptions, it).getOrThrow().toString()
-                        }
-                    }
-            }
+        creationOptions: DcApiCreationOptions,
+    ): KmmResult<CredentialRequestOptions> = catching {
+        require(requestOptions.isAnyDcApi) {
+            "responseMode must be ${OpenIdConstants.ResponseMode.DcApi} or ${OpenIdConstants.ResponseMode.DcApiJwt}"
         }
+        CredentialRequestOptions.create(
+            listOf(
+                when (creationOptions) {
+                    is DcApiCreationOptions.OpenId4VpUnsigned -> DigitalCredentialGetRequest.OpenId4VpUnsigned(
+                        // client_id MUST be omitted in unsigned requests, per OpenID4VP 1.0 Appendix A.3.1
+                        createPlainAuthnRequest(requestOptions.copy(populateClientId = false))
+                    )
+
+                    is DcApiCreationOptions.OpenId4VpSigned -> DigitalCredentialGetRequest.OpenId4VpSigned(
+                        DigitalCredentialGetRequest.OpenId4Vp.SignedDataElement(
+                            createSignedRequestObject(requestOptions).getOrThrow().jws
+                        )
+                    )
+                }
+            )
+        )
     }
 
-    private fun String.toCreatedRequest() = CreatedRequest(this)
-    private fun String.toCreatedRequest(
-        loadRequestObject: suspend (RequestObjectParameters?) -> KmmResult<String>,
-    ) = CreatedRequest(this, loadRequestObject)
-
-    // TODO Should be called by DCAPI Verifier only
-    internal suspend fun createSignedRequestObject(
+    private suspend fun createSignedRequestObject(
         requestOptions: OpenId4VpRequestOptions,
-        requestObjectParameters: RequestObjectParameters? = null,
     ): KmmResult<JwsCompactTyped<AuthenticationRequestParameters>> = catching {
-        val requestObject = createPlainAuthnRequest(requestOptions, requestObjectParameters)
+        val requestObject = createPlainAuthnRequest(requestOptions)
         val siopClientId = "https://self-issued.me/v2"
         val issuer = when (clientIdScheme) {
             is ClientIdScheme.PreRegistered -> clientIdScheme.issuerUri ?: clientIdScheme.clientId
@@ -280,42 +234,39 @@ class DcApiVerifier @JvmOverloads constructor(
         ).getOrThrow()
     }
 
-    internal suspend fun createPlainAuthnRequest(
+    private suspend fun createPlainAuthnRequest(
         requestOptions: OpenId4VpRequestOptions,
-        requestObjectParameters: RequestObjectParameters? = null,
-    ) = requestOptions.toAuthnRequest(requestObjectParameters)
+    ) = requestOptions.toAuthnRequest()
         .also {
             storeAuthnRequest(it, requestOptions.state)
         }
 
-    private suspend fun OpenId4VpRequestOptions.toAuthnRequest(
-        requestObjectParameters: RequestObjectParameters?,
-    ): AuthenticationRequestParameters = AuthenticationRequestParameters(
-        responseType = responseType,
-        clientId = if (populateClientId) clientIdScheme.clientId else null,
-        redirectUrl = if (!isAnyDirectPost) clientIdScheme.redirectUri else null,
-        responseUrl = responseUrl,
-        // Using scope as an alias for a well-defined Presentation Exchange or DCQL is not supported
-        scope = if (isSiop) buildScope() else null,
-        nonce = nonceAwareVerifier.provideNonce(),
-        walletNonce = requestObjectParameters?.walletNonce,
-        clientMetadata = clientMetadata(),
-        idTokenType = if (isSiop) IdTokenType.SUBJECT_SIGNED.text else null,
-        responseMode = responseMode,
-        state = null,
-        dcqlQuery = (presentationRequest as? DCQLRequest)?.dcqlQuery,
-        presentationDefinition = (presentationRequest as? PresentationExchangeRequest)?.presentationDefinition?.run {
-            copy(
-                inputDescriptors = inputDescriptors.map {
-                    when (it) {
-                        is DifInputDescriptor -> it.replaceAvailableFormatHolders()
+    private suspend fun OpenId4VpRequestOptions.toAuthnRequest(): AuthenticationRequestParameters =
+        AuthenticationRequestParameters(
+            responseType = responseType,
+            clientId = if (populateClientId) clientIdScheme.clientId else null,
+            redirectUrl = if (!isAnyDirectPost) clientIdScheme.redirectUri else null,
+            responseUrl = responseUrl,
+            // Using scope as an alias for a well-defined Presentation Exchange or DCQL is not supported
+            scope = if (isSiop) buildScope() else null,
+            nonce = nonceAwareVerifier.provideNonce(),
+            clientMetadata = clientMetadata(),
+            idTokenType = if (isSiop) IdTokenType.SUBJECT_SIGNED.text else null,
+            responseMode = responseMode,
+            state = null,
+            dcqlQuery = (presentationRequest as? DCQLRequest)?.dcqlQuery,
+            presentationDefinition = (presentationRequest as? PresentationExchangeRequest)?.presentationDefinition?.run {
+                copy(
+                    inputDescriptors = inputDescriptors.map {
+                        when (it) {
+                            is DifInputDescriptor -> it.replaceAvailableFormatHolders()
+                        }
                     }
-                }
-            )
-        },
-        transactionData = transactionData?.map { it.toBase64UrlJsonString() },
-        expectedOrigins = expectedOrigins,
-    )
+                )
+            },
+            transactionData = transactionData?.map { it.toBase64UrlJsonString() },
+            expectedOrigins = expectedOrigins,
+        )
 
     /**
      * Defining *some* non-null format container is our way of specifying the allowed credential representations,
@@ -329,7 +280,7 @@ class DcApiVerifier @JvmOverloads constructor(
         )
     )
 
-    internal suspend fun storeAuthnRequest(
+    private suspend fun storeAuthnRequest(
         authenticationRequestParameters: AuthenticationRequestParameters,
         externalId: String? = null,
     ) = stateToAuthnRequestStore.put(
@@ -403,26 +354,16 @@ class DcApiVerifier @JvmOverloads constructor(
         require(responseType != null) {
             "No response type was specified in the original authentication request."
         }
-
-        val expectedNonce = authnRequest.nonce
-            ?: throw IllegalArgumentException("nonce not present in $authnRequest")
-        val idTokenValidationResult = if (OpenIdConstants.ID_TOKEN in responseType) {
-            extractValidatedIdToken(input, expectedNonce)
-        } else {
-            null
-        }
-        val vpTokenValidationResult = if (OpenIdConstants.VP_TOKEN in responseType) {
-            validateVpToken(authnRequest, input)
-        } else {
-            null
-        }
-
-        require(listOfNotNull(idTokenValidationResult, vpTokenValidationResult).isNotEmpty()) {
+        require(OpenIdConstants.VP_TOKEN in responseType) {
             "Unsupported response type: $responseType"
         }
+        val expectedNonce = authnRequest.nonce
+            ?: throw IllegalArgumentException("nonce not present in $authnRequest")
+
+        val vpTokenValidationResult = validateVpToken(authnRequest, input)
 
         AuthnResponseResult(
-            idTokenValidationResult = idTokenValidationResult,
+            idTokenValidationResult = null,
             vpTokenValidationResult = vpTokenValidationResult,
             request = authnRequest,
         ).also {
@@ -458,44 +399,6 @@ class DcApiVerifier @JvmOverloads constructor(
                 "response_mode requires encryption, but no encrypted response was given"
             }
         return authnRequest
-    }
-
-    @Throws(IllegalArgumentException::class, CancellationException::class)
-    private suspend fun extractValidatedIdToken(
-        input: ResponseParametersFrom,
-        expectedNonce: String,
-    ): KmmResult<IdToken> = catching {
-        val idTokenJws = input.parameters.idToken
-            ?: throw IllegalArgumentException("idToken")
-        val jwsSigned = catching { JwsCompactTyped<IdToken>(idTokenJws) }
-            .getOrElse { throw IllegalArgumentException("idToken", it) }
-        verifyJwsObject(jwsSigned.jws).getOrElse {
-            throw IllegalArgumentException("idToken.", it)
-                .also { Napier.w { "JWS of idToken not verified: $idTokenJws" } }
-        }
-        val idToken = jwsSigned.payload
-        require(idToken.issuer == idToken.subject) {
-            "Wrong issuer: ${idToken.issuer}, expected: ${idToken.subject}"
-        }
-        require(idToken.audience == clientIdScheme.clientId) {
-            "audience not valid: ${idToken.audience}"
-        }
-        require(idToken.expiration >= (clock.now() - timeLeeway)) {
-            "expirationDate before now: ${idToken.expiration}"
-        }
-        require(idToken.issuedAt <= (clock.now() + timeLeeway)) {
-            "issuedAt after now: ${idToken.issuedAt}"
-        }
-        require(idToken.nonce == expectedNonce && nonceAwareVerifier.verifyNonce(expectedNonce)) {
-            "nonce not valid: ${idToken.nonce}, expected $expectedNonce"
-        }
-        require(idToken.subjectJwk != null) {
-            "sub_jwk is null"
-        }
-        require(idToken.subject == idToken.subjectJwk!!.jwkThumbprint) {
-            "subject does not equal thumbprint of sub_jwk: ${idToken.subject}"
-        }
-        idToken
     }
 
     /**
@@ -708,6 +611,17 @@ class DcApiVerifier @JvmOverloads constructor(
             hash = coseCompliantSerializer.encodeToByteArray<OpenID4VPDCAPIHandoverInfo>(
                 toBeHashed as? OpenID4VPDCAPIHandoverInfo
                     ?: throw IllegalArgumentException("Unsupported DCAPIHandoverInfo")
+            ).sha256(),
+        )
+    )
+
+    fun createDcApiSessionTranscriptAnnexC(
+        toBeHashed: SessionTranscriptContentHashable,
+    ): SessionTranscript = SessionTranscript.forDcApi(
+        DCAPIHandover(
+            type = TYPE_DCAPI,
+            hash = coseCompliantSerializer.encodeToByteArray(
+                toBeHashed as? DCAPIInfo ?: throw IllegalStateException("Expected DCAPIInfo")
             ).sha256(),
         )
     )

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/Iso180137AnnexCProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/Iso180137AnnexCProtocolTest.kt
@@ -1,0 +1,330 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.dcapi.DCAPIHandover
+import at.asitplus.dcapi.DCAPIHandover.Companion.TYPE_DCAPI
+import at.asitplus.dcapi.DCAPIInfo
+import at.asitplus.dcapi.DCAPIResponse
+import at.asitplus.dcapi.EncryptedResponse
+import at.asitplus.dcapi.EncryptedResponseData
+import at.asitplus.dcapi.request.IsoMdocRequest
+import at.asitplus.iso.DeviceAuthentication
+import at.asitplus.iso.SessionTranscript
+import at.asitplus.iso.serializeOrigin
+import at.asitplus.iso.sha256
+import at.asitplus.iso.wrapInCborTag
+import at.asitplus.openid.dcql.DCQLClaimsPathPointer
+import at.asitplus.signum.indispensable.CryptoPrivateKey
+import at.asitplus.signum.indispensable.CryptoPublicKey
+import at.asitplus.signum.indispensable.ECCurve
+import at.asitplus.signum.indispensable.KeyAgreementPrivateValue
+import at.asitplus.signum.indispensable.cosef.CoseKey
+import at.asitplus.signum.indispensable.cosef.io.ByteStringWrapper
+import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
+import at.asitplus.signum.indispensable.cosef.toCoseKey
+import at.asitplus.signum.indispensable.symmetric.SymmetricEncryptionAlgorithm
+import at.asitplus.signum.indispensable.symmetric.authTag
+import at.asitplus.signum.indispensable.symmetric.keyFrom
+import at.asitplus.signum.indispensable.symmetric.nonce
+import at.asitplus.signum.supreme.agree.Ephemeral
+import at.asitplus.signum.supreme.agree.keyAgreement
+import at.asitplus.signum.supreme.symmetric.decrypt
+import at.asitplus.signum.supreme.symmetric.encrypt
+import at.asitplus.testballoon.matrix.fixture
+import at.asitplus.testballoon.matrix.matrixSuite
+import at.asitplus.wallet.lib.RequestOptionsCredential
+import at.asitplus.wallet.lib.agent.CreatePresentationResult
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithSelfSignedCert
+import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
+import at.asitplus.wallet.lib.agent.Holder
+import at.asitplus.wallet.lib.agent.HolderAgent
+import at.asitplus.wallet.lib.agent.IssuerAgent
+import at.asitplus.wallet.lib.agent.KeyMaterial
+import at.asitplus.wallet.lib.agent.PresentationRequestParameters
+import at.asitplus.wallet.lib.agent.PresentationResponseParameters
+import at.asitplus.wallet.lib.agent.RandomSource
+import at.asitplus.wallet.lib.agent.toStoreCredentialInput
+import at.asitplus.wallet.lib.cbor.SignCoseDetached
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_DATE_OF_BIRTH
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
+import at.asitplus.wallet.lib.data.rfc3986.toUri
+import at.asitplus.wallet.lib.iso.Iso180137AnnexCRequestOptions
+import at.asitplus.wallet.lib.iso.Iso180137AnnexCVerifier
+import at.asitplus.wallet.lib.utils.DefaultMapStore
+import com.benasher44.uuid.uuid4
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.builtins.ByteArraySerializer
+import kotlinx.serialization.encodeToByteArray
+
+/**
+ * Tests [Iso180137AnnexCVerifier] against a simulated wallet performing an ISO/IEC 18013-7 Annex C
+ * presentation over the Digital Credentials API, analogous to [OpenId4VpDcApiProtocolTest].
+ */
+val Iso180137AnnexCProtocolTest by matrixSuite {
+
+    val callingOrigin = "https://example.com"
+
+    val requestedCredential = RequestOptionsCredential(
+        credentialScheme = AtomicAttribute2023,
+        representation = ISO_MDOC,
+        attributePaths = setOf(
+            DCQLClaimsPathPointer(CLAIM_GIVEN_NAME),
+            DCQLClaimsPathPointer(CLAIM_DATE_OF_BIRTH),
+        ),
+    )
+    val deviceRequest = CredentialPresentationRequestBuilder(requestedCredential).toIso180137AnnexCDeviceRequest()
+
+    fixture({
+        kotlinx.coroutines.runBlocking {
+            val holderKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert()
+            val holderAgent = HolderAgent(holderKeyMaterial).also { agent ->
+                agent.storeCredential(
+                    IssuerAgent(
+                        keyMaterial = EphemeralKeyWithSelfSignedCert(),
+                        identifier = "https://issuer.example.com/".toUri(),
+                        randomSource = RandomSource.Default,
+                    ).issueCredential(
+                        DummyCredentialDataProvider.getCredential(
+                            holderKeyMaterial.publicKey,
+                            AtomicAttribute2023,
+                            ISO_MDOC,
+                        ).getOrThrow()
+                    ).getOrThrow().toStoreCredentialInput()
+                ).getOrThrow()
+            }
+            object {
+                val decryptionKeyMaterial = EphemeralKeyWithoutCert()
+                val stateToIsoMdocRequestStore = DefaultMapStore<String, IsoMdocRequest>()
+                val verifier = Iso180137AnnexCVerifier(
+                    stateToIsoMdocRequestStore = stateToIsoMdocRequestStore,
+                    decryptionKeyMaterial = decryptionKeyMaterial,
+                )
+
+                suspend fun walletResponse(
+                    isoMdocRequest: IsoMdocRequest,
+                    origin: String = callingOrigin,
+                ) = createWalletResponse(holderAgent, holderKeyMaterial, isoMdocRequest, origin, requestedCredential)
+            }
+        }
+    }) - {
+
+        test("createRequest contains device request and encryption info, and remembers the request") { f ->
+            val transactionId = uuid4().toString()
+            val isoMdocRequest = f.verifier.createRequest(
+                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
+            )
+
+            isoMdocRequest.deviceRequest shouldBe deviceRequest
+            isoMdocRequest.encryptionInfo.type shouldBe TYPE_DCAPI
+            isoMdocRequest.encryptionInfo.encryptionParameters.nonce.shouldNotBeNull()
+            isoMdocRequest.encryptionInfo.encryptionParameters.recipientPublicKey shouldBe
+                    f.decryptionKeyMaterial.publicKey.toCoseKey().getOrThrow()
+
+            f.stateToIsoMdocRequestStore.get(transactionId) shouldBe isoMdocRequest
+        }
+
+        test("Annex C walk-through: wallet response validates and contains requested claims") { f ->
+            val transactionId = uuid4().toString()
+            val isoMdocRequest = f.verifier.createRequest(
+                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
+            )
+
+            val dcApiResponse = f.walletResponse(isoMdocRequest)
+
+            val result = f.verifier.validateResponse(
+                receivedData = dcApiResponse,
+                externalId = transactionId,
+                decryptHpke = ::testHpkeOpen,
+                expectedOrigin = callingOrigin,
+            ).getOrThrow()
+
+            result.documents.shouldBeSingleton().first().apply {
+                validItems.firstOrNull { it.elementIdentifier == CLAIM_GIVEN_NAME }
+                    .shouldNotBeNull().elementValue shouldBe "Susanne"
+                validItems.firstOrNull { it.elementIdentifier == CLAIM_DATE_OF_BIRTH }
+                    .shouldNotBeNull().elementValue shouldBe LocalDate(1990, 1, 1)
+                invalidItems shouldBe emptyList()
+            }
+        }
+
+        test("origin mismatch: session transcript differs, device signature verification fails") { f ->
+            val transactionId = uuid4().toString()
+            val isoMdocRequest = f.verifier.createRequest(
+                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
+            )
+
+            val dcApiResponse = f.walletResponse(isoMdocRequest)
+
+            f.verifier.validateResponse(
+                receivedData = dcApiResponse,
+                externalId = transactionId,
+                decryptHpke = ::testHpkeOpen,
+                expectedOrigin = "https://evil.example.com",
+            ).isFailure shouldBe true
+        }
+
+        test("wallet responding to a different encryption info fails validation") { f ->
+            val transactionId = uuid4().toString()
+            val isoMdocRequest = f.verifier.createRequest(
+                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
+            )
+            // wallet answers a request with the same decryption key, but a different nonce,
+            // i.e. its session transcript is not the one the verifier will calculate
+            val otherRequest = isoMdocRequest.copy(
+                encryptionInfo = isoMdocRequest.encryptionInfo.copy(
+                    encryptionParameters = isoMdocRequest.encryptionInfo.encryptionParameters.copy(
+                        nonce = ByteArray(16) { it.toByte() }
+                    )
+                )
+            )
+
+            val dcApiResponse = f.walletResponse(otherRequest)
+
+            f.verifier.validateResponse(
+                receivedData = dcApiResponse,
+                externalId = transactionId,
+                decryptHpke = ::testHpkeOpen,
+                expectedOrigin = callingOrigin,
+            ).isFailure shouldBe true
+        }
+
+        test("unknown transaction id fails validation") { f ->
+            val transactionId = uuid4().toString()
+            val isoMdocRequest = f.verifier.createRequest(
+                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
+            )
+
+            val dcApiResponse = f.walletResponse(isoMdocRequest)
+
+            f.verifier.validateResponse(
+                receivedData = dcApiResponse,
+                externalId = "unknown-${uuid4()}",
+                decryptHpke = ::testHpkeOpen,
+                expectedOrigin = callingOrigin,
+            ).isFailure shouldBe true
+        }
+
+        test("tampered ciphertext fails validation") { f ->
+            val transactionId = uuid4().toString()
+            val isoMdocRequest = f.verifier.createRequest(
+                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
+            )
+
+            val dcApiResponse = f.walletResponse(isoMdocRequest)
+            val tampered = dcApiResponse.response.encryptedResponseData.cipherText
+                .also { it[0] = (it[0].toInt() xor 0x01).toByte() }
+                .let { DCAPIResponse(EncryptedResponse(TYPE_DCAPI, EncryptedResponseData(dcApiResponse.response.encryptedResponseData.enc, it))) }
+
+            f.verifier.validateResponse(
+                receivedData = tampered,
+                externalId = transactionId,
+                decryptHpke = ::testHpkeOpen,
+                expectedOrigin = callingOrigin,
+            ).isFailure shouldBe true
+        }
+    }
+}
+
+/**
+ * Simulates the wallet: computes the Annex C session transcript from the received [isoMdocRequest]
+ * and its own [origin], creates a device response with the device signature over that transcript,
+ * and encrypts it to the verifier's public key from the encryption info.
+ */
+private suspend fun createWalletResponse(
+    holder: Holder,
+    holderKeyMaterial: KeyMaterial,
+    isoMdocRequest: IsoMdocRequest,
+    origin: String,
+    requestedCredential: RequestOptionsCredential,
+): DCAPIResponse {
+    val sessionTranscript = SessionTranscript.forDcApi(
+        DCAPIHandover(
+            type = TYPE_DCAPI,
+            hash = coseCompliantSerializer.encodeToByteArray(
+                DCAPIInfo(isoMdocRequest.encryptionInfo, origin.serializeOrigin()!!)
+            ).sha256(),
+        )
+    )
+    val signer = SignCoseDetached<ByteArray>(keyMaterial = holderKeyMaterial)
+    val deviceResponse = holder.createDefaultPresentation(
+        request = PresentationRequestParameters(
+            nonce = uuid4().toString(), // not relevant for mdoc device authentication
+            audience = origin,
+            calcIsoDeviceSignaturePlain = { input ->
+                signer(
+                    protectedHeader = null,
+                    unprotectedHeader = null,
+                    payload = coseCompliantSerializer.encodeToByteArray(
+                        ByteStringWrapper(
+                            DeviceAuthentication(
+                                type = DeviceAuthentication.TYPE,
+                                sessionTranscript = sessionTranscript,
+                                docType = input.docType,
+                                namespaces = input.deviceNameSpaceBytes,
+                            )
+                        )
+                    ).wrapInCborTag(24),
+                    serializer = ByteArraySerializer(),
+                ).getOrThrow()
+            }
+        ),
+        credentialPresentationRequest = CredentialPresentationRequestBuilder(requestedCredential).toDCQLRequest()!!,
+    ).getOrThrow()
+        .shouldBeInstanceOf<PresentationResponseParameters.DCQLParameters>()
+        .verifiablePresentations.values.shouldBeSingleton().first().shouldBeSingleton().first()
+        .shouldBeInstanceOf<CreatePresentationResult.DeviceResponse>()
+        .deviceResponse
+
+    val encryptedResponseData = testHpkeSeal(
+        recipientPublicKey = isoMdocRequest.encryptionInfo.encryptionParameters.recipientPublicKey,
+        plaintext = coseCompliantSerializer.encodeToByteArray(deviceResponse),
+        info = coseCompliantSerializer.encodeToByteArray(sessionTranscript),
+    )
+    return DCAPIResponse(EncryptedResponse(TYPE_DCAPI, encryptedResponseData))
+}
+
+// ponytail: stand-in for HPKE (RFC 9180), which is not available in signum supreme 0.14:
+// ephemeral ECDH + SHA-256 KDF over (sharedSecret || info) + AES-256-GCM.
+// [Iso180137AnnexCVerifier.validateResponse] takes the HPKE decryption function as a parameter,
+// so actual HPKE interop is out of scope here; this pair still binds the response to the
+// verifier's decryption key and the session transcript. Replace with signum HPKE once available.
+private suspend fun testHpkeSeal(
+    recipientPublicKey: CoseKey,
+    plaintext: ByteArray,
+    info: ByteArray,
+): EncryptedResponseData {
+    val recipientKey = recipientPublicKey.toCryptoPublicKey().getOrThrow() as CryptoPublicKey.EC
+    val ephemeralKey = KeyAgreementPrivateValue.ECDH.Ephemeral(ECCurve.SECP_256_R_1).getOrThrow()
+    val sharedSecret = ephemeralKey.keyAgreement(recipientKey).getOrThrow()
+    val sealedBox = testHpkeKey(sharedSecret, info).encrypt(plaintext).getOrThrow()
+    return EncryptedResponseData(
+        enc = ephemeralKey.publicValue.asCryptoPublicKey().iosEncoded,
+        cipherText = sealedBox.nonce + sealedBox.encryptedData + sealedBox.authTag,
+    )
+}
+
+private suspend fun testHpkeOpen(
+    enc: ByteArray,
+    cipherText: ByteArray,
+    recipientPrivateKey: CryptoPrivateKey.EC.WithPublicKey,
+    info: ByteArray,
+): ByteArray {
+    val ephemeralPublicKey = CryptoPublicKey.fromIosEncoded(enc) as CryptoPublicKey.EC
+    val sharedSecret = (recipientPrivateKey as KeyAgreementPrivateValue).keyAgreement(ephemeralPublicKey).getOrThrow()
+    return testHpkeKey(sharedSecret, info).decrypt(
+        nonce = cipherText.copyOfRange(0, NONCE_LENGTH),
+        encryptedData = cipherText.copyOfRange(NONCE_LENGTH, cipherText.size - AUTH_TAG_LENGTH),
+        authTag = cipherText.copyOfRange(cipherText.size - AUTH_TAG_LENGTH, cipherText.size),
+    ).getOrThrow()
+}
+
+private fun testHpkeKey(sharedSecret: ByteArray, info: ByteArray) =
+    SymmetricEncryptionAlgorithm.AES_256.GCM.keyFrom((sharedSecret + info).sha256()).getOrThrow()
+
+private const val NONCE_LENGTH = 12
+private const val AUTH_TAG_LENGTH = 16

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/Iso180137AnnexCProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/Iso180137AnnexCProtocolTest.kt
@@ -7,11 +7,15 @@ import at.asitplus.dcapi.DCAPIResponse
 import at.asitplus.dcapi.EncryptedResponse
 import at.asitplus.dcapi.EncryptedResponseData
 import at.asitplus.dcapi.request.IsoMdocRequest
+import at.asitplus.dcapi.request.verifier.CredentialRequestOptions
+import at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest
 import at.asitplus.iso.DeviceAuthentication
+import at.asitplus.iso.SingleItemsRequest
 import at.asitplus.iso.SessionTranscript
 import at.asitplus.iso.serializeOrigin
 import at.asitplus.iso.sha256
 import at.asitplus.iso.wrapInCborTag
+import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.dcql.DCQLClaimsPathPointer
 import at.asitplus.signum.indispensable.CryptoPrivateKey
 import at.asitplus.signum.indispensable.CryptoPublicKey
@@ -49,8 +53,6 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_DATE_
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.rfc3986.toUri
-import at.asitplus.wallet.lib.iso.Iso180137AnnexCRequestOptions
-import at.asitplus.wallet.lib.iso.Iso180137AnnexCVerifier
 import at.asitplus.wallet.lib.utils.DefaultMapStore
 import com.benasher44.uuid.uuid4
 import io.kotest.matchers.collections.shouldBeSingleton
@@ -62,7 +64,7 @@ import kotlinx.serialization.builtins.ByteArraySerializer
 import kotlinx.serialization.encodeToByteArray
 
 /**
- * Tests [Iso180137AnnexCVerifier] against a simulated wallet performing an ISO/IEC 18013-7 Annex C
+ * Tests [DcApiVerifier] against a simulated wallet performing an ISO/IEC 18013-7 Annex C
  * presentation over the Digital Credentials API, analogous to [OpenId4VpDcApiProtocolTest].
  */
 val Iso180137AnnexCProtocolTest by matrixSuite {
@@ -77,7 +79,7 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
             DCQLClaimsPathPointer(CLAIM_DATE_OF_BIRTH),
         ),
     )
-    val deviceRequest = CredentialPresentationRequestBuilder(requestedCredential).toIso180137AnnexCDeviceRequest()
+    val dcqlRequest = CredentialPresentationRequestBuilder(requestedCredential).toDCQLRequest()!!
 
     fixture({
         kotlinx.coroutines.runBlocking {
@@ -100,10 +102,30 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
             object {
                 val decryptionKeyMaterial = EphemeralKeyWithoutCert()
                 val stateToIsoMdocRequestStore = DefaultMapStore<String, IsoMdocRequest>()
-                val verifier = Iso180137AnnexCVerifier(
+                val verifier = DcApiVerifier(
+                    clientIdScheme = ClientIdScheme.PreRegistered(
+                        clientId = "dc-api-rp-${uuid4()}",
+                        redirectUri = "https://example.com/callback",
+                    ),
                     stateToIsoMdocRequestStore = stateToIsoMdocRequestStore,
                     decryptionKeyMaterial = decryptionKeyMaterial,
+                    decryptHpke = ::testHpkeOpen,
                 )
+
+                /** Extracts the Annex C request from the browser-facing [CredentialRequestOptions]. */
+                suspend fun createIsoMdocRequest(transactionId: String): IsoMdocRequest = verifier
+                    .createAuthnRequest(
+                        OpenId4VpRequestOptions(
+                            presentationRequest = dcqlRequest,
+                            responseMode = OpenIdConstants.ResponseMode.DcApi,
+                            expectedOrigins = listOf(callingOrigin),
+                            state = transactionId,
+                        ),
+                        DcApiCreationOptions.Iso180137AnnexC,
+                    ).getOrThrow()
+                    .digital.requests.shouldBeSingleton().first()
+                    .shouldBeInstanceOf<DigitalCredentialGetRequest.IsoMdoc>()
+                    .data
 
                 suspend fun walletResponse(
                     isoMdocRequest: IsoMdocRequest,
@@ -113,13 +135,16 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
         }
     }) - {
 
-        test("createRequest contains device request and encryption info, and remembers the request") { f ->
+        test("createAuthnRequest renders device request and encryption info, and remembers the request") { f ->
             val transactionId = uuid4().toString()
-            val isoMdocRequest = f.verifier.createRequest(
-                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
-            )
+            val isoMdocRequest = f.createIsoMdocRequest(transactionId)
 
-            isoMdocRequest.deviceRequest shouldBe deviceRequest
+            val itemsRequest = isoMdocRequest.deviceRequest.docRequests.single().itemsRequest.value
+            itemsRequest.docType shouldBe AtomicAttribute2023.isoDocType
+            itemsRequest.namespaces[AtomicAttribute2023.isoNamespace]!!.entries shouldBe listOf(
+                SingleItemsRequest(CLAIM_GIVEN_NAME, false),
+                SingleItemsRequest(CLAIM_DATE_OF_BIRTH, false),
+            )
             isoMdocRequest.encryptionInfo.type shouldBe TYPE_DCAPI
             isoMdocRequest.encryptionInfo.encryptionParameters.nonce.shouldNotBeNull()
             isoMdocRequest.encryptionInfo.encryptionParameters.recipientPublicKey shouldBe
@@ -130,16 +155,13 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
 
         test("Annex C walk-through: wallet response validates and contains requested claims") { f ->
             val transactionId = uuid4().toString()
-            val isoMdocRequest = f.verifier.createRequest(
-                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
-            )
+            val isoMdocRequest = f.createIsoMdocRequest(transactionId)
 
             val dcApiResponse = f.walletResponse(isoMdocRequest)
 
             val result = f.verifier.validateResponse(
                 receivedData = dcApiResponse,
                 externalId = transactionId,
-                decryptHpke = ::testHpkeOpen,
                 expectedOrigin = callingOrigin,
             ).getOrThrow()
 
@@ -154,25 +176,20 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
 
         test("origin mismatch: session transcript differs, device signature verification fails") { f ->
             val transactionId = uuid4().toString()
-            val isoMdocRequest = f.verifier.createRequest(
-                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
-            )
+            val isoMdocRequest = f.createIsoMdocRequest(transactionId)
 
             val dcApiResponse = f.walletResponse(isoMdocRequest)
 
             f.verifier.validateResponse(
                 receivedData = dcApiResponse,
                 externalId = transactionId,
-                decryptHpke = ::testHpkeOpen,
                 expectedOrigin = "https://evil.example.com",
             ).isFailure shouldBe true
         }
 
         test("wallet responding to a different encryption info fails validation") { f ->
             val transactionId = uuid4().toString()
-            val isoMdocRequest = f.verifier.createRequest(
-                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
-            )
+            val isoMdocRequest = f.createIsoMdocRequest(transactionId)
             // wallet answers a request with the same decryption key, but a different nonce,
             // i.e. its session transcript is not the one the verifier will calculate
             val otherRequest = isoMdocRequest.copy(
@@ -188,32 +205,26 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
             f.verifier.validateResponse(
                 receivedData = dcApiResponse,
                 externalId = transactionId,
-                decryptHpke = ::testHpkeOpen,
                 expectedOrigin = callingOrigin,
             ).isFailure shouldBe true
         }
 
         test("unknown transaction id fails validation") { f ->
             val transactionId = uuid4().toString()
-            val isoMdocRequest = f.verifier.createRequest(
-                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
-            )
+            val isoMdocRequest = f.createIsoMdocRequest(transactionId)
 
             val dcApiResponse = f.walletResponse(isoMdocRequest)
 
             f.verifier.validateResponse(
                 receivedData = dcApiResponse,
                 externalId = "unknown-${uuid4()}",
-                decryptHpke = ::testHpkeOpen,
                 expectedOrigin = callingOrigin,
             ).isFailure shouldBe true
         }
 
         test("tampered ciphertext fails validation") { f ->
             val transactionId = uuid4().toString()
-            val isoMdocRequest = f.verifier.createRequest(
-                Iso180137AnnexCRequestOptions(deviceRequest, transactionId)
-            )
+            val isoMdocRequest = f.createIsoMdocRequest(transactionId)
 
             val dcApiResponse = f.walletResponse(isoMdocRequest)
             val tampered = dcApiResponse.response.encryptedResponseData.cipherText
@@ -223,7 +234,6 @@ val Iso180137AnnexCProtocolTest by matrixSuite {
             f.verifier.validateResponse(
                 receivedData = tampered,
                 externalId = transactionId,
-                decryptHpke = ::testHpkeOpen,
                 expectedOrigin = callingOrigin,
             ).isFailure shouldBe true
         }
@@ -290,7 +300,7 @@ private suspend fun createWalletResponse(
 
 // ponytail: stand-in for HPKE (RFC 9180), which is not available in signum supreme 0.14:
 // ephemeral ECDH + SHA-256 KDF over (sharedSecret || info) + AES-256-GCM.
-// [Iso180137AnnexCVerifier.validateResponse] takes the HPKE decryption function as a parameter,
+// [DcApiVerifier.validateResponse] takes the HPKE decryption function as a parameter,
 // so actual HPKE interop is out of scope here; this pair still binds the response to the
 // verifier's decryption key and the session transcript. Replace with signum HPKE once available.
 private suspend fun testHpkeSeal(

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
@@ -3,12 +3,17 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.dcapi.OpenId4VpResponseMultiSigned
 import at.asitplus.dcapi.OpenId4VpResponseSigned
 import at.asitplus.dcapi.OpenId4VpResponseUnsigned
+import at.asitplus.dcapi.request.verifier.CredentialRequestOptions
+import at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RequestParametersFrom
+import at.asitplus.signum.indispensable.josef.JwsCompact
+import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JwsTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.toJwsFlattened
+import at.asitplus.signum.indispensable.josef.typed
 import at.asitplus.testballoon.matrix.fixture
 import at.asitplus.testballoon.matrix.matrixSuite
 import at.asitplus.wallet.lib.RequestOptionsCredential
@@ -23,6 +28,8 @@ import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import com.benasher44.uuid.uuid4
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -68,18 +75,47 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                         redirectUri = "https://example.com/callback",
                     ),
                 )
+
+                /** Extracts the unsigned authn request from the browser-facing [CredentialRequestOptions]. */
+                suspend fun createUnsignedAuthnRequest(
+                    reqOptions: OpenId4VpRequestOptions,
+                ): AuthenticationRequestParameters = dcApiVerifier
+                    .createAuthnRequest(reqOptions, DcApiCreationOptions.OpenId4VpUnsigned).getOrThrow()
+                    .singleRequest<DigitalCredentialGetRequest.OpenId4VpUnsigned>()
+                    .data
+
+                /** Extracts the signed authn request from the browser-facing [CredentialRequestOptions]. */
+                suspend fun createSignedAuthnRequest(
+                    reqOptions: OpenId4VpRequestOptions,
+                ): JwsCompactTyped<AuthenticationRequestParameters> = dcApiVerifier
+                    .createAuthnRequest(reqOptions, DcApiCreationOptions.OpenId4VpSigned).getOrThrow()
+                    .singleRequest<DigitalCredentialGetRequest.OpenId4VpSigned>()
+                    .data.request
+                    .typed<AuthenticationRequestParameters, JwsCompact>()
             }
         }
     }) - {
+
+        test("createAuthnRequest rejects response modes other than DC API") { f ->
+            val reqOptions = OpenId4VpRequestOptions(
+                presentationRequest = dcqlRequest,
+                responseMode = OpenIdConstants.ResponseMode.Fragment,
+            )
+            f.dcApiVerifier.createAuthnRequest(reqOptions, DcApiCreationOptions.OpenId4VpUnsigned)
+                .isFailure shouldBe true
+            f.dcApiVerifier.createAuthnRequest(reqOptions, DcApiCreationOptions.OpenId4VpSigned)
+                .isFailure shouldBe true
+        }
 
         test("DC API unsigned: parsed as DcApiUnsigned, validates and responds with OpenId4VpResponseUnsigned") { f ->
             val reqOptions = OpenId4VpRequestOptions(
                 presentationRequest = dcqlRequest,
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
-                // client_id is populated, but the Wallet MUST ignore it for unsigned DC API requests
             )
-            val authnRequest = f.dcApiVerifier.createPlainAuthnRequest(reqOptions)
+            val authnRequest = f.createUnsignedAuthnRequest(reqOptions)
+            // client_id MUST be omitted in unsigned requests, per OpenID4VP 1.0 Appendix A.3.1
+            authnRequest.clientId.shouldBeNull()
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiUnsigned(
                 parameters = authnRequest,
@@ -102,13 +138,12 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
         test("DC API unsigned: SD-JWT response validates with origin audience") { f ->
             val rpOrigin = "https://wallet-rp.a-sit.plus"
             val transactionId = uuid4().toString()
-            val authnRequest = f.dcApiVerifier.createPlainAuthnRequest(
+            val authnRequest = f.createUnsignedAuthnRequest(
                 OpenId4VpRequestOptions(
                     presentationRequest = dcqlRequest,
                     responseMode = OpenIdConstants.ResponseMode.DcApi,
                     responseUrl = "$rpOrigin/transaction/result/$transactionId",
                     expectedOrigins = listOf(rpOrigin),
-                    populateClientId = false,
                     state = transactionId,
                 )
             )
@@ -141,7 +176,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.dcApiVerifier.createSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.createSignedAuthnRequest(reqOptions)
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
                 jwsTyped = signedRequest,
@@ -167,7 +202,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.dcApiVerifier.createSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.createSignedAuthnRequest(reqOptions)
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
                 jwsTyped = JwsTyped<AuthenticationRequestParameters>(listOf(signedRequest.jws.toJwsFlattened())),
@@ -193,7 +228,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.dcApiVerifier.createSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.createSignedAuthnRequest(reqOptions)
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiMultiSigned(
                 jwsTyped = JwsTyped<AuthenticationRequestParameters>(listOf(signedRequest.jws.toJwsFlattened())),
@@ -214,7 +249,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.dcApiVerifier.createSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.createSignedAuthnRequest(reqOptions)
 
             val dcApiRequest = RequestParametersFrom.OpenId4VpDcApiSigned(
                 jwsTyped = signedRequest,
@@ -235,7 +270,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 responseMode = OpenIdConstants.ResponseMode.DcApi,
                 expectedOrigins = listOf(callingOrigin),
             )
-            val signedRequest = f.dcApiVerifier.createSignedRequestObject(reqOptions).getOrThrow()
+            val signedRequest = f.createSignedAuthnRequest(reqOptions)
 
             // Simulate a (third-party) signed request that omits expected_origins entirely.
             val withoutExpectedOrigins = JwsTyped(
@@ -256,3 +291,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
         }
     }
 }
+
+/** Extracts the single [DigitalCredentialGetRequest] of the expected protocol, as a wallet would receive it. */
+private inline fun <reified T : DigitalCredentialGetRequest> CredentialRequestOptions.singleRequest(): T =
+    digital.requests.shouldBeSingleton().first().shouldBeInstanceOf<T>()

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpDcApiProtocolTest.kt
@@ -1,13 +1,16 @@
 package at.asitplus.wallet.lib.openid
 
+import at.asitplus.dcapi.DCAPIHandover
 import at.asitplus.dcapi.OpenId4VpResponseMultiSigned
 import at.asitplus.dcapi.OpenId4VpResponseSigned
 import at.asitplus.dcapi.OpenId4VpResponseUnsigned
 import at.asitplus.dcapi.request.verifier.CredentialRequestOptions
 import at.asitplus.dcapi.request.verifier.DigitalCredentialGetRequest
+import at.asitplus.iso.SingleItemsRequest
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.OpenIdConstants
 import at.asitplus.openid.RequestParametersFrom
+import at.asitplus.openid.dcql.DCQLClaimsPathPointer
 import at.asitplus.signum.indispensable.josef.JwsCompact
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.JwsTyped
@@ -25,14 +28,18 @@ import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.agent.RandomSource
 import at.asitplus.wallet.lib.agent.toStoreCredentialInput
 import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023
+import at.asitplus.wallet.lib.data.ConstantIndex.AtomicAttribute2023.CLAIM_GIVEN_NAME
+import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.ISO_MDOC
 import at.asitplus.wallet.lib.data.ConstantIndex.CredentialRepresentation.SD_JWT
 import at.asitplus.wallet.lib.data.rfc3986.toUri
 import com.benasher44.uuid.uuid4
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.runBlocking
 
 val OpenId4VpDcApiProtocolTest by matrixSuite {
 
@@ -44,8 +51,8 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
         RequestOptionsCredential(AtomicAttribute2023, SD_JWT),
     ).toDCQLRequest()
 
-    fixture({
-        kotlinx.coroutines.runBlocking {
+    fixture {
+        runBlocking {
             val holderKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert()
             val holderAgent: Holder = HolderAgent(holderKeyMaterial).also { agent ->
                 agent.storeCredential(
@@ -67,11 +74,10 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                     holder = holderAgent,
                     randomSource = RandomSource.Default,
                 )
-                val clientId: String = "dc-api-rp-${uuid4()}"
                 val dcApiVerifier = DcApiVerifier(
                     keyMaterial = EphemeralKeyWithoutCert(),
                     clientIdScheme = ClientIdScheme.PreRegistered(
-                        clientId = clientId,
+                        clientId = "dc-api-rp-${uuid4()}",
                         redirectUri = "https://example.com/callback",
                     ),
                 )
@@ -94,7 +100,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                     .typed<AuthenticationRequestParameters, JwsCompact>()
             }
         }
-    }) - {
+    } - {
 
         test("createAuthnRequest rejects response modes other than DC API") { f ->
             val reqOptions = OpenId4VpRequestOptions(
@@ -104,6 +110,42 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
             f.dcApiVerifier.createAuthnRequest(reqOptions, DcApiCreationOptions.OpenId4VpUnsigned)
                 .isFailure shouldBe true
             f.dcApiVerifier.createAuthnRequest(reqOptions, DcApiCreationOptions.OpenId4VpSigned)
+                .isFailure shouldBe true
+        }
+
+        test("DC API Annex C: createAuthnRequest renders the DCQL query as ISO device request") { f ->
+            val isoDcqlRequest = CredentialPresentationRequestBuilder(
+                RequestOptionsCredential(
+                    credentialScheme = AtomicAttribute2023,
+                    representation = ISO_MDOC,
+                    attributePaths = setOf(DCQLClaimsPathPointer(CLAIM_GIVEN_NAME)),
+                ),
+            ).toDCQLRequest()
+            val reqOptions = OpenId4VpRequestOptions(
+                presentationRequest = isoDcqlRequest,
+                responseMode = OpenIdConstants.ResponseMode.DcApi,
+                expectedOrigins = listOf(callingOrigin),
+            )
+
+            val isoMdocRequest = f.dcApiVerifier.createAuthnRequest(reqOptions, DcApiCreationOptions.Iso180137AnnexC)
+                .getOrThrow().singleRequest<DigitalCredentialGetRequest.IsoMdoc>()
+                .data
+
+            val itemsRequest = isoMdocRequest.deviceRequest.docRequests.single().itemsRequest.value
+            itemsRequest.docType shouldBe AtomicAttribute2023.isoDocType
+            itemsRequest.namespaces[AtomicAttribute2023.isoNamespace]!!.entries.single() shouldBe
+                    SingleItemsRequest(CLAIM_GIVEN_NAME, false)
+            isoMdocRequest.encryptionInfo.type shouldBe DCAPIHandover.TYPE_DCAPI
+            isoMdocRequest.encryptionInfo.encryptionParameters.nonce.shouldNotBeNull()
+        }
+
+        test("DC API Annex C: createAuthnRequest rejects non-mdoc DCQL queries") { f ->
+            val reqOptions = OpenId4VpRequestOptions(
+                presentationRequest = dcqlRequest, // SD-JWT credential query
+                responseMode = OpenIdConstants.ResponseMode.DcApi,
+                expectedOrigins = listOf(callingOrigin),
+            )
+            f.dcApiVerifier.createAuthnRequest(reqOptions, DcApiCreationOptions.Iso180137AnnexC)
                 .isFailure shouldBe true
         }
 
@@ -163,6 +205,7 @@ val OpenId4VpDcApiProtocolTest by matrixSuite {
                 .copy(origin = rpOrigin)
 
             val validation = f.dcApiVerifier.validateAuthnResponse(response, transactionId).getOrThrow()
+                .shouldBeInstanceOf<AuthnResponseResult>()
                 .vpTokenValidationResult!!.getOrThrow()
                 .shouldBeInstanceOf<VpTokenValidationResultDCQL>()
                 .credentialQueryResponseValidations.values.single().single()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/AbstractMdocVerifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/AbstractMdocVerifier.kt
@@ -39,17 +39,20 @@ abstract class AbstractMdocVerifier {
         val deviceSignature = document.deviceSigned.deviceAuth.deviceSignature
             ?: throw IllegalArgumentException("deviceSignature is null")
 
-        val expected = document.calcDeviceAuthenticationOpenId4VpFinal(
+        val expectedDetachedPayload = DeviceAuthentication(
+            type = DeviceAuthentication.TYPE,
             sessionTranscript = sessionTranscript,
+            docType = document.docType,
+            namespaces = document.deviceSigned.namespaces
         ).wrapAsExpectedPayload()
 
         verifyCoseSignature(
             coseSigned = deviceSignature,
             signer = mso.deviceKeyInfo.deviceKey,
             externalAad = byteArrayOf(),
-            detachedPayload = expected
+            detachedPayload = expectedDetachedPayload
         ).onFailure {
-            throw IllegalArgumentException("deviceSignature not matching ${expected.encodeToString(Base16())}", it)
+            throw IllegalArgumentException("deviceSignature not matching ${expectedDetachedPayload.encodeToString(Base16())}", it)
         }
         true
     }
@@ -58,18 +61,5 @@ abstract class AbstractMdocVerifier {
         .encodeToByteArray(coseCompliantSerializer.encodeToByteArray(this))
         .wrapInCborTag(24)
 
-
-    /**
-     * Performs calculation of the [at.asitplus.iso.DeviceAuthentication],
-     * acc. to ISO 18013. Can take session transcripts acc. to ISO 18013 or OpenID4VP 1.0
-     */
-    private fun Document.calcDeviceAuthenticationOpenId4VpFinal(
-        sessionTranscript: SessionTranscript,
-    ) = DeviceAuthentication(
-        type = DeviceAuthentication.TYPE,
-        sessionTranscript = sessionTranscript,
-        docType = docType,
-        namespaces = deviceSigned.namespaces
-    )
 
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialPresentationRequest.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/CredentialPresentationRequest.kt
@@ -61,5 +61,6 @@ sealed interface CredentialPresentationRequest {
             presentationRequest = this,
             credentialQuerySubmissions = credentialQuerySubmissions
         )
+
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCRequestOptions.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCRequestOptions.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.iso
 import at.asitplus.iso.DeviceRequest
 import at.asitplus.wallet.lib.RequestOptions
 
+@Deprecated("Use OpenId4VpRequestOptions and DcApiVerifier instead")
 data class Iso180137AnnexCRequestOptions(
     /**
      * Device request can be built using [CredentialPresentationRequestBuilder]

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCVerifiedPresentationResult.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCVerifiedPresentationResult.kt
@@ -2,9 +2,7 @@ package at.asitplus.wallet.lib.iso
 
 import at.asitplus.wallet.lib.data.IsoDocumentParsed
 
-/**
- * Validation results of ISO 18013-7 presentation
- */
+@Deprecated("Use Iso180137AnnexCWrapper and DcApiVerifier instead")
 data class Iso180137AnnexCVerifiedPresentationResult(
     val documents: Collection<IsoDocumentParsed>,
 )

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCVerifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCVerifier.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package at.asitplus.wallet.lib.iso
 
 
@@ -36,16 +38,15 @@ import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
 import kotlin.jvm.JvmOverloads
 
+@Deprecated("Use DcApiVerifier instead")
 class Iso180137AnnexCVerifier @JvmOverloads constructor(
     /** Creates challenges in authentication requests. */
     override val nonceService: NonceService = DefaultNonceService(),
     /** Used to store issued requests to verify the response to it */
-    private val stateToIsoMdocRequestStore: MapStore<String, IsoMdocRequest> = DefaultMapStore(), //stateToRequestStore
-
+    private val stateToIsoMdocRequestStore: MapStore<String, IsoMdocRequest> = DefaultMapStore(),
     override val decryptionKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
     /** Used to verify session transcripts from mDoc responses. */
     override val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray> = VerifyCoseSignatureWithKey(),
-
     private val validatorMdoc: ValidatorMdoc = ValidatorMdoc(),
 ) : AbstractMdocVerifier() {
 
@@ -63,6 +64,7 @@ class Iso180137AnnexCVerifier @JvmOverloads constructor(
         value = authenticationRequestParameters,
     ).also { Napier.w("Request with external ID $externalId stored") }
 
+    @Deprecated("Use createAuthnRequest from DcApiVerifier instead")
     suspend fun createRequest(
         requestOptions: Iso180137AnnexCRequestOptions,
     ): IsoMdocRequest {
@@ -96,6 +98,7 @@ class Iso180137AnnexCVerifier @JvmOverloads constructor(
         Iso180137AnnexCVerifiedPresentationResult(it.documents)
     }
 
+    @Deprecated("Use validateAuthnResponse from DcApiVerifier instead")
     @OptIn(SecretExposure::class)
     suspend fun validateResponse(
         receivedData: DCAPIResponse,
@@ -118,7 +121,12 @@ class Iso180137AnnexCVerifier @JvmOverloads constructor(
             )
         )
         val encodedSessionTranscript = coseCompliantSerializer.encodeToByteArray(sessionTranscript)
-        val encodedDeviceResponse = decryptHpke(encryptedResponseData.enc, encryptedResponseData.cipherText, privateKey, encodedSessionTranscript)
+        val encodedDeviceResponse = decryptHpke(
+            encryptedResponseData.enc,
+            encryptedResponseData.cipherText,
+            privateKey,
+            encodedSessionTranscript
+        )
         val deviceResponse = coseCompliantSerializer.decodeFromByteArray<DeviceResponse>(encodedDeviceResponse)
 
         return validatorMdoc.verifyDeviceResponse(


### PR DESCRIPTION
Part 3 of a better interface for DCAPI: Integrate handling ISO 18013-7 Annex C into the dedicated DCAPI Verifier.

TODO for expected origin probably covered by https://github.com/a-sit-plus/vck/pull/587

Next step: See how we can do VP token validation only once in the case of OpenID4VP over DCAPI.

Previous PR: https://github.com/a-sit-plus/vck/pull/590
Next PR: https://github.com/a-sit-plus/vck/pull/592