### PR TITLE
Rework Status List Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Release 7.0.0 (unreleased):
 - OpenID for Verifiable Credential Issuance:
     - Wallet does not send any proofs when the issuer doesn't [support any proof types](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.4-2.11.2.5.1)
    - Update Wallet Instance Attestation and Key Attestation to [EUDI Wallet TS3 1.5.2](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md) from 2026-05-26
+   - In `IssuerAgent` introduce constructor parameter `statusListAgent` to decouple creation of status elements from issuing credentials
 - JVM interoperability:
     - Add `@JvmOverloads` to public API constructors with default parameters across the published modules.
 - Refactorings:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,10 @@ Release 7.0.0 (unreleased):
     - Extract `VpTokenValidator` from common code in `OpenId4VpVerifier` and `DcApiVerifier`
 - OpenID for Verifiable Credential Issuance:
     - Wallet does not send any proofs when the issuer doesn't [support any proof types](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.4-2.11.2.5.1)
-   - Update Wallet Instance Attestation and Key Attestation to [EUDI Wallet TS3 1.5.2](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md) from 2026-05-26
-   - In `IssuerAgent` introduce constructor parameter `statusListAgent` to decouple creation of status elements from issuing credentials
+    - Update Wallet Instance Attestation and Key Attestation to [EUDI Wallet TS3 1.5.2](https://github.com/eu-digital-identity-wallet/eudi-doc-standards-and-technical-specifications/blob/main/docs/technical-specifications/ts3-wallet-unit-attestation.md) from 2026-05-26
+    - In `IssuerAgent` introduce constructor parameter `statusListAgent` to decouple creation of status elements from issuing credentials
+    - Rework `IssuerCredentialStore` by moving some functionality to `ReferencedTokenStore`
+    - Status claims for identifier lists from ISO 18013-5 contain the certificate of the status list issuer
 - JVM interoperability:
     - Add `@JvmOverloads` to public API constructors with default parameters across the published modules.
 - Refactorings:

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredential.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredential.kt
@@ -70,7 +70,7 @@ data class VerifiableCredential(
         issuer: String,
         issuanceDate: Instant,
         expirationDate: Instant?,
-        credentialStatus: RevocationListInfo,
+        credentialStatus: RevocationListInfo?,
         credentialSubject: JsonElement,
         credentialType: String,
     ) : this(

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/RevocationList.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/RevocationList.kt
@@ -5,21 +5,22 @@ package at.asitplus.wallet.lib.data.rfc.tokenStatusList
  * credentials.
  *
  * Two transport formats are supported:
- * - [StatusList] for the IETF OAuth Status List draft (compressed bitset, referenced from JOSE/COSE).
- * - [IdentifierList] for ISO 18013-5 mobile document revocation (identifier list with optional
+ * - [StatusList] for the IETF Token Status List draft (compressed bitset, referenced from JOSE/COSE).
+ * - [IdentifierList] for ISO/IEC 18013-5 mobile document revocation (identifier list with optional
  *   certificate anchor).
  */
 sealed class RevocationList {
 
     /**
-     * `kind` lets runtime components (issuers, resolvers, validators) pick the correct
-     * serialization and validation pipeline without relying on generics, which are awkward to use across
-     * KMP interfaces.
+     * Lets runtime components (issuers, resolvers, validators) pick the correct
+     * serialization and validation pipeline without relying on generics,
+     * which are awkward to use across KMP interfaces.
      */
-    enum class Kind{
-        /** OAuth Status List (draft-ietf-oauth-status-list) bitset-based representation. */
+    enum class Kind {
+        /** Token Status List bitset-based representation. */
         STATUS_LIST,
-        /** ISO 18013-5 IdentifierList representation. */
+
+        /** ISO/IEC 18013-5 IdentifierList representation. */
         IDENTIFIER_LIST
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
@@ -12,64 +12,83 @@ import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatusBitSize
 import com.benasher44.uuid.uuid4
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.time.Instant
 
 class InMemoryIssuerCredentialStore(
     val tokenStatusBitSize: TokenStatusBitSize = TokenStatusBitSize.ONE,
 ) : IssuerCredentialStore, ReferencedTokenStore {
-    // TODO Check if necessary
     private val indexMutex = Mutex()
 
     data class Credential(
         val vcId: String,
         val statusListIndex: ULong,
         var status: TokenStatus,
-        val expirationDate: Instant,
-        val scheme: CredentialScheme,
     )
 
-    /** Maps timePeriod to credentials */
-    private val credentialMap = mutableMapOf<Int, MutableList<Credential>>()
+    /** Maps timePeriod to credentials for referenced tokens which may be revoked later on */
+    private val referencedTokens = mutableMapOf<Int, MutableList<Credential>>()
+
+    /** Tracks issued credentials */
+    private val issuedCredentials = mutableListOf<Issuer.IssuedCredential>()
 
     /** Tracks revoked identifiers for timePeriod to build [IdentifierList]; Sets to remove duplicates */
     private val identifierRevocationList = mutableMapOf<Int, MutableSet<String>>()
 
-    override suspend fun createStoredCredentialReference(
+    override suspend fun storeReferencedToken(
         credential: CredentialToBeIssued,
         timePeriod: Int,
-    ): KmmResult<IssuerCredentialStore.StoredCredentialReference> = catching {
-        val list = credentialMap.getOrPut(timePeriod) { mutableListOf() }
-        val newIndex: ULong = (list.maxOfOrNull { it.statusListIndex } ?: 0U) + 1U
-        val vcId = uuid4().toString()
-        list += Credential(
-            vcId = vcId,
-            statusListIndex = newIndex,
-            status = TokenStatus.Valid,
-            expirationDate = credential.expiration,
-            scheme = credential.scheme,
-        )
-        IssuerCredentialStore.StoredCredentialReference(vcId, timePeriod, newIndex)
+    ): KmmResult<ReferencedTokenStore.StoredCredentialReference> = catching {
+        indexMutex.withLock {
+            val list = referencedTokens.getOrPut(timePeriod) { mutableListOf() }
+            val newIndex: ULong = (list.maxOfOrNull { it.statusListIndex } ?: 0U) + 1U
+            val vcId = uuid4().toString()
+            list += Credential(
+                vcId = vcId,
+                statusListIndex = newIndex,
+                status = TokenStatus.Valid,
+            )
+            ReferencedTokenStore.StoredCredentialReference(
+                id = vcId,
+                timePeriod = timePeriod,
+                statusListIndex = newIndex
+            )
+        }
     }
 
+    @Deprecated("Use method from `ReferencedTokenStore` instead")
+    @Suppress("DEPRECATION")
+    override suspend fun createStoredCredentialReference(
+        credential: CredentialToBeIssued,
+        timePeriod: Int
+    ): KmmResult<IssuerCredentialStore.StoredCredentialReference> =
+        storeReferencedToken(credential, timePeriod).map {
+            IssuerCredentialStore.StoredCredentialReference(
+                id = it.id,
+                timePeriod = it.timePeriod,
+                statusListIndex = it.statusListIndex
+            )
+        }
+
+    @Suppress("DEPRECATION")
+    @Deprecated("Issuer will call onCredentialStored instead")
     override suspend fun updateStoredCredential(
         reference: IssuerCredentialStore.StoredCredentialReference,
         credential: Issuer.IssuedCredential,
     ): KmmResult<IssuerCredentialStore.StoredCredentialReference> = catching {
-        val list = credentialMap.getOrPut(reference.timePeriod) { mutableListOf() }
-        if (list.find { it.vcId == reference.id } == null) {
-            list += Credential(
-                vcId = reference.id,
-                statusListIndex = reference.statusListIndex,
-                status = TokenStatus.Valid,
-                expirationDate = credential.validUntil,
-                scheme = credential.scheme
-            )
+        val list = referencedTokens.getOrPut(reference.timePeriod) { mutableListOf() }
+        require(list.find { it.vcId == reference.id } != null) {
+            "Updating a credential that we did not create before"
         }
         reference
     }
 
+    override suspend fun onCredentialIssued(credential: Issuer.IssuedCredential) {
+        issuedCredentials += credential
+    }
+
     override fun getStatusListView(timePeriod: Int): StatusListView {
-        val timePeriodStatusCollection = credentialMap[timePeriod]
+        val timePeriodStatusCollection = referencedTokens[timePeriod]
             ?: return StatusListView(ByteArray(0), tokenStatusBitSize)
 
         val timePeriodStatusMap = timePeriodStatusCollection.associate {
@@ -107,7 +126,7 @@ class InMemoryIssuerCredentialStore(
         index: ULong,
         status: TokenStatus,
     ): Boolean {
-        val entry = credentialMap.getOrPut(timePeriod) {
+        val entry = referencedTokens.getOrPut(timePeriod) {
             mutableListOf()
         }.find {
             it.statusListIndex == index
@@ -131,7 +150,7 @@ class InMemoryIssuerCredentialStore(
         timePeriod: Int,
         identifier: ByteArray
     ): Boolean {
-        val entry = credentialMap.getOrPut(timePeriod) {
+        val entry = referencedTokens.getOrPut(timePeriod) {
             mutableListOf()
         }.find {
             it.vcId == identifier.decodeToString()

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/InMemoryIssuerCredentialStore.kt
@@ -17,6 +17,7 @@ import kotlin.time.Instant
 class InMemoryIssuerCredentialStore(
     val tokenStatusBitSize: TokenStatusBitSize = TokenStatusBitSize.ONE,
 ) : IssuerCredentialStore, ReferencedTokenStore {
+    // TODO Check if necessary
     private val indexMutex = Mutex()
 
     data class Credential(
@@ -96,7 +97,8 @@ class InMemoryIssuerCredentialStore(
      * Set the [status] of the referenced token with this [index] for the [timePeriod], if it exists.
      *
      * If [status] is [TokenStatus.Invalid] the associated identifier will be added to [identifierRevocationList]
-     * Note that ISO 18-013 does not support any action besides full revocation. If a credential has been suspended it remains suspended.
+     * Note that ISO 18-013 does not support any action besides full revocation.
+     * If a credential has been suspended, it remains suspended.
      *
      * Care must be taken to handle drift between the two systems and it is recommended to use only one at a time.
      */
@@ -122,7 +124,8 @@ class InMemoryIssuerCredentialStore(
      * Set the status of the referenced token with this [identifier] for the [timePeriod] to revoked, if it exists.
      * Additionally the `TokenStatus` at the associated `StatusListIndex` is also automatically set to invalid
      *
-     * ISO 18-013 does not support any action besides full revocation. If a credential has been suspended it remains suspended
+     * ISO 18-013 does not support any action besides full revocation.
+     * If a credential has been suspended, it remains suspended.
      */
     override fun revokeIdentifier(
         timePeriod: Int,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -62,9 +62,12 @@ import kotlin.time.Instant
  * An agent that implements [Issuer], i.e., it issues credentials for other agents.
  */
 class IssuerAgent @JvmOverloads constructor(
+    /** Key material used to sign credentials in [signIssuedVc], [signIssuedSdJwt], [signMobileSecurityObject]. */
     override val keyMaterial: KeyMaterial = EphemeralKeyWithoutCert(),
     private val issuerCredentialStore: IssuerCredentialStore = InMemoryIssuerCredentialStore(),
+    @Suppress("unused") @Deprecated("Set value for statusListAgent instead")
     private val statusListBaseUrl: String = "https://wallet.a-sit.at/backend/credentials/status",
+    @Suppress("unused") @Deprecated("Set value for statusListAgent instead")
     private val identifierListBaseUrl: String = "https://wallet.a-sit.at/backend/credentials/identifier",
     private val clock: Clock = Clock.System,
     /** Time to adjust the [Clock.now] for issuance date of credentials. */
@@ -73,12 +76,18 @@ class IssuerAgent @JvmOverloads constructor(
     private val timePeriodProvider: TimePeriodProvider = FixedTimePeriodProvider,
     /** The identifier used in `issuer` properties of credentials (JWT VC and SD JWT). */
     private val identifier: UniformResourceIdentifier,
-    private val signIssuedSdJwt: SignJwtExtFun<JsonObject> = SignJwtExt(keyMaterial, JwsHeaderCertOrJwk()),
-    private val signIssuedVc: SignJwtFun<VerifiableCredentialJws> = SignJwt(keyMaterial, JwsHeaderCertOrJwk()),
+    private val signIssuedSdJwt: SignJwtExtFun<JsonObject> =
+        SignJwtExt(keyMaterial, JwsHeaderCertOrJwk()),
+    private val signIssuedVc: SignJwtFun<VerifiableCredentialJws> =
+        SignJwt(keyMaterial, JwsHeaderCertOrJwk()),
     private val signMobileSecurityObject: SignCoseFun<MobileSecurityObject> =
         SignCose(keyMaterial, CoseHeaderNone(), CoseHeaderCertificate()),
     /** Source for random bytes, i.e., salts for selective-disclosure items. */
     private val randomSource: RandomSource = RandomSource.Secure,
+    /** Set if we want to set the `status` claim of issued credentials to point to a Status List */
+    private val statusListAgent: StatusListAgent? = StatusListAgent(
+        issuerCredentialStore = issuerCredentialStore as? InMemoryIssuerCredentialStore ?: InMemoryIssuerCredentialStore(),
+    )
 ) : Issuer {
 
     /**
@@ -96,7 +105,6 @@ class IssuerAgent @JvmOverloads constructor(
         }
     }
 
-
     private suspend fun issueMdoc(
         credential: CredentialToBeIssued.Iso,
         issuanceDate: Instant,
@@ -108,17 +116,19 @@ class IssuerAgent @JvmOverloads constructor(
             .getOrElse { throw IllegalStateException("Could not create subject COSE key", it) }
         val deviceKeyInfo = DeviceKeyInfo(coseKey)
 
-        val credentialStatus = when (credential.revocationKind) {
-            RevocationList.Kind.STATUS_LIST -> StatusListInfo(
-                index = reference.statusListIndex,
-                uri = UniformResourceIdentifier(getStatusListUrlFor(timePeriod)),
-            )
+        val credentialStatus = statusListAgent?.let {
+            when (credential.revocationKind) {
+                RevocationList.Kind.STATUS_LIST -> StatusListInfo(
+                    index = reference.statusListIndex,
+                    uri = UniformResourceIdentifier(statusListAgent.getStatusListUrlFor(timePeriod)),
+                )
 
-            RevocationList.Kind.IDENTIFIER_LIST -> IdentifierListInfo(
-                identifier = reference.id.encodeToByteArray(),
-                uri = UniformResourceIdentifier(getIdentifierListUrlFor(timePeriod)),
-                certificate = null //TODO
-            )
+                RevocationList.Kind.IDENTIFIER_LIST -> IdentifierListInfo(
+                    identifier = reference.id.encodeToByteArray(),
+                    uri = UniformResourceIdentifier(statusListAgent.getIdentifierListUrlFor(timePeriod)),
+                    certificate = null //TODO statusListAgent.certificate()
+                )
+            }
         }
         val mso = MobileSecurityObject(
             version = "1.0",
@@ -165,10 +175,12 @@ class IssuerAgent @JvmOverloads constructor(
         val expirationDate = credential.expiration
         val timePeriod = timePeriodProvider.getTimePeriodFor(issuanceDate)
         val reference = issuerCredentialStore.createStoredCredentialReference(credential, timePeriod).getOrThrow()
-        val credentialStatus = StatusListInfo(
-            index = reference.statusListIndex,
-            uri = UniformResourceIdentifier(getStatusListUrlFor(timePeriod)),
-        )
+        val credentialStatus = statusListAgent?.let {
+            StatusListInfo(
+                index = reference.statusListIndex,
+                uri = UniformResourceIdentifier(statusListAgent.getStatusListUrlFor(timePeriod)),
+            )
+        }
         val vc = VerifiableCredential(
             id = vcId,
             issuer = identifier.string,
@@ -206,10 +218,12 @@ class IssuerAgent @JvmOverloads constructor(
         val timePeriod = timePeriodProvider.getTimePeriodFor(issuanceDate)
         val subjectId = credential.subjectPublicKey.didEncoded // TODO not necessarily!
         val reference = issuerCredentialStore.createStoredCredentialReference(credential, timePeriod).getOrThrow()
-        val credentialStatus = StatusListInfo(
-            index = reference.statusListIndex,
-            uri = UniformResourceIdentifier(getStatusListUrlFor(timePeriod)),
-        )
+        val credentialStatus = statusListAgent?.let {
+            StatusListInfo(
+                index = reference.statusListIndex,
+                uri = UniformResourceIdentifier(statusListAgent.getStatusListUrlFor(timePeriod)),
+            )
+        }
         val (sdJwt, disclosures) = credential.claims.toSdJsonObject(randomSource, credential.sdAlgorithm)
         val cnf = ConfirmationClaim(jsonWebKey = credential.subjectPublicKey.toJsonWebKey())
         val vcSdJwt = VerifiableCredentialSdJwt(
@@ -251,14 +265,6 @@ class IssuerAgent @JvmOverloads constructor(
         ).also {
             issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
         }
-    }
-
-    private fun getStatusListUrlFor(timePeriod: Int) = statusListBaseUrl.let {
-        it + (if (!it.endsWith('/')) "/" else "") + timePeriod
-    }
-
-    private fun getIdentifierListUrlFor(timePeriod: Int) = identifierListBaseUrl.let {
-        it + (if (!it.endsWith('/')) "/" else "") + timePeriod
     }
 
     private fun VerifiableCredential.toJws() = VerifiableCredentialJws(

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerAgent.kt
@@ -35,9 +35,6 @@ import at.asitplus.wallet.lib.data.VerifiableCredential
 import at.asitplus.wallet.lib.data.VerifiableCredentialJws
 import at.asitplus.wallet.lib.data.VerifiableCredentialSdJwt
 import at.asitplus.wallet.lib.data.ktx.extractId
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.IdentifierListInfo
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationList
-import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListInfo
 import at.asitplus.wallet.lib.data.rfc3986.UniformResourceIdentifier
 import at.asitplus.wallet.lib.jws.JwsContentTypeConstants
 import at.asitplus.wallet.lib.jws.JwsHeaderCertOrJwk
@@ -73,6 +70,7 @@ class IssuerAgent @JvmOverloads constructor(
     /** Time to adjust the [Clock.now] for issuance date of credentials. */
     private val issuanceOffset: Duration = (-3).minutes,
     override val cryptoAlgorithms: Set<SignatureAlgorithm> = setOf(keyMaterial.signatureAlgorithm),
+    @Suppress("unused") @Deprecated("Set value for statusListAgent instead")
     private val timePeriodProvider: TimePeriodProvider = FixedTimePeriodProvider,
     /** The identifier used in `issuer` properties of credentials (JWT VC and SD JWT). */
     private val identifier: UniformResourceIdentifier,
@@ -110,26 +108,9 @@ class IssuerAgent @JvmOverloads constructor(
         issuanceDate: Instant,
     ): Issuer.IssuedCredential {
         val expirationDate = credential.expiration
-        val timePeriod = timePeriodProvider.getTimePeriodFor(issuanceDate)
-        val reference = issuerCredentialStore.createStoredCredentialReference(credential, timePeriod).getOrThrow()
         val coseKey = credential.subjectPublicKey.toCoseKey()
             .getOrElse { throw IllegalStateException("Could not create subject COSE key", it) }
         val deviceKeyInfo = DeviceKeyInfo(coseKey)
-
-        val credentialStatus = statusListAgent?.let {
-            when (credential.revocationKind) {
-                RevocationList.Kind.STATUS_LIST -> StatusListInfo(
-                    index = reference.statusListIndex,
-                    uri = UniformResourceIdentifier(statusListAgent.getStatusListUrlFor(timePeriod)),
-                )
-
-                RevocationList.Kind.IDENTIFIER_LIST -> IdentifierListInfo(
-                    identifier = reference.id.encodeToByteArray(),
-                    uri = UniformResourceIdentifier(statusListAgent.getIdentifierListUrlFor(timePeriod)),
-                    certificate = null //TODO statusListAgent.certificate()
-                )
-            }
-        }
         val mso = MobileSecurityObject(
             version = "1.0",
             digestAlgorithm = "SHA-256",
@@ -145,7 +126,7 @@ class IssuerAgent @JvmOverloads constructor(
                 validFrom = issuanceDate,
                 validUntil = expirationDate,
             ),
-            status = credentialStatus
+            status = statusListAgent?.provideStatusReference(credential, issuanceDate)
         )
         val issuerSigned = IssuerSigned.fromIssuerSignedItems(
             namespacedItems = mapOf(credential.scheme.isoNamespace to credential.issuerSignedItems),
@@ -163,7 +144,7 @@ class IssuerAgent @JvmOverloads constructor(
             subjectPublicKey = credential.subjectPublicKey,
             userInfo = credential.userInfo
         ).also {
-            issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
+            issuerCredentialStore.onCredentialIssued(it)
         }
     }
 
@@ -173,20 +154,12 @@ class IssuerAgent @JvmOverloads constructor(
     ): Issuer.IssuedCredential {
         val vcId = "urn:uuid:${uuid4()}"
         val expirationDate = credential.expiration
-        val timePeriod = timePeriodProvider.getTimePeriodFor(issuanceDate)
-        val reference = issuerCredentialStore.createStoredCredentialReference(credential, timePeriod).getOrThrow()
-        val credentialStatus = statusListAgent?.let {
-            StatusListInfo(
-                index = reference.statusListIndex,
-                uri = UniformResourceIdentifier(statusListAgent.getStatusListUrlFor(timePeriod)),
-            )
-        }
         val vc = VerifiableCredential(
             id = vcId,
             issuer = identifier.string,
             issuanceDate = issuanceDate,
             expirationDate = expirationDate,
-            credentialStatus = credentialStatus,
+            credentialStatus = statusListAgent?.provideStatusReference(credential, issuanceDate),
             credentialSubject = credential.subject,
             credentialType = credential.scheme.vcType,
         )
@@ -206,7 +179,7 @@ class IssuerAgent @JvmOverloads constructor(
             subjectPublicKey = credential.subjectPublicKey,
             userInfo = credential.userInfo,
         ).also {
-            issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
+            issuerCredentialStore.onCredentialIssued(it)
         }
     }
 
@@ -215,15 +188,7 @@ class IssuerAgent @JvmOverloads constructor(
         issuanceDate: Instant,
     ): Issuer.IssuedCredential {
         val expirationDate = credential.expiration
-        val timePeriod = timePeriodProvider.getTimePeriodFor(issuanceDate)
         val subjectId = credential.subjectPublicKey.didEncoded // TODO not necessarily!
-        val reference = issuerCredentialStore.createStoredCredentialReference(credential, timePeriod).getOrThrow()
-        val credentialStatus = statusListAgent?.let {
-            StatusListInfo(
-                index = reference.statusListIndex,
-                uri = UniformResourceIdentifier(statusListAgent.getStatusListUrlFor(timePeriod)),
-            )
-        }
         val (sdJwt, disclosures) = credential.claims.toSdJsonObject(randomSource, credential.sdAlgorithm)
         val cnf = ConfirmationClaim(jsonWebKey = credential.subjectPublicKey.toJsonWebKey())
         val vcSdJwt = VerifiableCredentialSdJwt(
@@ -235,7 +200,7 @@ class IssuerAgent @JvmOverloads constructor(
             verifiableCredentialType = credential.scheme.sdJwtType,
             selectiveDisclosureAlgorithm = credential.sdAlgorithm.toIanaName(),
             confirmationClaim = cnf,
-            statusElement = credentialStatus
+            statusElement = statusListAgent?.provideStatusReference(credential, issuanceDate)
         )
         val vcSdJwtObject = joseCompliantSerializer.encodeToJsonElement(vcSdJwt).jsonObject
         val entireObject = buildJsonObject {
@@ -263,7 +228,7 @@ class IssuerAgent @JvmOverloads constructor(
             subjectPublicKey = credential.subjectPublicKey,
             userInfo = credential.userInfo,
         ).also {
-            issuerCredentialStore.updateStoredCredential(reference, it).getOrThrow()
+            issuerCredentialStore.onCredentialIssued(it)
         }
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IssuerCredentialStore.kt
@@ -7,26 +7,29 @@ import at.asitplus.KmmResult
  */
 interface IssuerCredentialStore {
 
+    @Deprecated("Use data class from `ReferencedTokenStore` instead")
     data class StoredCredentialReference(
         val id: String,
         val timePeriod: Int,
         val statusListIndex: ULong,
     )
 
-    /**
-     * Called by an [Issuer] when creating a new credential to get a `statusListIndex` and `identifier first.
-     * [Issuer] will call [updateStoredCredential] with the issued credential afterwards.
-     */
+    @Deprecated("Use method from `ReferencedTokenStore` instead")
     suspend fun createStoredCredentialReference(
         credential: CredentialToBeIssued,
         timePeriod: Int,
     ): KmmResult<StoredCredentialReference>
 
-    /**
-     * Called by an [Issuer] when the credential has been signed and delivered to the holder.
-     */
+    @Deprecated("Issuer will call onCredentialStored instead")
     suspend fun updateStoredCredential(
         reference: StoredCredentialReference,
         credential: Issuer.IssuedCredential,
     ): KmmResult<StoredCredentialReference>
+
+    /**
+     * Called by an [Issuer] when the credential has been signed and delivered to the holder.
+     */
+    suspend fun onCredentialIssued(
+        credential: Issuer.IssuedCredential,
+    )
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListAgent.kt
@@ -38,7 +38,8 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
 
 /**
- * An agent that implements [StatusListIssuer], i.e. it manages status of credentials and status lists.
+ * An agent that implements [StatusListIssuer] for a Status Issuer in the sense of
+ * [Token Status List (TSL)](https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-21.html).
  */
 class StatusListAgent @JvmOverloads constructor(
     /** Should either be [PublishedKeyMaterial] or contain a certificate, so clients can look up the key. */
@@ -76,7 +77,10 @@ class StatusListAgent @JvmOverloads constructor(
     override suspend fun issueStatusListCwt(time: Instant?, kind: RevocationList.Kind) =
         issueStatusListCwt(time.toTimePeriod(), kind)
 
-    override suspend fun issueStatusListJwt(timePeriod: Int, kind: RevocationList.Kind): JwsCompactTyped<StatusListTokenPayload> =
+    override suspend fun issueStatusListJwt(
+        timePeriod: Int,
+        kind: RevocationList.Kind
+    ): JwsCompactTyped<StatusListTokenPayload> =
         catching {
             require(kind == RevocationList.Kind.STATUS_LIST) { "JWT only supports revocation list kind StatusList" }
         }.transform {
@@ -100,6 +104,7 @@ class StatusListAgent @JvmOverloads constructor(
                 throw IllegalStateException("Status token could not be created", it)
             }
         }
+
     private fun RevocationList.Kind.mediaType(): String =
         if (this == RevocationList.Kind.STATUS_LIST)
             MediaTypes.Application.STATUSLIST_CWT
@@ -211,11 +216,11 @@ class StatusListAgent @JvmOverloads constructor(
         return list
     }
 
-    private fun getStatusListUrlFor(timePeriod: Int) = statusListBaseUrl.let {
+    internal fun getStatusListUrlFor(timePeriod: Int) = statusListBaseUrl.let {
         it + (if (!it.endsWith('/')) "/" else "") + timePeriod
     }
 
-    private fun getIdentifierListUrlFor(timePeriod: Int) = identifierListBaseUrl.let {
+    internal fun getIdentifierListUrlFor(timePeriod: Int) = identifierListBaseUrl.let {
         it + (if (!it.endsWith('/')) "/" else "") + timePeriod
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListAgent.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListAgent.kt
@@ -3,6 +3,7 @@ package at.asitplus.wallet.lib.agent
 import at.asitplus.catching
 import at.asitplus.openid.truncateToSeconds
 import at.asitplus.signum.indispensable.cosef.CoseHeader
+import at.asitplus.signum.indispensable.cosef.CoseSigned
 import at.asitplus.signum.indispensable.cosef.io.coseCompliantSerializer
 import at.asitplus.signum.indispensable.josef.JwsCompactTyped
 import at.asitplus.wallet.lib.DefaultZlibService
@@ -15,9 +16,14 @@ import at.asitplus.wallet.lib.data.StatusListCwt
 import at.asitplus.wallet.lib.data.StatusListJwt
 import at.asitplus.wallet.lib.data.StatusListToken
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.IdentifierList
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.IdentifierListInfo
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.MediaTypes
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationList
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationList.Kind.IDENTIFIER_LIST
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationList.Kind.STATUS_LIST
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationListInfo
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListAggregation
+import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListInfo
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListTokenPayload
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.ReferencedTokenStore
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.communication.primitives.StatusListTokenMediaType
@@ -74,7 +80,10 @@ class StatusListAgent @JvmOverloads constructor(
      * Wraps the revocation information from [issuerCredentialStore] into a Status List Token,
      * returns a CWS representation of that.
      */
-    override suspend fun issueStatusListCwt(time: Instant?, kind: RevocationList.Kind) =
+    override suspend fun issueStatusListCwt(
+        time: Instant?,
+        kind: RevocationList.Kind
+    ): CoseSigned<ByteArray> =
         issueStatusListCwt(time.toTimePeriod(), kind)
 
     override suspend fun issueStatusListJwt(
@@ -82,7 +91,7 @@ class StatusListAgent @JvmOverloads constructor(
         kind: RevocationList.Kind
     ): JwsCompactTyped<StatusListTokenPayload> =
         catching {
-            require(kind == RevocationList.Kind.STATUS_LIST) { "JWT only supports revocation list kind StatusList" }
+            require(kind == STATUS_LIST) { "JWT only supports revocation list kind StatusList" }
         }.transform {
             signStatusListJwt(
                 type = MediaTypes.STATUSLIST_JWT,
@@ -105,51 +114,49 @@ class StatusListAgent @JvmOverloads constructor(
             }
         }
 
-    private fun RevocationList.Kind.mediaType(): String =
-        if (this == RevocationList.Kind.STATUS_LIST)
-            MediaTypes.Application.STATUSLIST_CWT
-        else
-            MediaTypes.Application.IDENTIFIERLIST_CWT
+    private fun RevocationList.Kind.mediaType(): String = when (this) {
+        STATUS_LIST -> MediaTypes.Application.STATUSLIST_CWT
+        IDENTIFIER_LIST -> MediaTypes.Application.IDENTIFIERLIST_CWT
+    }
 
     /**
      * Wraps the revocation information from [issuerCredentialStore] into a Token Payload
      */
-    private fun buildStatusListTokenPayload(timePeriod: Int?, kind: RevocationList.Kind): StatusListTokenPayload =
-        StatusListTokenPayload(
-            revocationList = buildRevocationList(timePeriod, kind),
-            issuedAt = clock.now().truncateToSeconds(),
-            timeToLive = PositiveDuration(revocationListLifetime),
-            subject = UniformResourceIdentifier(
-                when (kind) {
-                    RevocationList.Kind.STATUS_LIST -> getStatusListUrlFor(
-                        timePeriod ?: timePeriodProvider.getCurrentTimePeriod(clock)
-                    )
-
-                    RevocationList.Kind.IDENTIFIER_LIST -> getIdentifierListUrlFor(
-                        timePeriod ?: timePeriodProvider.getCurrentTimePeriod(clock)
-                    )
-                }
-            ),
-        ).also {
-            Napier.d("revocation status list: ${it.revocationList}")
-        }
+    private fun buildStatusListTokenPayload(
+        timePeriod: Int?,
+        kind: RevocationList.Kind
+    ): StatusListTokenPayload = StatusListTokenPayload(
+        revocationList = buildRevocationList(timePeriod, kind),
+        issuedAt = clock.now().truncateToSeconds(),
+        timeToLive = PositiveDuration(revocationListLifetime),
+        subject = UniformResourceIdentifier(
+            when (kind) {
+                STATUS_LIST -> getStatusListUrlFor(timePeriod ?: timePeriodProvider.getCurrentTimePeriod(clock))
+                IDENTIFIER_LIST -> getIdentifierListUrlFor(timePeriod ?: timePeriodProvider.getCurrentTimePeriod(clock))
+            }
+        ),
+    ).also {
+        Napier.d("revocation status list: ${it.revocationList}")
+    }
 
     /**
      * Returns a status list, where the entry at "revocationListIndex" (of the credential) is INVALID if it is revoked
      */
-    override fun buildRevocationList(timePeriod: Int?, kind: RevocationList.Kind): RevocationList =
-        when (kind) {
-            RevocationList.Kind.STATUS_LIST -> issuerCredentialStore
-                .getStatusListView(timePeriod ?: timePeriodProvider.getCurrentTimePeriod(clock))
-                .toStatusList(zlibService, statusListAggregationUrl)
+    override fun buildRevocationList(
+        timePeriod: Int?,
+        kind: RevocationList.Kind
+    ): RevocationList = when (kind) {
+        STATUS_LIST -> issuerCredentialStore
+            .getStatusListView(timePeriod ?: timePeriodProvider.getCurrentTimePeriod(clock))
+            .toStatusList(zlibService, statusListAggregationUrl)
 
-            RevocationList.Kind.IDENTIFIER_LIST -> IdentifierList(
-                identifiers = issuerCredentialStore.getRawIdentifierList(
-                    timePeriod ?: timePeriodProvider.getCurrentTimePeriod(clock)
-                ),
-                aggregationUri = identifierListAggregationUrl
-            )
-        }
+        IDENTIFIER_LIST -> IdentifierList(
+            identifiers = issuerCredentialStore.getRawIdentifierList(
+                timePeriod ?: timePeriodProvider.getCurrentTimePeriod(clock)
+            ),
+            aggregationUri = identifierListAggregationUrl
+        )
+    }
 
 
     /**
@@ -171,10 +178,10 @@ class StatusListAgent @JvmOverloads constructor(
         time: Instant?,
         kind: RevocationList.Kind
     ): Pair<StatusListTokenMediaType, StatusListToken> {
-        val preferedType = acceptedContentTypes.firstOrNull()
+        val preferredType = acceptedContentTypes.firstOrNull()
             ?: throw IllegalArgumentException("Argument `acceptedContentTypes` must contain at least one item.")
 
-        return preferedType to when (preferedType) {
+        return preferredType to when (preferredType) {
             StatusListTokenMediaType.Jwt -> StatusListJwt(issueStatusListJwt(time, kind), resolvedAt = clock.now())
             StatusListTokenMediaType.Cwt -> StatusListCwt(issueStatusListCwt(time, kind), resolvedAt = clock.now())
         }
@@ -216,15 +223,49 @@ class StatusListAgent @JvmOverloads constructor(
         return list
     }
 
-    internal fun getStatusListUrlFor(timePeriod: Int) = statusListBaseUrl.let {
+    private fun getStatusListUrlFor(timePeriod: Int) = statusListBaseUrl.let {
         it + (if (!it.endsWith('/')) "/" else "") + timePeriod
     }
 
-    internal fun getIdentifierListUrlFor(timePeriod: Int) = identifierListBaseUrl.let {
+    private fun getIdentifierListUrlFor(timePeriod: Int) = identifierListBaseUrl.let {
         it + (if (!it.endsWith('/')) "/" else "") + timePeriod
     }
 
     fun Instant?.toTimePeriod() = this?.let {
         timePeriodProvider.getTimePeriodFor(it)
     } ?: timePeriodProvider.getCurrentTimePeriod(clock)
+
+    /** Provide a status reference to be included in a [Issuer.IssuedCredential]. */
+    suspend fun provideStatusReference(
+        credential: CredentialToBeIssued.Iso,
+        issuanceDate: Instant
+    ): RevocationListInfo {
+        val timePeriod = timePeriodProvider.getTimePeriodFor(issuanceDate)
+        val reference = issuerCredentialStore.storeReferencedToken(credential, timePeriod).getOrThrow()
+        return when (credential.revocationKind) {
+            STATUS_LIST -> StatusListInfo(
+                index = reference.statusListIndex,
+                uri = UniformResourceIdentifier(getStatusListUrlFor(timePeriod)),
+            )
+
+            IDENTIFIER_LIST -> IdentifierListInfo(
+                identifier = reference.id.encodeToByteArray(),
+                uri = UniformResourceIdentifier(getIdentifierListUrlFor(timePeriod)),
+                certificate = keyMaterial.getCertificate()?.encodeToDer()
+            )
+        }
+    }
+
+    /** Provide a status reference to be included in a [Issuer.IssuedCredential]. */
+    suspend fun provideStatusReference(
+        credential: CredentialToBeIssued,
+        issuanceDate: Instant
+    ): RevocationListInfo {
+        val timePeriod = timePeriodProvider.getTimePeriodFor(issuanceDate)
+        val reference = issuerCredentialStore.storeReferencedToken(credential, timePeriod).getOrThrow()
+        return StatusListInfo(
+            index = reference.statusListIndex,
+            uri = UniformResourceIdentifier(getStatusListUrlFor(timePeriod)),
+        )
+    }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListIssuer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/StatusListIssuer.kt
@@ -5,16 +5,20 @@ import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.StatusIssuer
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents.StatusProvider
 
 /**
- * Summarizes operations for an Issuer in the sense of the [W3C VC Data Model](https://w3c.github.io/vc-data-model/).
+ * Summarizes operations for a Status Issuer in the sense of
+ * [Token Status List (TSL)](https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-21.html).
  *
- * It can issue Verifiable Credentials, revoke credentials and build a revocation list.
+ * See also [at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus].
+ *
+ * It manages the Status List (which describe status of referenced tokens, mostly verifiable credentials),
+ * and issue Status List Tokens (which embed the status list).
  */
 interface StatusListIssuer : StatusIssuer, StatusProvider {
 
     /**
-     * Returns a revocation list which can either be
-     * status list as defined in [TokenListStatus](https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-17.html)
-     * or an identifier list as defined in ISO18013-5
+     * Returns a revocation list which can either be status list as defined in
+     * [Token Status List](https://www.ietf.org/archive/id/draft-ietf-oauth-status-list-21.html)
+     * or an identifier list as defined in ISO/IEC 18013-5:2021.
      */
     fun buildRevocationList(
         timePeriod: Int? = null,
@@ -23,13 +27,15 @@ interface StatusListIssuer : StatusIssuer, StatusProvider {
 
 
     /**
-     * Sets the status of one specific credential to [at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus.Invalid].
+     * Sets the status of one specific credential to
+     * [at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus.Invalid].
      * Returns true if this credential has been revoked.
      */
     fun revokeCredentialByIndex(timePeriod: Int, statusListIndex: ULong): Boolean
 
     /**
-     * Sets the status of one specific credential to [at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus.Invalid].
+     * Sets the status of one specific credential to
+     * [at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus.Invalid].
      * Returns true if this credential has been revoked.
      */
     fun revokeCredentialByIdentifier(timePeriod: Int, identifier: ByteArray): Boolean

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/agents/ReferencedTokenStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/agents/ReferencedTokenStore.kt
@@ -1,5 +1,7 @@
 package at.asitplus.wallet.lib.data.rfc.tokenStatusList.agents
 
+import at.asitplus.KmmResult
+import at.asitplus.wallet.lib.agent.CredentialToBeIssued
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListView
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.iso18013.Identifier
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.iso18013.IdentifierInfo
@@ -9,6 +11,21 @@ import at.asitplus.wallet.lib.data.rfc.tokenStatusList.primitives.TokenStatus
  * Stores all tokens that may be referenced to by a [at.asitplus.wallet.lib.data.rfc.tokenStatusList.StatusListView]
  */
 interface ReferencedTokenStore {
+
+    data class StoredCredentialReference(
+        val id: String,
+        val timePeriod: Int,
+        val statusListIndex: ULong,
+    )
+
+    /**
+     * Called by an `StatusListIssuer` when creating a token (that is a verifiable credential for us)
+     * to get a `statusListIndex` and `identifier`.
+     */
+    suspend fun storeReferencedToken(
+        credential: CredentialToBeIssued,
+        timePeriod: Int,
+    ): KmmResult<StoredCredentialReference>
 
     /**
      * Returns a list of the status of tokens, represented by their `statusListIndex` for that [timePeriod].

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/agents/StatusIssuer.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/data/rfc/tokenStatusList/agents/StatusIssuer.kt
@@ -15,20 +15,32 @@ interface StatusIssuer {
     /**
      * @return a status list jwt.
      */
-    suspend fun issueStatusListJwt(time: Instant? = null, kind: RevocationList.Kind = STATUS_LIST): JwsCompactTyped<StatusListTokenPayload>
+    suspend fun issueStatusListJwt(
+        time: Instant? = null,
+        kind: RevocationList.Kind = STATUS_LIST
+    ): JwsCompactTyped<StatusListTokenPayload>
 
     /**
      * @return a status list jwt for the given [timePeriod].
      */
-    suspend fun issueStatusListJwt(timePeriod: Int, kind: RevocationList.Kind = STATUS_LIST): JwsCompactTyped<StatusListTokenPayload>
+    suspend fun issueStatusListJwt(
+        timePeriod: Int,
+        kind: RevocationList.Kind = STATUS_LIST
+    ): JwsCompactTyped<StatusListTokenPayload>
 
     /**
      * @return a status list cwt.
      */
-    suspend fun issueStatusListCwt(time: Instant? = null, kind: RevocationList.Kind = STATUS_LIST): CoseSigned<ByteArray>
+    suspend fun issueStatusListCwt(
+        time: Instant? = null,
+        kind: RevocationList.Kind = STATUS_LIST
+    ): CoseSigned<ByteArray>
 
     /**
      * @return a status list cwt for the given [timePeriod].
      */
-    suspend fun issueStatusListCwt(timePeriod: Int, kind: RevocationList.Kind = STATUS_LIST): CoseSigned<ByteArray>
+    suspend fun issueStatusListCwt(
+        timePeriod: Int,
+        kind: RevocationList.Kind = STATUS_LIST
+    ): CoseSigned<ByteArray>
 }

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/AgentRevocationTest.kt
@@ -272,7 +272,7 @@ private suspend fun InMemoryIssuerCredentialStore.revokeCredentialsWithIndexes(r
     val issuanceDate = Clock.System.now()
     val expirationDate = issuanceDate + 60.seconds
     for (i in 1..16) {
-        val reference = createStoredCredentialReference(
+        val reference = storeReferencedToken(
             CredentialToBeIssued.VcJwt(
                 subject = cred,
                 expiration = expirationDate,
@@ -295,7 +295,7 @@ private suspend fun InMemoryIssuerCredentialStore.revokeRandomCredentials(): Lis
     val issuanceDate = Clock.System.now()
     val expirationDate = issuanceDate + 60.seconds
     for (i in 1..256) {
-        val revListIndex = createStoredCredentialReference(
+        val revListIndex = storeReferencedToken(
             CredentialToBeIssued.VcJwt(
                 subject = cred,
                 expiration = expirationDate,

--- a/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
+++ b/vck/src/commonTest/kotlin/at/asitplus/wallet/lib/agent/ValidatorVcTest.kt
@@ -79,7 +79,7 @@ val ValidatorVcTest by matrixSuite {
                 val sub = credential.subject
                 val vcId = "urn:uuid:${uuid4()}"
                 val exp = expirationDate ?: (Clock.System.now() + 60.seconds)
-                val statusListIndex = issuerCredentialStore.createStoredCredentialReference(
+                val statusListIndex = issuerCredentialStore.storeReferencedToken(
                     CredentialToBeIssued.VcJwt(
                         subject = sub,
                         expiration = exp,


### PR DESCRIPTION
Fixes https://github.com/a-sit-plus/vck/issues/529 and also the requirement to not always issue status claims for credentials, which can now be achieved by setting `IssuerAgent.statusListAgent=null`.