### PR TITLE
Fix - LoTE filtering logic

### DIFF
--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterService.kt
@@ -86,17 +86,12 @@ enum class LoTEServiceType(val type: String) {
         /**
          * Resolves a raw scheme type string into a safe Enum
          */
-        fun fromSchemeType(rawSchemeType: String?): LoTEServiceType? {
-            if (rawSchemeType.isNullOrBlank()) return null
+        fun fromSchemeType(rawSchemeType: String?): LoTEServiceType {
+            if (rawSchemeType.isNullOrBlank()) return EAA
 
-            return when {
-                rawSchemeType.contains("pid", ignoreCase = true) -> PID
-                rawSchemeType.contains("mdl", ignoreCase = true) -> MDL
-                rawSchemeType.contains("wrpac", ignoreCase = true) -> WRPAC
-                rawSchemeType.contains("eaa", ignoreCase = true) -> EAA
-                rawSchemeType.contains("wallet", ignoreCase = true) -> WALLET
-                else -> null
-            }
+            return entries.firstOrNull {
+                it != EAA && rawSchemeType.contains(it.type, ignoreCase = true)
+            } ?: EAA
         }
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterService.kt
@@ -75,31 +75,28 @@ data class LoTEFilterCriteria(
     val expectedServiceType: LoTEServiceType,
 )
 
-enum class LoTEServiceType(val type: String, val fileName: String) {
-    PID("pid", "pid-providers.json"),
-    MDL("mdl", "mdl-providers.json"),
+enum class LoTEServiceType(
+    val type: String,
+    val fileName: String,
+    private val identifiers: List<String> = emptyList()
+) {
+    PID("pid", "pid-providers.json", listOf("urn:eudi:pid:", "eu.europa.ec.eudi.pid.")),
+    MDL("mdl", "mdl-providers.json", listOf("org.iso.18013.5.1.mDL")),
     WRPAC("wrpac", "wrpac-providers.json"),
     WALLET("wallet", "wallet-providers.json"),
     EAA("eaa", "pub-eaa-providers.json");
 
-    /**
-     * Resolves the full URL for this service type's trust list using a given base URL.
-     */
-    fun defaultUrl(baseUrl: String = DEFAULT_BASE_URL): String = "$baseUrl/$fileName"
+    fun defaultUrl(baseUrl: String = DEFAULT_BASE_URL) = "$baseUrl/$fileName"
 
     companion object {
         const val DEFAULT_BASE_URL = "https://acceptance.trust.tech.ec.europa.eu/lists/eudiw"
+        val defaultUrls = entries.map { it.defaultUrl() }
 
-        val defaultUrls: List<String> = entries.map { it.defaultUrl() }
+        fun fromSchemeIdentifier(schemeIdentifier: String?): LoTEServiceType {
+            if (schemeIdentifier.isNullOrBlank()) return EAA
 
-        /**
-         * Resolves a raw scheme type string into a safe Enum
-         */
-        fun fromSchemeType(rawSchemeType: String?): LoTEServiceType {
-            if (rawSchemeType.isNullOrBlank()) return EAA
-
-            return entries.firstOrNull {
-                it != EAA && rawSchemeType.contains(it.type, ignoreCase = true)
+            return entries.firstOrNull { entry ->
+                entry.identifiers.any { schemeIdentifier.contains(it, ignoreCase = true) }
             } ?: EAA
         }
     }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterService.kt
@@ -75,14 +75,23 @@ data class LoTEFilterCriteria(
     val expectedServiceType: LoTEServiceType,
 )
 
-enum class LoTEServiceType(val type: String) {
-    PID("pid"),
-    MDL("mdl"),
-    WRPAC("wrpac"),
-    EAA("eaa"),
-    WALLET("wallet");
+enum class LoTEServiceType(val type: String, val fileName: String) {
+    PID("pid", "pid-providers.json"),
+    MDL("mdl", "mdl-providers.json"),
+    WRPAC("wrpac", "wrpac-providers.json"),
+    WALLET("wallet", "wallet-providers.json"),
+    EAA("eaa", "pub-eaa-providers.json");
+
+    /**
+     * Resolves the full URL for this service type's trust list using a given base URL.
+     */
+    fun defaultUrl(baseUrl: String = DEFAULT_BASE_URL): String = "$baseUrl/$fileName"
 
     companion object {
+        const val DEFAULT_BASE_URL = "https://acceptance.trust.tech.ec.europa.eu/lists/eudiw"
+
+        val defaultUrls: List<String> = entries.map { it.defaultUrl() }
+
         /**
          * Resolves a raw scheme type string into a safe Enum
          */

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterService.kt
@@ -18,14 +18,24 @@ class LoTEFilterService {
      * Extracts certificates matching the requested service type identifier where
      * the certificate's subject organization aligns with the trusted provider's registered names
      */
-    fun extractTrustedCertificates(lote: ListOfTrustedEntities, criteria: LoTEFilterCriteria): List<TrustedCertificate> {
+    fun extractTrustedCertificates(sourceUrl: String, lote: ListOfTrustedEntities, criteria: LoTEFilterCriteria): List<TrustedCertificate> {
         val entities = lote.trustedEntitiesList ?: return emptyList()
 
         return entities.flatMap { entity ->
             val providerName = entity.trustedEntityInformation.teName
 
             entity.trustedEntityServices
-                .filter { it.serviceInformation.serviceTypeIdentifier?.string == criteria.expectedServiceType }
+                .filter { service ->
+                    val serviceTypeId = service.serviceInformation.serviceTypeIdentifier?.string
+
+                    if (serviceTypeId != null) {
+                        // Field is present. Check if it matches type
+                        serviceTypeId.contains(criteria.expectedServiceType.type, ignoreCase = true)
+                    } else {
+                        // Field is absent. The services inherit the list's default type
+                        sourceUrl.contains(criteria.expectedServiceType.type, ignoreCase = true)
+                    }
+                }
                 .flatMap { service -> service.serviceInformation.serviceDigitalIdentity.x509Certificates }
                 .filter { cert -> cert?.hasMatchingOrganization(providerName) == true }
                 .map { cert -> TrustedCertificate(cert, providerName, criteria.expectedServiceType) }
@@ -58,9 +68,35 @@ class LoTEFilterService {
 data class TrustedCertificate(
     val certificate: @Serializable(with = EtsiX509CertificateSerializer::class) X509Certificate?,
     val providerName: TEName,
-    val serviceType: String
+    val serviceType: LoTEServiceType
 )
 
 data class LoTEFilterCriteria(
-    val expectedServiceType: String,
+    val expectedServiceType: LoTEServiceType,
 )
+
+enum class LoTEServiceType(val type: String) {
+    PID("pid"),
+    MDL("mdl"),
+    WRPAC("wrpac"),
+    EAA("eaa"),
+    WALLET("wallet");
+
+    companion object {
+        /**
+         * Resolves a raw scheme type string into a safe Enum
+         */
+        fun fromSchemeType(rawSchemeType: String?): LoTEServiceType? {
+            if (rawSchemeType.isNullOrBlank()) return null
+
+            return when {
+                rawSchemeType.contains("pid", ignoreCase = true) -> PID
+                rawSchemeType.contains("mdl", ignoreCase = true) -> MDL
+                rawSchemeType.contains("wrpac", ignoreCase = true) -> WRPAC
+                rawSchemeType.contains("eaa", ignoreCase = true) -> EAA
+                rawSchemeType.contains("wallet", ignoreCase = true) -> WALLET
+                else -> null
+            }
+        }
+    }
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterService.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterService.kt
@@ -20,7 +20,7 @@ class LoTEFilterService {
      */
     fun extractTrustedCertificates(sourceUrl: String, lote: ListOfTrustedEntities, criteria: LoTEFilterCriteria): List<TrustedCertificate> {
         val entities = lote.trustedEntitiesList ?: return emptyList()
-
+        val loteType = lote.listAndSchemeInformation?.loteType?.toString()
         return entities.flatMap { entity ->
             val providerName = entity.trustedEntityInformation.teName
 
@@ -33,6 +33,7 @@ class LoTEFilterService {
                         serviceTypeId.contains(criteria.expectedServiceType.type, ignoreCase = true)
                     } else {
                         // Field is absent. The services inherit the list's default type
+                        loteType?.contains(criteria.expectedServiceType.type, ignoreCase = true) == true ||
                         sourceUrl.contains(criteria.expectedServiceType.type, ignoreCase = true)
                     }
                 }

--- a/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterTest.kt
+++ b/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterTest.kt
@@ -7029,21 +7029,21 @@ val LoTEFilterTest by matrixSuite {
 
     data class TestData(
         val json: String,
-        val expectedServiceType: String
+        val fetchUrl: String
     )
 
     testSuite("filter lote by type identifier") {
         mapOf(
-            "pidProviders" to TestData(pidProvidersFixed, "http://uri.etsi.org/19602/SvcType/PID/Issuance"),
-            "walletProviders" to TestData(walletProvidersFixed, "http://uri.etsi.org/19602/SvcType/WalletSolution/Issuance"),
-            "wrpacProviders" to TestData(wrpacProvidersFixed, "http://uri.etsi.org/19602/SvcType/WRPAC/Issuance"),
-            "mdlProviders" to TestData(mdlProvidersFixed, "http://uri.etsi.org/19602/SvcType/mDL/Issuance"),
+            "pidProviders" to TestData(pidProvidersFixed, "https://acceptance.trust.tech.ec.europa.eu/lists/eudiw/pid-providers.json"),
+            "walletProviders" to TestData(walletProvidersFixed, "https://acceptance.trust.tech.ec.europa.eu/lists/eudiw/wallet-providers.json"),
+            "wrpacProviders" to TestData(wrpacProvidersFixed, "https://acceptance.trust.tech.ec.europa.eu/lists/eudiw/wrpac-providers.json"),
+            "mdlProviders" to TestData(mdlProvidersFixed, "https://acceptance.trust.tech.ec.europa.eu/lists/eudiw/mdl-providers.json"),
         ).asData() test{ (_, data) ->
             val lote = Json.decodeFromString<ListOfTrustedEntities>(data.json)
 
-            val criteria = LoTEFilterCriteria(expectedServiceType = data.expectedServiceType)
+            val criteria = LoTEFilterCriteria(expectedServiceType = LoTEServiceType.fromSchemeType(data.fetchUrl)!!)
 
-            val trustedCerts = LoTEFilterService().extractTrustedCertificates(lote, criteria)
+            val trustedCerts = LoTEFilterService().extractTrustedCertificates(data.fetchUrl, lote, criteria)
 
             trustedCerts.size shouldNotBe(0)
         }

--- a/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterTest.kt
+++ b/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterTest.kt
@@ -7029,23 +7029,40 @@ val LoTEFilterTest by matrixSuite {
 
     data class TestData(
         val json: String,
-        val fetchUrl: String
+        val fetchUrl: String,
+        val schemeIdentifier: String? = null,
+        val fixedType: LoTEServiceType? = null
     )
 
     testSuite("filter lote by type identifier") {
         mapOf(
-            "pidProviders" to TestData(pidProvidersFixed, LoTEServiceType.PID.defaultUrl()),
-            "walletProviders" to TestData(walletProvidersFixed, LoTEServiceType.WALLET.defaultUrl()),
-            "wrpacProviders" to TestData(wrpacProvidersFixed, LoTEServiceType.WRPAC.defaultUrl()),
-            "mdlProviders" to TestData(mdlProvidersFixed, LoTEServiceType.MDL.defaultUrl()),
-        ).asData() test{ (_, data) ->
+            "pidProviders" to TestData(
+                json = pidProvidersFixed,
+                fetchUrl = LoTEServiceType.PID.defaultUrl(),
+                schemeIdentifier = "urn:eudi:pid:de:1"
+            ),
+            "walletProviders" to TestData(
+                json = walletProvidersFixed,
+                fetchUrl = LoTEServiceType.WALLET.defaultUrl(),
+                fixedType = LoTEServiceType.WALLET
+            ),
+            "wrpacProviders" to TestData(
+                json = wrpacProvidersFixed,
+                fetchUrl = LoTEServiceType.WRPAC.defaultUrl(),
+                fixedType = LoTEServiceType.WRPAC
+            ),
+            "mdlProviders" to TestData(
+                json = mdlProvidersFixed,
+                fetchUrl = LoTEServiceType.MDL.defaultUrl(),
+                schemeIdentifier = "org.iso.18013.5.1.mDL"
+            ),
+        ).asData() test { (_, data) ->
             val lote = Json.decodeFromString<ListOfTrustedEntities>(data.json)
-
-            val criteria = LoTEFilterCriteria(expectedServiceType = LoTEServiceType.fromSchemeType(data.fetchUrl)!!)
-
+            val expectedType = data.fixedType ?: LoTEServiceType.fromSchemeIdentifier(data.schemeIdentifier)
+            val criteria = LoTEFilterCriteria(expectedServiceType = expectedType)
             val trustedCerts = LoTEFilterService().extractTrustedCertificates(data.fetchUrl, lote, criteria)
 
-            trustedCerts.size shouldNotBe(0)
+            trustedCerts.size shouldNotBe 0
         }
     }
 }

--- a/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterTest.kt
+++ b/vck/src/jvmTest/kotlin/at/asitplus/wallet/lib/etsi/LoTEFilterTest.kt
@@ -7034,10 +7034,10 @@ val LoTEFilterTest by matrixSuite {
 
     testSuite("filter lote by type identifier") {
         mapOf(
-            "pidProviders" to TestData(pidProvidersFixed, "https://acceptance.trust.tech.ec.europa.eu/lists/eudiw/pid-providers.json"),
-            "walletProviders" to TestData(walletProvidersFixed, "https://acceptance.trust.tech.ec.europa.eu/lists/eudiw/wallet-providers.json"),
-            "wrpacProviders" to TestData(wrpacProvidersFixed, "https://acceptance.trust.tech.ec.europa.eu/lists/eudiw/wrpac-providers.json"),
-            "mdlProviders" to TestData(mdlProvidersFixed, "https://acceptance.trust.tech.ec.europa.eu/lists/eudiw/mdl-providers.json"),
+            "pidProviders" to TestData(pidProvidersFixed, LoTEServiceType.PID.defaultUrl()),
+            "walletProviders" to TestData(walletProvidersFixed, LoTEServiceType.WALLET.defaultUrl()),
+            "wrpacProviders" to TestData(wrpacProvidersFixed, LoTEServiceType.WRPAC.defaultUrl()),
+            "mdlProviders" to TestData(mdlProvidersFixed, LoTEServiceType.MDL.defaultUrl()),
         ).asData() test{ (_, data) ->
             val lote = Json.decodeFromString<ListOfTrustedEntities>(data.json)
 


### PR DESCRIPTION
- Fix filtering of the Trust Lists, where absence of the `ServiceTypeIdentifier` signifies that all listed trusted entity 
services are of the same type. Previous filtering logic was too strict