### PR TITLE
DCAPI: Extract shared code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Release 7.0.0 (unreleased):
 - Verifier:
     - Add `NonceChallengeVerifier`, a thin `Verifier` wrapper that creates presentation challenges from a `NonceService` and verifies SD-JWT/VC-JWT presentations against the embedded challenge.
     - Move OpenID4VP request nonce handling out of `VerifierAgent` and consume nonces after successful response validation to prevent replay.
+    - Deprecate abstract base class `AbstractMdocVerifier`
+    - Extract `MdocDeviceSignatureVerifier` from `AbstractMdocVerifier`
 - JVM interoperability:
     - Add `@JvmOverloads` to public API constructors with default parameters across the published modules.
 - Refactorings:

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/AuthnResponseResult.kt
@@ -12,7 +12,7 @@ data class AuthnResponseResult(
     val idTokenValidationResult: KmmResult<IdToken>?,
     val vpTokenValidationResult: KmmResult<VpTokenValidationResult>?,
     val request: AuthenticationRequestParameters?,
-) : DcApiResponseResult() {
+) : DcApiResponseResult {
     val state
         get() = request?.state
 }

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiResponseResult.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiResponseResult.kt
@@ -1,0 +1,14 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.wallet.lib.data.IsoDocumentParsed
+
+/** Result of validating a DCAPI response, see [DcApiVerifier.validateAuthnResponse] */
+sealed interface DcApiResponseResult
+
+/**
+ * Result of validating an ISO 18013-7 Annex C response, see [DcApiVerifier.validateAuthnResponse]
+ * and [DcApiCreationOptions.Iso180137AnnexC]
+ */
+data class Iso180137AnnexCWrapper(
+    val documents: Collection<IsoDocumentParsed>
+) : DcApiResponseResult

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
@@ -56,6 +56,7 @@ import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
 import at.asitplus.signum.supreme.asymmetric.HPKE
 import at.asitplus.wallet.lib.AbstractMdocVerifier
 import at.asitplus.wallet.lib.DefaultNonceService
+import at.asitplus.wallet.lib.MdocDeviceSignatureVerifier
 import at.asitplus.wallet.lib.NonceService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.KeyMaterial
