### PR TITLE
Deprecate and replace NullableInstantLongSerializer

### DIFF
--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/NullableInstantLongSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/NullableInstantLongSerializer.kt
@@ -9,9 +9,8 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.time.Instant
 
-@Deprecated("Use InstantLongSerializer instead", replaceWith = ReplaceWith("InstantLongSerializer"), level = DeprecationLevel.WARNING)
+@Deprecated("Use InstantLongSerializer instead", replaceWith = ReplaceWith("InstantLongSerializer", imports = arrayOf("at.asitplus.signum.indispensable.io.InstantLongSerializer")), level = DeprecationLevel.WARNING)
 class NullableInstantLongSerializer : KSerializer<Instant?> {
-
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("NullableInstantLongSerializer", PrimitiveKind.LONG)
 
@@ -21,5 +20,4 @@ class NullableInstantLongSerializer : KSerializer<Instant?> {
     override fun serialize(encoder: Encoder, value: Instant?) {
         value?.let { encoder.encodeLong(it.epochSeconds) }
     }
-
 }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/NullableInstantLongSerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/NullableInstantLongSerializer.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlin.time.Instant
 
+@Deprecated("Use InstantLongSerializer instead", replaceWith = ReplaceWith("InstantLongSerializer"), level = DeprecationLevel.WARNING)
 class NullableInstantLongSerializer : KSerializer<Instant?> {
 
     override val descriptor: SerialDescriptor =

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialJws.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialJws.kt
@@ -16,7 +16,6 @@ package at.asitplus.wallet.lib.data
 import at.asitplus.signum.indispensable.io.InstantLongSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.nullable
 import kotlin.time.Instant
 
 /**

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialJws.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialJws.kt
@@ -16,6 +16,7 @@ package at.asitplus.wallet.lib.data
 import at.asitplus.signum.indispensable.io.InstantLongSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.nullable
 import kotlin.time.Instant
 
 /**
@@ -33,7 +34,7 @@ data class VerifiableCredentialJws(
     @SerialName("iss")
     val issuer: String,
     @SerialName("exp")
-    @Serializable(with = NullableInstantLongSerializer::class)
+    @Serializable(with = InstantLongSerializer::class)
     val expiration: Instant?,
     @SerialName("jti")
     val jwtId: String,

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialSdJwt.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/wallet/lib/data/VerifiableCredentialSdJwt.kt
@@ -1,5 +1,6 @@
 package at.asitplus.wallet.lib.data
 
+import at.asitplus.signum.indispensable.io.InstantLongSerializer
 import at.asitplus.signum.indispensable.josef.ConfirmationClaim
 import at.asitplus.wallet.lib.data.rfc.tokenStatusList.RevocationListInfo
 import kotlinx.serialization.SerialName
@@ -28,7 +29,7 @@ data class VerifiableCredentialSdJwt(
      * See [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519) for more information.
      */
     @SerialName("nbf")
-    @Serializable(with = NullableInstantLongSerializer::class)
+    @Serializable(with = InstantLongSerializer::class)
     val notBefore: Instant? = null,
 
     /**
@@ -44,7 +45,7 @@ data class VerifiableCredentialSdJwt(
      * See [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519) for more information.
      */
     @SerialName("exp")
-    @Serializable(with = NullableInstantLongSerializer::class)
+    @Serializable(with = InstantLongSerializer::class)
     val expiration: Instant? = null,
 
     /**
@@ -52,7 +53,7 @@ data class VerifiableCredentialSdJwt(
      * See [RFC7519](https://datatracker.ietf.org/doc/html/rfc7519) for more information.
      */
     @SerialName("iat")
-    @Serializable(with = NullableInstantLongSerializer::class)
+    @Serializable(with = InstantLongSerializer::class)
     val issuedAt: Instant? = null,
 
     @SerialName("jti")

--- a/openid-data-classes/src/commonTest/kotlin/at/asitplus/wallet/lib/data/NullableInstantLongSerializerTest.kt
+++ b/openid-data-classes/src/commonTest/kotlin/at/asitplus/wallet/lib/data/NullableInstantLongSerializerTest.kt
@@ -1,0 +1,53 @@
+@file:Suppress("DEPRECATION")
+
+package at.asitplus.wallet.lib.data
+
+import at.asitplus.signum.indispensable.io.InstantLongSerializer
+import at.asitplus.testballoon.matrix.matrixSuite
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.time.Instant
+
+private const val VALUE = "value"
+
+@Serializable
+private data class LegacySerializedInstant(
+    @Serializable(with = NullableInstantLongSerializer::class)
+    val value: Instant?,
+)
+
+@Serializable
+private data class SignumSerializedInstant(
+    @Serializable(with = InstantLongSerializer::class)
+    val value: Instant?,
+)
+
+@Deprecated("To be removed with [NullableInstantLongSerializer]")
+val NullableInstantLongSerializerTest by matrixSuite {
+    "serialization is equivalent to Signum's InstantLongSerializer" - {
+        mapOf(
+            "null" to null,
+            "Unix epoch" to Instant.fromEpochSeconds(0),
+            "before Unix epoch" to Instant.fromEpochSeconds(-1),
+            "fractional second" to Instant.fromEpochSeconds(1_721_234_567, 890_123_456),
+        ).asData(nameFn = { (name, _) -> name }) test { (_, instant) ->
+            Json.encodeToString(LegacySerializedInstant(instant)) shouldBe
+                Json.encodeToString(SignumSerializedInstant(instant))
+        }
+    }
+
+    "deserialization is equivalent to Signum's InstantLongSerializer" - {
+        mapOf(
+            "null" to "null",
+            "Unix epoch" to "0",
+            "before Unix epoch" to "-1",
+            "positive epoch seconds" to "1721234567",
+        ).asData(nameFn = { (name, _) -> name }) test { (_, encodedValue) ->
+            val encoded = """{"$VALUE":$encodedValue}"""
+
+            Json.decodeFromString<LegacySerializedInstant>(encoded).value shouldBe
+                Json.decodeFromString<SignumSerializedInstant>(encoded).value
+        }
+    }
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/mdl/MobileDrivingLicenceJws.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/mdl/MobileDrivingLicenceJws.kt
@@ -1,7 +1,6 @@
 package at.asitplus.wallet.mdl
 
 import at.asitplus.signum.indispensable.io.InstantLongSerializer
-import at.asitplus.wallet.lib.data.NullableInstantLongSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.time.Instant
@@ -20,6 +19,6 @@ data class MobileDrivingLicenceJws(
     @Serializable(with = InstantLongSerializer::class)
     val issuedAt: Instant,
     @SerialName("exp")
-    @Serializable(with = NullableInstantLongSerializer::class)
+    @Serializable(with = InstantLongSerializer::class)
     val expiration: Instant?,
 )


### PR DESCRIPTION
Remove redundant serializer. Kotlinx Serialization (now?) handles nullable types automatically via `serializer.nullable`.
Added small test to show equivalence.

We could also remove it directly.