@@ -134,6 +135,8 @@ class DcApiVerifier @JvmOverloads constructor(
     /** Algorithms supported to decrypt responses from wallets, for [metadataWithEncryption]. */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption> = JweEncryption.entries.toSet(),
 ) : AbstractMdocVerifier() {
+
+    private val mdocDeviceSignatureVerifier = MdocDeviceSignatureVerifier(verifyCoseSignature = verifyCoseSignature)
 
     /** Cipher suite to decrypt responses acc. to ISO/IEC 18013-7 Annex C */
     private val hpke = HPKE(HPKE.KEM.DHKEM_P256_HKDF_SHA256, HPKE.KDF.HKDF_SHA256, HPKE.AEAD.AES_128_GCM)
@@ -439,7 +442,7 @@ class DcApiVerifier @JvmOverloads constructor(
 
         val documents = verifier.verifyPresentationIsoMdoc(
             input = deviceResponse,
-            verifyDocument = verifyDocument(
+            verifyDocument = mdocDeviceSignatureVerifier.verifyDocument(
                 sessionTranscript = sessionTranscript
             )
         ).getOrThrow().documents
@@ -607,7 +610,7 @@ class DcApiVerifier @JvmOverloads constructor(
             ClaimFormat.MSO_MDOC -> nonceAwareVerifier.verifyPresentationIsoMdoc(
                 input = relatedPresentation.extractContent().decodeToByteArray(Base64UrlStrict)
                     .let { coseCompliantSerializer.decodeFromByteArray<DeviceResponse>(it) },
-                verifyDocument = verifyDocument(
+                verifyDocument = mdocDeviceSignatureVerifier.verifyDocument(
                     sessionTranscript = createSessionTranscript(
                         input = input,
                         clientId = clientId,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
@@ -8,7 +8,6 @@ import at.asitplus.dcapi.DCAPIInfo
 import at.asitplus.dcapi.DCAPIResponse
 import at.asitplus.dcapi.DigitalCredentialInterface
 import at.asitplus.dcapi.IsoMdocResponse
-import at.asitplus.dcapi.OpenID4VPDCAPIHandoverInfo
 import at.asitplus.dcapi.OpenId4VpResponse
 import at.asitplus.dcapi.SessionTranscriptContentHashable
 import at.asitplus.dcapi.request.IsoMdocRequest
@@ -67,7 +66,6 @@ import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
 import at.asitplus.wallet.lib.data.toBase64UrlJsonString
-import at.asitplus.wallet.lib.extensions.sessionTranscriptThumbprint
 import at.asitplus.wallet.lib.jws.DecryptJwe
 import at.asitplus.wallet.lib.jws.DecryptJweFun
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
@@ -610,7 +608,7 @@ class DcApiVerifier @JvmOverloads constructor(
                 input = relatedPresentation.extractContent().decodeToByteArray(Base64UrlStrict)
                     .let { coseCompliantSerializer.decodeFromByteArray<DeviceResponse>(it) },
                 verifyDocument = mdocDeviceSignatureVerifier.verifyDocument(
-                    sessionTranscript = createSessionTranscript(
+                    sessionTranscript = DcApiSessionTranscriptCalculator(decryptionKeyMaterial)(
                         input = input,
                         clientId = clientId,
                         expectedNonce = expectedNonce,
@@ -625,52 +623,6 @@ class DcApiVerifier @JvmOverloads constructor(
             else -> throw IllegalArgumentException("descriptor.format: $claimFormat")
         }.getOrThrow()
     }
-
-    private fun createSessionTranscript(
-        input: ResponseParametersFrom,
-        clientId: String?,
-        expectedNonce: String,
-        hasBeenEncrypted: Boolean,
-        responseUrl: String?,
-        clientIdRequired: Boolean,
-        origin: String?,
-    ): SessionTranscript {
-        require((!clientIdRequired || clientId != null)) { "Missing required parameter: clientId" }
-        require(responseUrl != null) { "Missing required parameter: responseUrl" }
-        require(input.originalResponseParameters is ResponseParametersFrom.DcApi) {
-            "Unsupported response mechanism: ${input.originalResponseParameters}"
-        }
-        require(origin != null) { "Missing required parameter: origin" }
-        val serializedOrigin = requireNotNull(origin.serializeOrigin()) {
-            "Invalid parameter: origin"
-        }
-        return createDcApiSessionTranscript(
-            OpenID4VPDCAPIHandoverInfo(
-                // Device signatures are bound to the HTML-serialized origin used by OpenID4VP/DCAPI.
-                // Hashing the raw URL would make `https://example.com/` differ from `https://example.com`.
-                origin = serializedOrigin,
-                nonce = expectedNonce,
-                jwkThumbprint = if (hasBeenEncrypted) {
-                    decryptionKeyMaterial.jsonWebKey.sessionTranscriptThumbprint()
-                } else null,
-            )
-        )
-    }
-
-    /**
-     * Performs calculation of the [SessionTranscript] for DC API according to OID4VP
-     */
-    private fun createDcApiSessionTranscript(
-        toBeHashed: SessionTranscriptContentHashable,
-    ): SessionTranscript = SessionTranscript.forDcApi(
-        DCAPIHandover(
-            type = DCAPIHandover.TYPE_OPENID4VP,
-            hash = coseCompliantSerializer.encodeToByteArray<OpenID4VPDCAPIHandoverInfo>(
-                toBeHashed as? OpenID4VPDCAPIHandoverInfo
-                    ?: throw IllegalArgumentException("Unsupported DCAPIHandoverInfo")
-            ).sha256(),
-        )
-    )
 
     fun createDcApiSessionTranscriptAnnexC(
         toBeHashed: SessionTranscriptContentHashable,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
@@ -65,7 +65,6 @@ import at.asitplus.wallet.lib.agent.VerifierAgent
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
-import at.asitplus.wallet.lib.data.IsoDocumentParsed
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
 import at.asitplus.wallet.lib.data.toBase64UrlJsonString
 import at.asitplus.wallet.lib.extensions.sessionTranscriptThumbprint
@@ -694,8 +693,3 @@ class DcApiVerifier @JvmOverloads constructor(
     private fun JsonWebKey.withAlgorithm(): JsonWebKey = this.copy(algorithm = JweAlgorithm.ECDH_ES)
 }
 
-sealed class DcApiResponseResult {
-
-}
-
-data class Iso180137AnnexCWrapper(val documents: Collection<IsoDocumentParsed>) : DcApiResponseResult()

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/DcApiVerifier.kt
@@ -54,7 +54,6 @@ import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
 import at.asitplus.signum.supreme.asymmetric.HPKE
-import at.asitplus.wallet.lib.AbstractMdocVerifier
 import at.asitplus.wallet.lib.DefaultNonceService
 import at.asitplus.wallet.lib.MdocDeviceSignatureVerifier
 import at.asitplus.wallet.lib.NonceService
@@ -114,7 +113,7 @@ class DcApiVerifier @JvmOverloads constructor(
     /** Verifies the holder's response against our identifier from [clientIdScheme]. */
     val verifier: Verifier = VerifierAgent(identifier = clientIdScheme.clientId),
     /** Advertised in [metadata] so that holders can encrypt responses. */
-    override val decryptionKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
+    private val decryptionKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
     /** Decrypts encrypted responses from holders. */
     private val decryptJwe: DecryptJweFun = DecryptJwe(decryptionKeyMaterial),
     /** Signs authentication requests in [createSignedRequestObject]. */
@@ -125,16 +124,16 @@ class DcApiVerifier @JvmOverloads constructor(
     /** Advertised in [metadata]. */
     private val supportedAlgorithms: Set<SignatureAlgorithm> = setOf(SignatureAlgorithm.ECDSAwithSHA256),
     /** Used to verify session transcripts from mDoc responses. */
-    override val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray> = VerifyCoseSignatureWithKey(),
+    private val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray> = VerifyCoseSignatureWithKey(),
     /** Creates and validates OpenID4VP request nonces. */
-    override val nonceService: NonceService = DefaultNonceService(),
+    private val nonceService: NonceService = DefaultNonceService(),
     /** Used to store issued authn requests to verify the authn response to it */
     private val stateToAuthnRequestStore: MapStore<String, AuthenticationRequestParameters> = DefaultMapStore(),
     /** Used to store issued requests to verify the response to it */
     private val stateToIsoMdocRequestStore: MapStore<String, IsoMdocRequest> = DefaultMapStore(),
     /** Algorithms supported to decrypt responses from wallets, for [metadataWithEncryption]. */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption> = JweEncryption.entries.toSet(),
-) : AbstractMdocVerifier() {
+) {
 
     private val mdocDeviceSignatureVerifier = MdocDeviceSignatureVerifier(verifyCoseSignature = verifyCoseSignature)
 
@@ -661,7 +660,7 @@ class DcApiVerifier @JvmOverloads constructor(
     /**
      * Performs calculation of the [SessionTranscript] for DC API according to OID4VP
      */
-    override fun createDcApiSessionTranscript(
+    private fun createDcApiSessionTranscript(
         toBeHashed: SessionTranscriptContentHashable,
     ): SessionTranscript = SessionTranscript.forDcApi(
         DCAPIHandover(

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/JwsHeaderClientIdScheme.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/JwsHeaderClientIdScheme.kt
@@ -1,0 +1,21 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.signum.indispensable.josef.JwsHeader
+import at.asitplus.wallet.lib.agent.KeyMaterial
+import at.asitplus.wallet.lib.jws.JwsHeaderIdentifierFun
+
+class JwsHeaderClientIdScheme(val clientIdScheme: ClientIdScheme) : JwsHeaderIdentifierFun {
+    override suspend operator fun invoke(
+        it: JwsHeader,
+        keyMaterial: KeyMaterial,
+    ) = when (clientIdScheme) {
+        is ClientIdScheme.CertificateHash -> it.copy(certificateChain = clientIdScheme.chain)
+        is ClientIdScheme.CertificateSanDns -> it.copy(certificateChain = clientIdScheme.chain)
+        is ClientIdScheme.VerifierAttestation -> it.copy(
+            jsonWebKey = keyMaterial.jsonWebKey,
+            attestationJwt = clientIdScheme.attestationJwt.jws
+        )
+
+        else -> it.copy(jsonWebKey = keyMaterial.jsonWebKey)
+    }
+}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -9,10 +9,6 @@ import at.asitplus.dif.FormatContainerJwt
 import at.asitplus.dif.FormatContainerSdJwt
 import at.asitplus.dif.PresentationSubmissionDescriptor
 import at.asitplus.iso.DeviceResponse
-import at.asitplus.iso.OpenId4VpHandover
-import at.asitplus.iso.OpenId4VpHandoverInfo
-import at.asitplus.iso.SessionTranscript
-import at.asitplus.iso.sha256
 import at.asitplus.jsonpath.JsonPath
 import at.asitplus.openid.AuthenticationRequestParameters
 import at.asitplus.openid.CredentialFormatEnum
@@ -59,7 +55,6 @@ import at.asitplus.wallet.lib.data.CredentialPresentationRequest.DCQLRequest
 import at.asitplus.wallet.lib.data.CredentialPresentationRequest.PresentationExchangeRequest
 import at.asitplus.wallet.lib.data.VerifiablePresentationJws
 import at.asitplus.wallet.lib.data.toBase64UrlJsonString
-import at.asitplus.wallet.lib.extensions.sessionTranscriptThumbprint
 import at.asitplus.wallet.lib.jws.DecryptJwe
 import at.asitplus.wallet.lib.jws.DecryptJweFun
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
@@ -76,7 +71,6 @@ import io.github.aakira.napier.Napier
 import io.ktor.http.*
 import io.matthewnelson.encoding.core.Decoder.Companion.decodeToByteArray
 import kotlinx.serialization.decodeFromByteArray
-import kotlinx.serialization.encodeToByteArray
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -667,7 +661,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
                 input = relatedPresentation.extractContent().decodeToByteArray(Base64UrlStrict)
                     .let { coseCompliantSerializer.decodeFromByteArray<DeviceResponse>(it) },
                 verifyDocument = mdocDeviceSignatureVerifier.verifyDocument(
-                    sessionTranscript = createSessionTranscript(
+                    sessionTranscript = UrlSessionTranscriptCalculator(decryptionKeyMaterial)(
                         input = input,
                         clientId = clientId,
                         expectedNonce = expectedNonce,
@@ -681,38 +675,6 @@ class OpenId4VpVerifier @JvmOverloads constructor(
 
             else -> throw IllegalArgumentException("descriptor.format: $claimFormat")
         }.getOrThrow()
-    }
-
-    private fun createSessionTranscript(
-        input: ResponseParametersFrom,
-        clientId: String?,
-        expectedNonce: String,
-        hasBeenEncrypted: Boolean,
-        responseUrl: String?,
-        clientIdRequired: Boolean,
-        origin: String?,
-    ): SessionTranscript {
-        require((!clientIdRequired || clientId != null)) { "Missing required parameter: clientId" }
-        require(responseUrl != null) { "Missing required parameter: responseUrl" }
-        require(input.originalResponseParameters !is ResponseParametersFrom.DcApi) {
-            "DCAPI verification is not supported, use DcApiVerifier"
-        }
-
-        return SessionTranscript.forOpenId(
-            OpenId4VpHandover(
-                type = OpenId4VpHandover.TYPE_OPENID4VP,
-                hash = coseCompliantSerializer.encodeToByteArray<OpenId4VpHandoverInfo>(
-                    OpenId4VpHandoverInfo(
-                        clientId = clientId,
-                        nonce = expectedNonce,
-                        jwkThumbprint = if (hasBeenEncrypted) {
-                            decryptionKeyMaterial.jsonWebKey.sessionTranscriptThumbprint()
-                        } else null,
-                        responseUrl = responseUrl,
-                    )
-                ).sha256(),
-            )
-        )
     }
 
     // To be reconsidered when supporting [DCQLCredentialQueryInstance.multiple]

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -42,7 +42,6 @@ import at.asitplus.signum.indispensable.josef.JsonWebKeySet
 import at.asitplus.signum.indispensable.josef.JweAlgorithm
 import at.asitplus.signum.indispensable.josef.JweEncryption
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
-import at.asitplus.signum.indispensable.josef.JwsHeader
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
@@ -65,7 +64,6 @@ import at.asitplus.wallet.lib.extensions.sessionTranscriptThumbprint
 import at.asitplus.wallet.lib.jws.DecryptJwe
 import at.asitplus.wallet.lib.jws.DecryptJweFun
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
-import at.asitplus.wallet.lib.jws.JwsHeaderIdentifierFun
 import at.asitplus.wallet.lib.jws.SdJwtSigned
 import at.asitplus.wallet.lib.jws.SignJwt
 import at.asitplus.wallet.lib.jws.SignJwtFun
@@ -745,18 +743,3 @@ private val PresentationSubmissionDescriptor.cumulativeJsonPath: String
     }
 
 
-class JwsHeaderClientIdScheme(val clientIdScheme: ClientIdScheme) : JwsHeaderIdentifierFun {
-    override suspend operator fun invoke(
-        it: JwsHeader,
-        keyMaterial: KeyMaterial,
-    ) = when (clientIdScheme) {
-        is ClientIdScheme.CertificateHash -> it.copy(certificateChain = clientIdScheme.chain)
-        is ClientIdScheme.CertificateSanDns -> it.copy(certificateChain = clientIdScheme.chain)
-        is ClientIdScheme.VerifierAttestation -> it.copy(
-            jsonWebKey = keyMaterial.jsonWebKey,
-            attestationJwt = clientIdScheme.attestationJwt.jws
-        )
-
-        else -> it.copy(jsonWebKey = keyMaterial.jsonWebKey)
-    }
-}

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -3,7 +3,6 @@ package at.asitplus.wallet.lib.openid
 import at.asitplus.KmmResult
 import at.asitplus.catching
 import at.asitplus.dcapi.OpenId4VpResponse
-import at.asitplus.dcapi.SessionTranscriptContentHashable
 import at.asitplus.dif.ClaimFormat
 import at.asitplus.dif.DifInputDescriptor
 import at.asitplus.dif.FormatContainerJwt
@@ -45,7 +44,6 @@ import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
-import at.asitplus.wallet.lib.AbstractMdocVerifier
 import at.asitplus.wallet.lib.DefaultNonceService
 import at.asitplus.wallet.lib.MdocDeviceSignatureVerifier
 import at.asitplus.wallet.lib.NonceService
@@ -110,7 +108,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     /** Verifies the holder's response against our identifier from [clientIdScheme]. */
     val verifier: Verifier = VerifierAgent(identifier = clientIdScheme.clientId),
     /** Advertised in [metadata] so that holders can encrypt responses. */
-    override val decryptionKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
+    private val decryptionKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
     /** Decrypts encrypted responses from holders. */
     private val decryptJwe: DecryptJweFun = DecryptJwe(decryptionKeyMaterial),
     /** Signs authentication requests in [createSignedRequestObject]. */
@@ -121,18 +119,18 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     /** Advertised in [metadata]. */
     private val supportedAlgorithms: Set<SignatureAlgorithm> = setOf(SignatureAlgorithm.ECDSAwithSHA256),
     /** Used to verify session transcripts from mDoc responses. */
-    override val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray> = VerifyCoseSignatureWithKey(),
+    private val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray> = VerifyCoseSignatureWithKey(),
     /** Leeway for time validity checks. */
     timeLeewaySeconds: Long = 300L,
     /** Clock for time validity checks. */
     private val clock: Clock = Clock.System,
     /** Creates and validates OpenID4VP request nonces. */
-    override val nonceService: NonceService = DefaultNonceService(),
+    private val nonceService: NonceService = DefaultNonceService(),
     /** Used to store issued authn requests to verify the authn response to it */
     private val stateToAuthnRequestStore: MapStore<String, AuthenticationRequestParameters> = DefaultMapStore(),
     /** Algorithms supported to decrypt responses from wallets, for [metadataWithEncryption]. */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption> = JweEncryption.entries.toSet(),
-) : AbstractMdocVerifier() {
+) {
 
     private val mdocDeviceSignatureVerifier = MdocDeviceSignatureVerifier(verifyCoseSignature = verifyCoseSignature)
 
@@ -716,11 +714,6 @@ class OpenId4VpVerifier @JvmOverloads constructor(
             )
         )
     }
-
-    override fun createDcApiSessionTranscript(
-        toBeHashed: SessionTranscriptContentHashable,
-    ): SessionTranscript =
-        throw IllegalArgumentException("DCAPI verification is not supported, use DcApiVerifier")
 
     // To be reconsidered when supporting [DCQLCredentialQueryInstance.multiple]
     private fun JsonElement.extractContent(): String = when (this) {

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpVerifier.kt
@@ -47,6 +47,7 @@ import at.asitplus.signum.indispensable.josef.toJsonWebKey
 import at.asitplus.signum.indispensable.josef.toJwsAlgorithm
 import at.asitplus.wallet.lib.AbstractMdocVerifier
 import at.asitplus.wallet.lib.DefaultNonceService
+import at.asitplus.wallet.lib.MdocDeviceSignatureVerifier
 import at.asitplus.wallet.lib.NonceService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.KeyMaterial
@@ -132,6 +133,8 @@ class OpenId4VpVerifier @JvmOverloads constructor(
     /** Algorithms supported to decrypt responses from wallets, for [metadataWithEncryption]. */
     private val supportedJweEncryptionAlgorithms: Set<JweEncryption> = JweEncryption.entries.toSet(),
 ) : AbstractMdocVerifier() {
+
+    private val mdocDeviceSignatureVerifier = MdocDeviceSignatureVerifier(verifyCoseSignature = verifyCoseSignature)
 
     private val nonceAwareVerifier = NonceChallengeVerifier(
         verifierId = clientIdScheme.clientId,
@@ -665,7 +668,7 @@ class OpenId4VpVerifier @JvmOverloads constructor(
             ClaimFormat.MSO_MDOC -> nonceAwareVerifier.verifyPresentationIsoMdoc(
                 input = relatedPresentation.extractContent().decodeToByteArray(Base64UrlStrict)
                     .let { coseCompliantSerializer.decodeFromByteArray<DeviceResponse>(it) },
-                verifyDocument = verifyDocument(
+                verifyDocument = mdocDeviceSignatureVerifier.verifyDocument(
                     sessionTranscript = createSessionTranscript(
                         input = input,
                         clientId = clientId,

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/SessionTranscriptCalculator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/SessionTranscriptCalculator.kt
@@ -1,0 +1,105 @@
+package at.asitplus.wallet.lib.openid
+
+import at.asitplus.dcapi.DCAPIHandover
+import at.asitplus.dcapi.OpenID4VPDCAPIHandoverInfo
+import at.asitplus.iso.OpenId4VpHandover
+import at.asitplus.iso.OpenId4VpHandoverInfo
+import at.asitplus.iso.SessionTranscript
+import at.asitplus.iso.serializeOrigin
+import at.asitplus.iso.sha256
+import at.asitplus.openid.ResponseParametersFrom
+import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
+import at.asitplus.wallet.lib.agent.KeyMaterial
+import at.asitplus.wallet.lib.extensions.sessionTranscriptThumbprint
+import kotlinx.serialization.encodeToByteArray
+
+internal fun interface SessionTranscriptCalculator {
+    operator fun invoke(
+        input: ResponseParametersFrom,
+        clientId: String?,
+        expectedNonce: String,
+        hasBeenEncrypted: Boolean,
+        responseUrl: String?,
+        clientIdRequired: Boolean,
+        origin: String?,
+    ): SessionTranscript
+}
+
+/** Calculates the ISO session transcript for URL transport, i.e. from [OpenId4VpVerifier]. */
+internal class UrlSessionTranscriptCalculator(
+    private val decryptionKeyMaterial: KeyMaterial
+) : SessionTranscriptCalculator {
+    override fun invoke(
+        input: ResponseParametersFrom,
+        clientId: String?,
+        expectedNonce: String,
+        hasBeenEncrypted: Boolean,
+        responseUrl: String?,
+        clientIdRequired: Boolean,
+        origin: String?
+    ): SessionTranscript {
+        require((!clientIdRequired || clientId != null)) { "Missing required parameter: clientId" }
+        require(responseUrl != null) { "Missing required parameter: responseUrl" }
+        require(input.originalResponseParameters !is ResponseParametersFrom.DcApi) {
+            "DCAPI verification is not supported, use DcApiVerifier"
+        }
+
+        return SessionTranscript.forOpenId(
+            OpenId4VpHandover(
+                type = OpenId4VpHandover.TYPE_OPENID4VP,
+                hash = coseCompliantSerializer.encodeToByteArray<OpenId4VpHandoverInfo>(
+                    OpenId4VpHandoverInfo(
+                        clientId = clientId,
+                        nonce = expectedNonce,
+                        jwkThumbprint = if (hasBeenEncrypted) {
+                            decryptionKeyMaterial.jsonWebKey.sessionTranscriptThumbprint()
+                        } else null,
+                        responseUrl = responseUrl,
+                    )
+                ).sha256(),
+            )
+        )
+    }
+}
+
+/** Calculates the ISO session transcript for DCAPI transport, i.e. from [DcApiVerifier]. */
+internal class DcApiSessionTranscriptCalculator(
+    private val decryptionKeyMaterial: KeyMaterial
+) : SessionTranscriptCalculator {
+    override fun invoke(
+        input: ResponseParametersFrom,
+        clientId: String?,
+        expectedNonce: String,
+        hasBeenEncrypted: Boolean,
+        responseUrl: String?,
+        clientIdRequired: Boolean,
+        origin: String?
+    ): SessionTranscript {
+        require((!clientIdRequired || clientId != null)) { "Missing required parameter: clientId" }
+        require(responseUrl != null) { "Missing required parameter: responseUrl" }
+        require(input.originalResponseParameters is ResponseParametersFrom.DcApi) {
+            "Unsupported response mechanism: ${input.originalResponseParameters}"
+        }
+        require(origin != null) { "Missing required parameter: origin" }
+        val serializedOrigin = requireNotNull(origin.serializeOrigin()) {
+            "Invalid parameter: origin"
+        }
+        return SessionTranscript.forDcApi(
+            DCAPIHandover(
+                type = DCAPIHandover.TYPE_OPENID4VP,
+                hash = coseCompliantSerializer.encodeToByteArray<OpenID4VPDCAPIHandoverInfo>(
+                    OpenID4VPDCAPIHandoverInfo(
+                        // Device signatures are bound to the HTML-serialized origin used by OpenID4VP/DCAPI.
+                        // Hashing the raw URL would make `https://example.com/` differ from `https://example.com`.
+                        origin = serializedOrigin,
+                        nonce = expectedNonce,
+                        jwkThumbprint = if (hasBeenEncrypted) {
+                            decryptionKeyMaterial.jsonWebKey.sessionTranscriptThumbprint()
+                        } else null,
+                    )
+                ).sha256(),
+            )
+        )
+    }
+
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/AbstractMdocVerifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/AbstractMdocVerifier.kt
@@ -1,29 +1,24 @@
 package at.asitplus.wallet.lib
 
 import at.asitplus.dcapi.SessionTranscriptContentHashable
-import at.asitplus.iso.DeviceAuthentication
 import at.asitplus.iso.Document
 import at.asitplus.iso.MobileSecurityObject
 import at.asitplus.iso.SessionTranscript
-import at.asitplus.iso.wrapInCborTag
-import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.wallet.lib.agent.KeyMaterial
 import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
-import io.matthewnelson.encoding.base16.Base16
-import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
-import kotlinx.serialization.encodeToByteArray
 
+@Deprecated("Logic moved to MdocDeviceSignatureVerifier")
 abstract class AbstractMdocVerifier {
     /** Creates challenges in authentication requests. */
     protected abstract val nonceService: NonceService
+
     /** Used for encrypted responses. */
     protected abstract val decryptionKeyMaterial: KeyMaterial
+
     /** Used to verify session transcripts from mDoc responses. */
     protected abstract val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray>
 
-    /**
-     * Performs calculation of the [at.asitplus.iso.SessionTranscript] for DC API
-     */
+    // Get's removed in 8.0.0
     protected abstract fun createDcApiSessionTranscript(
         toBeHashed: SessionTranscriptContentHashable,
     ): SessionTranscript
@@ -35,31 +30,8 @@ abstract class AbstractMdocVerifier {
     @Throws(IllegalArgumentException::class, IllegalStateException::class)
     protected fun verifyDocument(
         sessionTranscript: SessionTranscript
-    ): suspend (MobileSecurityObject, Document) -> Boolean = { mso, document ->
-        val deviceSignature = document.deviceSigned.deviceAuth.deviceSignature
-            ?: throw IllegalArgumentException("deviceSignature is null")
-
-        val expectedDetachedPayload = DeviceAuthentication(
-            type = DeviceAuthentication.TYPE,
-            sessionTranscript = sessionTranscript,
-            docType = document.docType,
-            namespaces = document.deviceSigned.namespaces
-        ).wrapAsExpectedPayload()
-
-        verifyCoseSignature(
-            coseSigned = deviceSignature,
-            signer = mso.deviceKeyInfo.deviceKey,
-            externalAad = byteArrayOf(),
-            detachedPayload = expectedDetachedPayload
-        ).onFailure {
-            throw IllegalArgumentException("deviceSignature not matching ${expectedDetachedPayload.encodeToString(Base16())}", it)
-        }
-        true
-    }
-
-    private fun DeviceAuthentication.wrapAsExpectedPayload(): ByteArray = coseCompliantSerializer
-        .encodeToByteArray(coseCompliantSerializer.encodeToByteArray(this))
-        .wrapInCborTag(24)
+    ): suspend (MobileSecurityObject, Document) -> Boolean =
+        MdocDeviceSignatureVerifier(verifyCoseSignature = verifyCoseSignature).verifyDocument(sessionTranscript)
 
 
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/MdocDeviceSignatureVerifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/MdocDeviceSignatureVerifier.kt
@@ -1,0 +1,57 @@
+package at.asitplus.wallet.lib
+
+import at.asitplus.iso.DeviceAuthentication
+import at.asitplus.iso.Document
+import at.asitplus.iso.MobileSecurityObject
+import at.asitplus.iso.SessionTranscript
+import at.asitplus.iso.wrapInCborTag
+import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
+import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKey
+import at.asitplus.wallet.lib.cbor.VerifyCoseSignatureWithKeyFun
+import io.matthewnelson.encoding.base16.Base16
+import io.matthewnelson.encoding.core.Encoder.Companion.encodeToString
+import kotlinx.serialization.encodeToByteArray
+import kotlin.jvm.JvmOverloads
+
+/** Verifies the mdoc device signature against a session transcript, acc. to ISO/IEC 18013-5/-7. */
+class MdocDeviceSignatureVerifier @JvmOverloads constructor(
+    private val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray> = VerifyCoseSignatureWithKey(),
+) {
+    /**
+     * Performs verification of the [at.asitplus.iso.SessionTranscript] and [at.asitplus.iso.DeviceAuthentication],
+     * acc. to ISO/IEC 18013-5:2021 and ISO/IEC 18013-7:2024, if required (i.e. response is encrypted)
+     */
+    @Throws(IllegalArgumentException::class, IllegalStateException::class)
+    fun verifyDocument(
+        sessionTranscript: SessionTranscript
+    ): suspend (MobileSecurityObject, Document) -> Boolean = { mso, document ->
+        val deviceSignature = document.deviceSigned.deviceAuth.deviceSignature
+            ?: throw IllegalArgumentException("deviceSignature is null")
+
+        val expectedDetachedPayload = DeviceAuthentication(
+            type = DeviceAuthentication.TYPE,
+            sessionTranscript = sessionTranscript,
+            docType = document.docType,
+            namespaces = document.deviceSigned.namespaces
+        ).wrapAsExpectedPayload()
+
+        verifyCoseSignature(
+            coseSigned = deviceSignature,
+            signer = mso.deviceKeyInfo.deviceKey,
+            externalAad = byteArrayOf(),
+            detachedPayload = expectedDetachedPayload
+        ).onFailure {
+            throw IllegalArgumentException(
+                "deviceSignature not matching ${expectedDetachedPayload.encodeToString(Base16())}",
+                it
+            )
+        }
+        true
+    }
+
+    private fun DeviceAuthentication.wrapAsExpectedPayload(): ByteArray = coseCompliantSerializer
+        .encodeToByteArray(coseCompliantSerializer.encodeToByteArray(this))
+        .wrapInCborTag(24)
+
+
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCVerifier.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/iso/Iso180137AnnexCVerifier.kt
@@ -21,8 +21,8 @@ import at.asitplus.signum.indispensable.CryptoPrivateKey
 import at.asitplus.signum.indispensable.SecretExposure
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.cosef.toCoseKey
-import at.asitplus.wallet.lib.AbstractMdocVerifier
 import at.asitplus.wallet.lib.DefaultNonceService
+import at.asitplus.wallet.lib.MdocDeviceSignatureVerifier
 import at.asitplus.wallet.lib.NonceService
 import at.asitplus.wallet.lib.agent.EphemeralKeyWithoutCert
 import at.asitplus.wallet.lib.agent.KeyMaterial
@@ -41,14 +41,15 @@ import kotlin.jvm.JvmOverloads
 @Deprecated("Use DcApiVerifier instead")
 class Iso180137AnnexCVerifier @JvmOverloads constructor(
     /** Creates challenges in authentication requests. */
-    override val nonceService: NonceService = DefaultNonceService(),
+    private val nonceService: NonceService = DefaultNonceService(),
     /** Used to store issued requests to verify the response to it */
     private val stateToIsoMdocRequestStore: MapStore<String, IsoMdocRequest> = DefaultMapStore(),
-    override val decryptionKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
+    private val decryptionKeyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
     /** Used to verify session transcripts from mDoc responses. */
-    override val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray> = VerifyCoseSignatureWithKey(),
+    private val verifyCoseSignature: VerifyCoseSignatureWithKeyFun<ByteArray> = VerifyCoseSignatureWithKey(),
     private val validatorMdoc: ValidatorMdoc = ValidatorMdoc(),
-) : AbstractMdocVerifier() {
+)  {
+    private val mdocDeviceSignatureVerifier = MdocDeviceSignatureVerifier(verifyCoseSignature = verifyCoseSignature)
 
     /**
      * Remembers [authenticationRequestParameters] to link responses to requests in [validateResponse].
@@ -83,7 +84,7 @@ class Iso180137AnnexCVerifier @JvmOverloads constructor(
     /**
      * Performs calculation of the [at.asitplus.iso.SessionTranscript] for DC API according to ISO/IEC 18013-7
      */
-    override fun createDcApiSessionTranscript(
+    fun createDcApiSessionTranscript(
         toBeHashed: SessionTranscriptContentHashable,
     ): SessionTranscript = SessionTranscript.forDcApi(
         DCAPIHandover(
@@ -131,7 +132,7 @@ class Iso180137AnnexCVerifier @JvmOverloads constructor(
 
         return validatorMdoc.verifyDeviceResponse(
             deviceResponse,
-            verifyDocumentCallback = verifyDocument(
+            verifyDocumentCallback = mdocDeviceSignatureVerifier.verifyDocument(
                 sessionTranscript = sessionTranscript
             )
         ).mapToResponseResult()


### PR DESCRIPTION
Part 6 of a better interface for DCAPI: Extract code shared between `DcApiVerifier` and `OpenId4VpVerifier`

Previous PR: https://github.com/a-sit-plus/vck/pull/593
Next PR: https://github.com/a-sit-plus/vck/pull/596