### PR TITLE
ISO ZKP Preparation

### DIFF
--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkInfo.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkInfo.kt
@@ -1,0 +1,17 @@
+package at.asitplus.iso
+
+interface ZkInfo {
+    val zkRequired: Boolean
+    val systemSpecs: List<ZkSystem>
+
+    fun validate() {
+        require(!zkRequired || systemSpecs.isNotEmpty()) {
+            "systemSpecs list cannot be empty if Zero-Knowledge is enforced"
+        }
+        val ids = systemSpecs.map { it.zkSystemId }
+        require(ids.size == ids.distinct().size) {
+            "ZkSystemType IDs are not unique!"
+        }
+    }
+
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkRequest.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkRequest.kt
@@ -9,16 +9,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ZkRequest (
     @SerialName("zkRequired")
-    val zkRequired: Boolean,
+    override val zkRequired: Boolean,
     @SerialName("systemSpecs")
-    val systemSpecs: List<ZkSystemSpec>,
-) {
-    fun validate() {
-        require(!zkRequired || systemSpecs.isNotEmpty()) {
-            "systemSpecs list cannot be empty if Zero-Knowledge is enforced"
-        }
-    }
-    companion object {
-        val Default = ZkRequest(false, emptyList())
-    }
-}
+    override val systemSpecs: List<ZkSystemSpec>,
+): ZkInfo

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystem.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystem.kt
@@ -1,0 +1,7 @@
+package at.asitplus.iso
+
+interface ZkSystem {
+    val zkSystemId: String
+    val system: String
+    val params: Map<String, Any>
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystem.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystem.kt
@@ -1,7 +1,27 @@
 package at.asitplus.iso
 
+/**
+ * Represents a configuration and metadata abstraction for a Zero-Knowledge proving system
+ * used in ISO mDoc presentation requests
+ * (e.g., via OpenID4VP+DCQL or native ISO/IEC 18013-5 Section 10.2.7 ZKP extensions).
+ *
+ * Implementations are dependent on the underlying request protocol in use.
+ */
 interface ZkSystem {
+    /**
+     * A unique identifier for this specific ZK system configuration instance within a request.
+     */
     val zkSystemId: String
+
+    /**
+     * The name or identifier of the underlying ZK system or proving scheme
+     * (e.g., the backend family).
+     */
     val system: String
+
+    /**
+     * Protocol- or circuit-specific parameters required by the ZK system
+     * (e.g., circuit hashes, attribute counts, or versioning parameters).
+     */
     val params: Map<String, Any>
 }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystemSpec.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/iso/ZkSystemSpec.kt
@@ -6,14 +6,12 @@ import kotlinx.serialization.Serializable
 @Serializable(with = ZkSystemSpecSerializer::class)
 data class ZkSystemSpec (
     @SerialName(PROP_ZK_SYSTEM_ID)
-    val zkSystemId: String,
+    override val zkSystemId: String,
     @SerialName(PROP_SYSTEM)
-    val system: String,
+    override val system: String,
     @SerialName(PROP_PARAMS)
-    val params: Map<String, Any>
-) {
-
-
+    override val params: Map<String, Any>
+) : ZkSystem {
     companion object {
         const val PROP_ZK_SYSTEM_ID = "zkSystemId"
         const val PROP_SYSTEM = "system"

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialFormatEnum.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/CredentialFormatEnum.kt
@@ -9,7 +9,8 @@ enum class CredentialFormatEnum(val text: String) {
     DC_SD_JWT("dc+sd-jwt"),
     JWT_VC_JSON_LD("jwt_vc_json-ld"),
     JSON_LD("ldp_vc"),
-    MSO_MDOC("mso_mdoc");
+    MSO_MDOC("mso_mdoc"),
+    MSO_MDOC_ZK("mso_mdoc_zk");
 
     companion object {
         fun parse(text: String) = entries.firstOrNull { it.text == text }

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SupportedCredentialFormat.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SupportedCredentialFormat.kt
@@ -210,8 +210,8 @@ sealed interface SupportedCredentialFormat {
                     CredentialFormatEnum.DC_SD_JWT -> SupportedCredentialFormatSdJwt.serializer()
                     CredentialFormatEnum.JWT_VC_JSON_LD -> SupportedCredentialFormatW3cVcJwtJsonLd.serializer()
                     CredentialFormatEnum.JSON_LD -> SupportedCredentialFormatW3cVcJsonLd.serializer()
-                    CredentialFormatEnum.MSO_MDOC,
-                    CredentialFormatEnum.MSO_MDOC_ZK-> SupportedCredentialFormatIsoMdoc.serializer()
+                    CredentialFormatEnum.MSO_MDOC -> SupportedCredentialFormatIsoMdoc.serializer()
+                    CredentialFormatEnum.MSO_MDOC_ZK,
                     CredentialFormatEnum.NONE -> throw IllegalArgumentException(
                         "Unsupported format identifier `$formatIdentifier`."
                     )

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SupportedCredentialFormat.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/SupportedCredentialFormat.kt
@@ -210,7 +210,8 @@ sealed interface SupportedCredentialFormat {
                     CredentialFormatEnum.DC_SD_JWT -> SupportedCredentialFormatSdJwt.serializer()
                     CredentialFormatEnum.JWT_VC_JSON_LD -> SupportedCredentialFormatW3cVcJwtJsonLd.serializer()
                     CredentialFormatEnum.JSON_LD -> SupportedCredentialFormatW3cVcJsonLd.serializer()
-                    CredentialFormatEnum.MSO_MDOC -> SupportedCredentialFormatIsoMdoc.serializer()
+                    CredentialFormatEnum.MSO_MDOC,
+                    CredentialFormatEnum.MSO_MDOC_ZK-> SupportedCredentialFormatIsoMdoc.serializer()
                     CredentialFormatEnum.NONE -> throw IllegalArgumentException(
                         "Unsupported format identifier `$formatIdentifier`."
                     )

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraints.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialMetadataAndValidityConstraints.kt
@@ -21,6 +21,13 @@ sealed interface DCQLCredentialMetadataAndValidityConstraints {
             is DCQLVcJwsCredential -> KmmResult.failure(IllegalArgumentException("Incompatible credential format `${credential.format}` for metadata constraints $this"))
         }
 
+        is DCQLIsoMdocZkCredentialMetadataAndValidityConstraints -> when (credential) {
+            is DCQLIsoMdocCredential -> validateCredentialConformance(credential)
+
+            is DCQLSdJwtCredential,
+            is DCQLVcJwsCredential -> KmmResult.failure(IllegalArgumentException("Incompatible credential format `${credential.format}` for metadata constraints $this"))
+        }
+
         is DCQLJwtVcCredentialMetadataAndValidityConstraints -> when (credential) {
             is DCQLVcJwsCredential -> validateCredentialConformance(credential)
 

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuery.kt
@@ -141,6 +141,20 @@ sealed interface DCQLCredentialQuery {
                     ?: Defaults.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING,
             )
 
+            CredentialFormatEnum.MSO_MDOC_ZK -> DCQLIsoMdocZkCredentialQuery(
+                id = id,
+                format = format,
+                meta = meta as DCQLIsoMdocZkCredentialMetadataAndValidityConstraints,
+                claims = claims?.map {
+                    it as DCQLIsoMdocClaimsQuery
+                }?.toNonEmptyList()?.let(::DCQLClaimsQueryList),
+                claimSets = claimSets,
+                multiple = multiple ?: Defaults.MULTIPLE,
+                trustedAuthorities = trustedAuthorities,
+                requireCryptographicHolderBinding = requireCryptographicHolderBinding
+                    ?: Defaults.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING,
+            )
+
             else -> throw IllegalArgumentException("Unsupported credential format: ${format}")
         }
     }
@@ -222,7 +236,11 @@ sealed interface DCQLCredentialQuery {
      * present.
      */
     fun match(credential: DCQLCredential): KmmResult<DCQLCredentialQueryMatchingResult> = catching {
-        if (credential.format != format) {
+        val expectedFormat = when (format) {
+            CredentialFormatEnum.MSO_MDOC_ZK -> CredentialFormatEnum.MSO_MDOC
+            else -> format
+        }
+        if (credential.format != expectedFormat) {
             throw IllegalArgumentException("Incompatible credential format")
         }
 
@@ -320,6 +338,7 @@ sealed interface DCQLCredentialQuery {
             match(
                 credential = when (this) {
                     is DCQLIsoMdocCredentialQuery -> parseIsoMdocCredential(it)
+                    is DCQLIsoMdocZkCredentialQuery -> parseIsoMdocCredential(it)
                     is DCQLSdJwtCredentialQuery -> parseSdJwtCredential(it)
                     is DCQLJwtVcCredentialQuery -> parseVcJwsCredential(it)
                 },

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuerySerializer.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLCredentialQuerySerializer.kt
@@ -28,6 +28,7 @@ object DCQLCredentialQuerySerializer : JsonContentPolymorphicSerializer<DCQLCred
             }
         return when (credentialFormatIdentifier) {
             CredentialFormatEnum.MSO_MDOC -> DCQLIsoMdocCredentialQuery.serializer()
+            CredentialFormatEnum.MSO_MDOC_ZK -> DCQLIsoMdocZkCredentialQuery.serializer()
             CredentialFormatEnum.DC_SD_JWT -> DCQLSdJwtCredentialQuery.serializer()
             CredentialFormatEnum.JWT_VC -> DCQLJwtVcCredentialQuery.serializer()
             else -> throw IllegalArgumentException("Credential format not supported: ${credentialFormatIdentifier}")

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocZkCredentialMetadataAndValidityConstraints.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocZkCredentialMetadataAndValidityConstraints.kt
@@ -1,0 +1,41 @@
+package at.asitplus.openid.dcql
+
+import at.asitplus.KmmResult
+import at.asitplus.catching
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DCQLIsoMdocZkCredentialMetadataAndValidityConstraints(
+    /**
+     * OID4VP 1.0 B.2.3: doctype_value: REQUIRED. String that specifies an allowed value for the
+     * doctype of the requested Verifiable Credential. It MUST be a valid doctype identifier as
+     * defined in [ISO.18013-5].
+     */
+    @SerialName(SerialNames.DOCTYPE_VALUE)
+    val doctypeValue: String,
+
+    /**
+     * Extended ISO Mdoc metadata with Longfellow ZK support (Vendor extension)
+     * See https://google.github.io/longfellow-zk/docs/protocols/
+     */
+    @SerialName(SerialNames.ZK_SYSTEM_TYPE)
+    val zkSystemType: DCQLIsoMdocZkSystemType,
+
+    ) : DCQLCredentialMetadataAndValidityConstraints {
+    object SerialNames {
+        const val DOCTYPE_VALUE = "doctype_value"
+        const val ZK_SYSTEM_TYPE = "zk_system_type"
+    }
+
+    fun validateCredentialConformance(credential: DCQLIsoMdocCredential): KmmResult<Unit> = validate(
+        actualDoctypeValue = credential.documentType,
+    )
+
+    fun validate(actualDoctypeValue: String?): KmmResult<Unit> = catching {
+        require(actualDoctypeValue == doctypeValue) {
+            "Incompatible MDOC document type."
+        }
+        zkSystemType.validate()
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocZkCredentialQuery.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocZkCredentialQuery.kt
@@ -1,0 +1,43 @@
+package at.asitplus.openid.dcql
+
+import at.asitplus.data.NonEmptyList
+import at.asitplus.openid.CredentialFormatEnum
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DCQLIsoMdocZkCredentialQuery(
+    @SerialName(DCQLCredentialQuery.SerialNames.ID)
+    override val id: DCQLCredentialQueryIdentifier,
+    @SerialName(DCQLCredentialQuery.SerialNames.META)
+    override val meta: DCQLIsoMdocZkCredentialMetadataAndValidityConstraints,
+    @SerialName(DCQLCredentialQuery.SerialNames.CLAIMS)
+    override val claims: DCQLClaimsQueryList<DCQLIsoMdocClaimsQuery>? = null,
+    @SerialName(DCQLCredentialQuery.SerialNames.CLAIM_SETS)
+    override val claimSets: NonEmptyList<List<DCQLClaimsQueryIdentifier>>? = null,
+    @SerialName(DCQLCredentialQuery.SerialNames.MULTIPLE)
+    override val multiple: Boolean = DCQLCredentialQuery.Defaults.MULTIPLE,
+    @SerialName(DCQLCredentialQuery.SerialNames.TRUSTED_AUTHORITIES)
+    override val trustedAuthorities: NonEmptyList<DCQLTrustedAuthorityQueryEntry>? = null,
+    @SerialName(DCQLCredentialQuery.SerialNames.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING)
+    override val requireCryptographicHolderBinding: Boolean = DCQLCredentialQuery.Defaults.REQUIRE_CRYPTOGRAPHIC_HOLDER_BINDING,
+    @SerialName(DCQLCredentialQuery.SerialNames.FORMAT)
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS)
+    override val format: CredentialFormatEnum = CREDENTIAL_FORMAT,
+) : DCQLCredentialQuery {
+    init {
+        validate()
+    }
+
+    companion object {
+        val CREDENTIAL_FORMAT = CredentialFormatEnum.MSO_MDOC_ZK
+    }
+
+    override fun validate() {
+        super.validate()
+        require(format == CREDENTIAL_FORMAT) {
+            "Value has an invalid format identifier in this context."
+        }
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocZkSystemSpec.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocZkSystemSpec.kt
@@ -1,0 +1,53 @@
+package at.asitplus.openid.dcql
+
+import at.asitplus.iso.ZkSystem
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Proposed DCQL ZK System Specification for OpenID4VP requests targeting ISO mDoc zero-knowledge proofs
+ * See: https://google.github.io/longfellow-zk/docs/protocols/
+ */
+@Serializable
+data class DCQLIsoMdocZkSystemSpec (
+    @SerialName(PROP_ID)
+    override val zkSystemId: String,
+
+    @SerialName(PROP_SYSTEM)
+    override val system: String,
+
+    @SerialName(PROP_CIRCUIT_HASH)
+    val circuitHash: String,
+
+    @SerialName(PROP_NUM_ATTRIBUTES)
+    val numAttributes: Int,
+
+    @SerialName(PROP_VERSION)
+    val version: Int,
+
+    @SerialName(PROP_BLOCK_ENC_HASH)
+    val blockEncHash: Int? = null,
+
+    @SerialName(PROP_BLOCK_ENC_SIG)
+    val blockEncSig: Int? = null,
+): ZkSystem {
+    override val params: Map<String, Any>
+        get() = buildMap {
+            put(PROP_CIRCUIT_HASH, circuitHash)
+            put(PROP_NUM_ATTRIBUTES, numAttributes)
+            put(PROP_VERSION, version)
+
+            blockEncHash?.let{ put(PROP_BLOCK_ENC_HASH, it) }
+            blockEncSig?.let{ put(PROP_BLOCK_ENC_SIG, it) }
+        }
+
+    companion object {
+        const val PROP_ID = "id"
+        const val PROP_SYSTEM = "system"
+        const val PROP_CIRCUIT_HASH = "circuit_hash"
+        const val PROP_NUM_ATTRIBUTES = "num_attributes"
+        const val PROP_VERSION = "version"
+        const val PROP_BLOCK_ENC_HASH = "block_enc_hash"
+        const val PROP_BLOCK_ENC_SIG = "block_enc_sig"
+    }
+}

--- a/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocZkSystemType.kt
+++ b/openid-data-classes/src/commonMain/kotlin/at/asitplus/openid/dcql/DCQLIsoMdocZkSystemType.kt
@@ -1,0 +1,37 @@
+package at.asitplus.openid.dcql
+
+import at.asitplus.iso.ZkInfo
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+@Serializable(with = DCQLIsoMdocZkSystemType.Companion.Serializer::class)
+data class DCQLIsoMdocZkSystemType(
+    override val systemSpecs: List<DCQLIsoMdocZkSystemSpec>,
+
+    @Transient
+    override val zkRequired: Boolean = false
+): ZkInfo {
+    companion object {
+        object Serializer : KSerializer<DCQLIsoMdocZkSystemType> {
+            private val delegate = ListSerializer(DCQLIsoMdocZkSystemSpec.serializer())
+
+            override val descriptor = delegate.descriptor
+
+            override fun serialize(encoder: Encoder, value: DCQLIsoMdocZkSystemType) {
+                encoder.encodeSerializableValue(delegate, value.systemSpecs)
+            }
+
+            override fun deserialize(decoder: Decoder): DCQLIsoMdocZkSystemType {
+                return DCQLIsoMdocZkSystemType(decoder.decodeSerializableValue(delegate))
+            }
+        }
+    }
+}
+
+
+
+

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/Extensions.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/oidvci/Extensions.kt
@@ -20,7 +20,8 @@ fun CredentialRepresentation.toFormat(): CredentialFormatEnum = when (this) {
 
 fun CredentialFormatEnum.toRepresentation() = when (this) {
     CredentialFormatEnum.DC_SD_JWT -> SD_JWT
-    CredentialFormatEnum.MSO_MDOC -> ISO_MDOC
+    CredentialFormatEnum.MSO_MDOC,
+    CredentialFormatEnum.MSO_MDOC_ZK -> ISO_MDOC
     else -> PLAIN_JWT
 }
 

--- a/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/VpTokenValidator.kt
+++ b/vck-openid/src/commonMain/kotlin/at/asitplus/wallet/lib/openid/VpTokenValidator.kt
@@ -115,7 +115,8 @@ internal class VpTokenValidator(
     private fun CredentialFormatEnum.toClaimFormat(): ClaimFormat = when (this) {
         CredentialFormatEnum.JWT_VC -> ClaimFormat.JWT_VP
         CredentialFormatEnum.DC_SD_JWT -> ClaimFormat.SD_JWT
-        CredentialFormatEnum.MSO_MDOC -> ClaimFormat.MSO_MDOC
+        CredentialFormatEnum.MSO_MDOC,
+        CredentialFormatEnum.MSO_MDOC_ZK -> ClaimFormat.MSO_MDOC
         CredentialFormatEnum.NONE,
         CredentialFormatEnum.JWT_VC_JSON_LD,
         CredentialFormatEnum.JSON_LD,

--- a/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
+++ b/vck-openid/src/commonTest/kotlin/at/asitplus/wallet/lib/openid/OpenId4VpCombinedProtocolTest.kt
@@ -18,6 +18,7 @@ import at.asitplus.openid.dcql.DCQLClaimsPathPointer
 import at.asitplus.openid.dcql.DCQLCredentialQueryIdentifier
 import at.asitplus.openid.dcql.DCQLCredentialQueryList
 import at.asitplus.openid.dcql.DCQLIsoMdocCredentialQuery
+import at.asitplus.openid.dcql.DCQLIsoMdocZkCredentialQuery
 import at.asitplus.openid.dcql.DCQLJwtVcCredentialQuery
 import at.asitplus.openid.dcql.DCQLSdJwtCredentialQuery
 import at.asitplus.signum.indispensable.josef.io.joseCompliantSerializer
@@ -329,6 +330,7 @@ val OpenId4VpCombinedProtocolTest by matrixSuite {
                         originalDcqlRequest.dcqlQuery.credentials.zip(otherDcqlQuery.credentials) { good, bad ->
                             when (bad) {
                                 is DCQLIsoMdocCredentialQuery -> bad.copy(id = good.id)
+                                is DCQLIsoMdocZkCredentialQuery -> bad.copy(id = good.id)
                                 is DCQLJwtVcCredentialQuery -> bad.copy(id = good.id)
                                 is DCQLSdJwtCredentialQuery -> bad.copy(id = good.id)
                             }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IsoPresentation.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IsoPresentation.kt
@@ -1,0 +1,9 @@
+package at.asitplus.wallet.lib.agent
+
+import at.asitplus.jsonpath.core.NormalizedJsonPath
+
+data class IsoPresentation(
+    val credential: SubjectCredentialStore.StoreEntry.Iso,
+    val paths: Collection<NormalizedJsonPath>,
+    val meta: PresentationMetadata? = null
+)

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IsoPresentation.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IsoPresentation.kt
@@ -1,9 +1,29 @@
 package at.asitplus.wallet.lib.agent
 
+import at.asitplus.KmmResult
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 
-data class IsoPresentation(
+@ConsistentCopyVisibility
+data class IsoPresentation private constructor(
     val credential: SubjectCredentialStore.StoreEntry.Iso,
     val paths: Collection<NormalizedJsonPath>,
-    val meta: PresentationMetadata? = null
-)
+    val meta: PresentationMetadata?
+) {
+    constructor(
+        credential: SubjectCredentialStore.StoreEntry.Iso,
+        paths: Collection<NormalizedJsonPath>
+    ) : this(credential, paths, null)
+
+    companion object {
+        fun create(
+            credential: SubjectCredentialStore.StoreEntry.Iso,
+            paths: Collection<NormalizedJsonPath>,
+            meta: PresentationMetadata?
+        ): KmmResult<IsoPresentation> {
+            if (meta?.isCompatibleWith(credential) == false) {
+                return KmmResult.failure(PresentationException("Metadata incompatible with credential"))
+            }
+            return KmmResult.success(IsoPresentation(credential, paths, meta))
+        }
+    }
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IsoPresentationParameters.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IsoPresentationParameters.kt
@@ -1,6 +1,7 @@
 package at.asitplus.wallet.lib.agent
 
 import at.asitplus.KmmResult
+import at.asitplus.catching
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 
 @ConsistentCopyVisibility
@@ -9,21 +10,16 @@ data class IsoPresentationParameters private constructor(
     val claims: Collection<NormalizedJsonPath>,
     val zkMetadata: ZkMetadata?
 ) {
-    constructor(
-        credential: SubjectCredentialStore.StoreEntry.Iso,
-        claims: Collection<NormalizedJsonPath>
-    ) : this(credential, claims, null)
-
     companion object {
         fun create(
             credential: SubjectCredentialStore.StoreEntry.Iso,
             claims: Collection<NormalizedJsonPath>,
-            zkMetadata: ZkMetadata?
-        ): KmmResult<IsoPresentationParameters> {
+            zkMetadata: ZkMetadata? = null,
+        ): KmmResult<IsoPresentationParameters> = catching {
             if (zkMetadata?.isCompatibleWith(credential) == false) {
-                return KmmResult.failure(PresentationException("Metadata incompatible with credential"))
+               throw PresentationException("Metadata incompatible with credential")
             }
-            return KmmResult.success(IsoPresentationParameters(credential, claims, zkMetadata))
+            IsoPresentationParameters(credential, claims, zkMetadata)
         }
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IsoPresentationParameters.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/IsoPresentationParameters.kt
@@ -4,26 +4,26 @@ import at.asitplus.KmmResult
 import at.asitplus.jsonpath.core.NormalizedJsonPath
 
 @ConsistentCopyVisibility
-data class IsoPresentation private constructor(
+data class IsoPresentationParameters private constructor(
     val credential: SubjectCredentialStore.StoreEntry.Iso,
-    val paths: Collection<NormalizedJsonPath>,
-    val meta: PresentationMetadata?
+    val claims: Collection<NormalizedJsonPath>,
+    val zkMetadata: ZkMetadata?
 ) {
     constructor(
         credential: SubjectCredentialStore.StoreEntry.Iso,
-        paths: Collection<NormalizedJsonPath>
-    ) : this(credential, paths, null)
+        claims: Collection<NormalizedJsonPath>
+    ) : this(credential, claims, null)
 
     companion object {
         fun create(
             credential: SubjectCredentialStore.StoreEntry.Iso,
-            paths: Collection<NormalizedJsonPath>,
-            meta: PresentationMetadata?
-        ): KmmResult<IsoPresentation> {
-            if (meta?.isCompatibleWith(credential) == false) {
+            claims: Collection<NormalizedJsonPath>,
+            zkMetadata: ZkMetadata?
+        ): KmmResult<IsoPresentationParameters> {
+            if (zkMetadata?.isCompatibleWith(credential) == false) {
                 return KmmResult.failure(PresentationException("Metadata incompatible with credential"))
             }
-            return KmmResult.success(IsoPresentation(credential, paths, meta))
+            return KmmResult.success(IsoPresentationParameters(credential, claims, zkMetadata))
         }
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationMetadata.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationMetadata.kt
@@ -1,0 +1,15 @@
+package at.asitplus.wallet.lib.agent
+
+import at.asitplus.iso.ZkInfo
+
+/**
+ * Defines metadata for presentations and a method to evaluate compatibility
+ * with specific credential entries stored in the credential store.
+ */
+sealed interface PresentationMetadata {
+    fun isCompatibleWith(credential: SubjectCredentialStore.StoreEntry): Boolean
+
+    data class IsoMdocZk(val zkInfo: ZkInfo) : PresentationMetadata {
+        override fun isCompatibleWith(credential: SubjectCredentialStore.StoreEntry) = credential is SubjectCredentialStore.StoreEntry.Iso
+    }
+}

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationResponseCreator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationResponseCreator.kt
@@ -11,6 +11,7 @@ import at.asitplus.dif.PresentationSubmissionDescriptor
 import at.asitplus.iso.DeviceRequest
 import at.asitplus.jsonpath.core.NodeList
 import at.asitplus.openid.dcql.DCQLCredentialQueryMatchingResult
+import at.asitplus.openid.dcql.DCQLIsoMdocZkCredentialQuery
 import at.asitplus.openid.dcql.DCQLQuery
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore.StoreEntry
 import at.asitplus.wallet.lib.data.CredentialPresentation
@@ -74,7 +75,7 @@ internal class PresentationResponseCreator(
 
         val presentations = credentialSubmissions.mapValues { (queryId, submissions) ->
             val query = dcqlQuery.credentials.first { it.id == queryId }
-            if (query.multiple != true && submissions.size != 1) {
+            if (!query.multiple && submissions.size != 1) {
                 throw IllegalArgumentException(
                     "Credential query ${query.id} does not allow multiple submission, but ${submissions.size} were provided."
                 )
@@ -87,10 +88,15 @@ internal class PresentationResponseCreator(
                     }
                     CreatePresentationResult.VcJws(credential.vcSerialized)
                 } else {
+                    val meta = when (query) {
+                        is DCQLIsoMdocZkCredentialQuery -> PresentationMetadata.IsoMdocZk(query.meta.zkSystemType)
+                        else -> null
+                    }
                     verifiablePresentationFactory.createVerifiablePresentation(
                         request = request,
                         credential = credential,
                         disclosedAttributes = it.matchingResult,
+                        presentationMetadata = meta,
                     ).getOrThrow()
                 }
             }
@@ -110,7 +116,7 @@ internal class PresentationResponseCreator(
         val selectedCredentials = DeviceRetrievalProcedure.validateSubmission(deviceRequest, submissions).getOrThrow()
         val result = verifiablePresentationFactory.createVerifiablePresentation(
             request = request,
-            credentialAndDisclosedAttributes = selectedCredentials,
+            isoPresentations = selectedCredentials,
         ).getOrThrow()
         return PresentationResponseParameters.DeviceRetrievalParameters(result.deviceResponse)
     }
@@ -145,8 +151,8 @@ internal class PresentationResponseCreator(
                 presentationResults = listOf(
                     verifiablePresentationFactory.createVerifiablePresentation(
                         request = request,
-                        credentialAndDisclosedAttributes = submissions.associate {
-                            it.second.credential as StoreEntry.Iso to it.second.disclosedAttributes
+                        isoPresentations = submissions.map {
+                            IsoPresentation(it.second.credential as StoreEntry.Iso, it.second.disclosedAttributes)
                         },
                     ).getOrThrow()
                 ),

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationResponseCreator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationResponseCreator.kt
@@ -89,14 +89,14 @@ internal class PresentationResponseCreator(
                     CreatePresentationResult.VcJws(credential.vcSerialized)
                 } else {
                     val meta = when (query) {
-                        is DCQLIsoMdocZkCredentialQuery -> PresentationMetadata.IsoMdocZk(query.meta.zkSystemType)
+                        is DCQLIsoMdocZkCredentialQuery -> ZkMetadata.IsoMdocZk(query.meta.zkSystemType)
                         else -> null
                     }
                     verifiablePresentationFactory.createVerifiablePresentation(
                         request = request,
                         credential = credential,
                         disclosedAttributes = it.matchingResult,
-                        presentationMetadata = meta,
+                        zkMetadata = meta,
                     ).getOrThrow()
                 }
             }
@@ -116,7 +116,7 @@ internal class PresentationResponseCreator(
         val selectedCredentials = DeviceRetrievalProcedure.validateSubmission(deviceRequest, submissions).getOrThrow()
         val result = verifiablePresentationFactory.createVerifiablePresentation(
             request = request,
-            isoPresentations = selectedCredentials,
+            isoPresentationParameters = selectedCredentials,
         ).getOrThrow()
         return PresentationResponseParameters.DeviceRetrievalParameters(result.deviceResponse)
     }
@@ -151,8 +151,8 @@ internal class PresentationResponseCreator(
                 presentationResults = listOf(
                     verifiablePresentationFactory.createVerifiablePresentation(
                         request = request,
-                        isoPresentations = submissions.map {
-                            IsoPresentation(it.second.credential as StoreEntry.Iso, it.second.disclosedAttributes)
+                        isoPresentationParameters = submissions.map {
+                            IsoPresentationParameters(it.second.credential as StoreEntry.Iso, it.second.disclosedAttributes)
                         },
                     ).getOrThrow()
                 ),

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationResponseCreator.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/PresentationResponseCreator.kt
@@ -88,15 +88,14 @@ internal class PresentationResponseCreator(
                     }
                     CreatePresentationResult.VcJws(credential.vcSerialized)
                 } else {
-                    val meta = when (query) {
-                        is DCQLIsoMdocZkCredentialQuery -> ZkMetadata.IsoMdocZk(query.meta.zkSystemType)
-                        else -> null
-                    }
                     verifiablePresentationFactory.createVerifiablePresentation(
                         request = request,
                         credential = credential,
                         disclosedAttributes = it.matchingResult,
-                        zkMetadata = meta,
+                        zkMetadata = when (query) {
+                            is DCQLIsoMdocZkCredentialQuery -> ZkMetadata.IsoMdocZk(query.meta.zkSystemType)
+                            else -> null
+                        }
                     ).getOrThrow()
                 }
             }
@@ -152,7 +151,10 @@ internal class PresentationResponseCreator(
                     verifiablePresentationFactory.createVerifiablePresentation(
                         request = request,
                         isoPresentationParameters = submissions.map {
-                            IsoPresentationParameters(it.second.credential as StoreEntry.Iso, it.second.disclosedAttributes)
+                            IsoPresentationParameters.create(
+                                credential = it.second.credential as StoreEntry.Iso,
+                                claims = it.second.disclosedAttributes
+                            ).getOrThrow()
                         },
                     ).getOrThrow()
                 ),

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -63,16 +63,16 @@ class VerifiablePresentationFactory(
     private val signKeyBinding: SignJwtFun<KeyBindingJws> =
         SignJwt(keyMaterial, JwsHeaderNone()),
 ) {
-
+    @Deprecated("Use createVerifiablePresentation(request, isoPresentationParameters) instead")
     suspend fun createVerifiablePresentation(
         request: PresentationRequestParameters,
         credentialAndDisclosedAttributes: Map<StoreEntry.Iso, Collection<NormalizedJsonPath>>,
     ): KmmResult<CreatePresentationResult.DeviceResponse> = createVerifiablePresentation(
         request = request,
-        isoPresentationParameters = credentialAndDisclosedAttributes.entries.map {
-            IsoPresentationParameters(it.key, it.value) },
+        isoPresentationParameters = credentialAndDisclosedAttributes.map { (credential, claims) ->
+            IsoPresentationParameters.create(credential, claims).getOrThrow()
+        }
     )
-
 
     /**
      * Creates one Device Response while preserving every selected document and its order. A collection is used rather
@@ -92,6 +92,7 @@ class VerifiablePresentationFactory(
         request: PresentationRequestParameters,
         credential: StoreEntry,
         disclosedAttributes: Collection<NormalizedJsonPath>,
+        zkMetadata: ZkMetadata? = null
     ): KmmResult<CreatePresentationResult> = catching {
         when (credential) {
             is StoreEntry.Vc -> createVcPresentation(
@@ -107,7 +108,11 @@ class VerifiablePresentationFactory(
 
             is StoreEntry.Iso -> createIsoPresentation(
                 request = request,
-                isoPresentationParameters = listOf(IsoPresentationParameters(credential, disclosedAttributes,)),
+                isoPresentationParameters = listOf(IsoPresentationParameters.create(
+                    credential = credential,
+                    claims = disclosedAttributes,
+                    zkMetadata = zkMetadata
+                ).getOrThrow()),
             )
         }
     }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -69,8 +69,10 @@ class VerifiablePresentationFactory(
         credentialAndDisclosedAttributes: Map<StoreEntry.Iso, Collection<NormalizedJsonPath>>,
     ): KmmResult<CreatePresentationResult.DeviceResponse> = createVerifiablePresentation(
         request = request,
-        credentialAndDisclosedAttributes = credentialAndDisclosedAttributes.entries.map { it.key to it.value },
+        isoPresentations = credentialAndDisclosedAttributes.entries.map {
+            IsoPresentation(it.key, it.value) },
     )
+
 
     /**
      * Creates one Device Response while preserving every selected document and its order. A collection is used rather
@@ -78,11 +80,11 @@ class VerifiablePresentationFactory(
      */
     suspend fun createVerifiablePresentation(
         request: PresentationRequestParameters,
-        credentialAndDisclosedAttributes: Collection<Pair<StoreEntry.Iso, Collection<NormalizedJsonPath>>>,
+        isoPresentations: Collection<IsoPresentation>,
     ): KmmResult<CreatePresentationResult.DeviceResponse> = catching {
         createIsoPresentation(
             request = request,
-            credentialAndRequestedClaims = credentialAndDisclosedAttributes,
+            isoPresentation = isoPresentations,
         )
     }
 
@@ -105,7 +107,7 @@ class VerifiablePresentationFactory(
 
             is StoreEntry.Iso -> createIsoPresentation(
                 request = request,
-                credentialAndRequestedClaims = listOf(credential to disclosedAttributes),
+                isoPresentation = listOf(IsoPresentation(credential, disclosedAttributes,)),
             )
         }
     }
@@ -114,6 +116,7 @@ class VerifiablePresentationFactory(
         request: PresentationRequestParameters,
         credential: StoreEntry,
         disclosedAttributes: DCQLCredentialQueryMatchingResult,
+        presentationMetadata: PresentationMetadata? = null
     ): KmmResult<CreatePresentationResult> = catching {
         when (credential) {
             is StoreEntry.Vc -> if (disclosedAttributes !is AllClaimsMatchingResult) {
@@ -131,8 +134,8 @@ class VerifiablePresentationFactory(
 
             is StoreEntry.Iso -> createIsoPresentation(
                 request = request,
-                credentialAndRequestedClaims = listOf(
-                    credential to disclosedAttributes.toRequestedIsoClaims(credential)
+                isoPresentation = listOf(IsoPresentation(
+                    credential, disclosedAttributes.toRequestedIsoClaims(credential), presentationMetadata)
                 ),
             )
         }
@@ -176,11 +179,11 @@ class VerifiablePresentationFactory(
 
     private suspend fun createIsoPresentation(
         request: PresentationRequestParameters,
-        credentialAndRequestedClaims: Collection<Pair<StoreEntry.Iso, Collection<NormalizedJsonPath>>>,
+        isoPresentation: Collection<IsoPresentation>,
     ) = CreatePresentationResult.DeviceResponse(
         deviceResponse = DeviceResponse(
             parsedVersion = Version(1, 0),
-            documents = credentialAndRequestedClaims.map { (credential, requestedClaims) ->
+            documents = isoPresentation.map { (credential, requestedClaims) ->
                 credential.discloseRequestedClaims(requestedClaims, request)
             }.toTypedArray(),
             status = 0U,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -69,8 +69,8 @@ class VerifiablePresentationFactory(
         credentialAndDisclosedAttributes: Map<StoreEntry.Iso, Collection<NormalizedJsonPath>>,
     ): KmmResult<CreatePresentationResult.DeviceResponse> = createVerifiablePresentation(
         request = request,
-        isoPresentations = credentialAndDisclosedAttributes.entries.map {
-            IsoPresentation(it.key, it.value) },
+        isoPresentationParameters = credentialAndDisclosedAttributes.entries.map {
+            IsoPresentationParameters(it.key, it.value) },
     )
 
 
@@ -80,11 +80,11 @@ class VerifiablePresentationFactory(
      */
     suspend fun createVerifiablePresentation(
         request: PresentationRequestParameters,
-        isoPresentations: Collection<IsoPresentation>,
+        isoPresentationParameters: Collection<IsoPresentationParameters>,
     ): KmmResult<CreatePresentationResult.DeviceResponse> = catching {
         createIsoPresentation(
             request = request,
-            isoPresentation = isoPresentations,
+            isoPresentationParameters = isoPresentationParameters,
         )
     }
 
@@ -107,7 +107,7 @@ class VerifiablePresentationFactory(
 
             is StoreEntry.Iso -> createIsoPresentation(
                 request = request,
-                isoPresentation = listOf(IsoPresentation(credential, disclosedAttributes,)),
+                isoPresentationParameters = listOf(IsoPresentationParameters(credential, disclosedAttributes,)),
             )
         }
     }
@@ -116,7 +116,7 @@ class VerifiablePresentationFactory(
         request: PresentationRequestParameters,
         credential: StoreEntry,
         disclosedAttributes: DCQLCredentialQueryMatchingResult,
-        presentationMetadata: PresentationMetadata? = null
+        zkMetadata: ZkMetadata? = null
     ): KmmResult<CreatePresentationResult> = catching {
         when (credential) {
             is StoreEntry.Vc -> if (disclosedAttributes !is AllClaimsMatchingResult) {
@@ -134,8 +134,8 @@ class VerifiablePresentationFactory(
 
             is StoreEntry.Iso -> createIsoPresentation(
                 request = request,
-                isoPresentation = listOf(IsoPresentation.create(
-                    credential, disclosedAttributes.toRequestedIsoClaims(credential), presentationMetadata).getOrThrow()
+                isoPresentationParameters = listOf(IsoPresentationParameters.create(
+                    credential, disclosedAttributes.toRequestedIsoClaims(credential), zkMetadata).getOrThrow()
                 ),
             )
         }
@@ -179,11 +179,11 @@ class VerifiablePresentationFactory(
 
     private suspend fun createIsoPresentation(
         request: PresentationRequestParameters,
-        isoPresentation: Collection<IsoPresentation>,
+        isoPresentationParameters: Collection<IsoPresentationParameters>,
     ) = CreatePresentationResult.DeviceResponse(
         deviceResponse = DeviceResponse(
             parsedVersion = Version(1, 0),
-            documents = isoPresentation.map { (credential, requestedClaims) ->
+            documents = isoPresentationParameters.map { (credential, requestedClaims) ->
                 credential.discloseRequestedClaims(requestedClaims, request)
             }.toTypedArray(),
             status = 0U,

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/VerifiablePresentationFactory.kt
@@ -134,8 +134,8 @@ class VerifiablePresentationFactory(
 
             is StoreEntry.Iso -> createIsoPresentation(
                 request = request,
-                isoPresentation = listOf(IsoPresentation(
-                    credential, disclosedAttributes.toRequestedIsoClaims(credential), presentationMetadata)
+                isoPresentation = listOf(IsoPresentation.create(
+                    credential, disclosedAttributes.toRequestedIsoClaims(credential), presentationMetadata).getOrThrow()
                 ),
             )
         }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ZkMetadata.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/ZkMetadata.kt
@@ -3,13 +3,13 @@ package at.asitplus.wallet.lib.agent
 import at.asitplus.iso.ZkInfo
 
 /**
- * Defines metadata for presentations and a method to evaluate compatibility
+ * Defines metadata for zero-knowledge presentations and a method to evaluate compatibility
  * with specific credential entries stored in the credential store.
  */
-sealed interface PresentationMetadata {
+sealed interface ZkMetadata {
     fun isCompatibleWith(credential: SubjectCredentialStore.StoreEntry): Boolean
 
-    data class IsoMdocZk(val zkInfo: ZkInfo) : PresentationMetadata {
+    data class IsoMdocZk(val zkInfo: ZkInfo) : ZkMetadata {
         override fun isCompatibleWith(credential: SubjectCredentialStore.StoreEntry) = credential is SubjectCredentialStore.StoreEntry.Iso
     }
 }

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/iso/DeviceRetrievalProcedure.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/iso/DeviceRetrievalProcedure.kt
@@ -10,9 +10,9 @@ import at.asitplus.wallet.lib.agent.DeviceRequestCredentialDisclosure
 import at.asitplus.wallet.lib.agent.IsoDeviceRetrievalClaimMatch
 import at.asitplus.wallet.lib.agent.IsoDeviceRetrievalCredentialMatch
 import at.asitplus.wallet.lib.agent.IsoDeviceRetrievalQueryMatchingResult
-import at.asitplus.wallet.lib.agent.IsoPresentation
+import at.asitplus.wallet.lib.agent.IsoPresentationParameters
 import at.asitplus.wallet.lib.agent.PresentationException
-import at.asitplus.wallet.lib.agent.PresentationMetadata
+import at.asitplus.wallet.lib.agent.ZkMetadata
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore.StoreEntry
 
 /** Matching and submission validation for ISO Device Retrieval requests. */
@@ -30,7 +30,7 @@ internal object DeviceRetrievalProcedure {
     fun validateSubmission(
         deviceRequest: DeviceRequest,
         submissions: Collection<DeviceRequestCredentialDisclosure<StoreEntry>>,
-    ): KmmResult<Collection<IsoPresentation>> = catching {
+    ): KmmResult<Collection<IsoPresentationParameters>> = catching {
         require(submissions.size == deviceRequest.docRequests.size) {
             "A submission is required for every document request"
         }
@@ -47,7 +47,7 @@ internal object DeviceRetrievalProcedure {
                 "Credential docType does not match document request at index $index"
             }
             val meta = itemsRequest.requestInfo?.zkRequest?.let {
-               PresentationMetadata.IsoMdocZk(it)
+               ZkMetadata.IsoMdocZk(it)
             }
             val requiredPaths = evaluateItemsRequestAgainstCredential(
                 itemsRequest = itemsRequest,
@@ -61,7 +61,7 @@ internal object DeviceRetrievalProcedure {
             ) {
                 "Disclosed attributes do not exactly match document request at index $index"
             }
-            IsoPresentation.create(credential, submission.disclosedAttributes, meta).getOrThrow()
+            IsoPresentationParameters.create(credential, submission.disclosedAttributes, meta).getOrThrow()
         }
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/iso/DeviceRetrievalProcedure.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/iso/DeviceRetrievalProcedure.kt
@@ -10,7 +10,9 @@ import at.asitplus.wallet.lib.agent.DeviceRequestCredentialDisclosure
 import at.asitplus.wallet.lib.agent.IsoDeviceRetrievalClaimMatch
 import at.asitplus.wallet.lib.agent.IsoDeviceRetrievalCredentialMatch
 import at.asitplus.wallet.lib.agent.IsoDeviceRetrievalQueryMatchingResult
+import at.asitplus.wallet.lib.agent.IsoPresentation
 import at.asitplus.wallet.lib.agent.PresentationException
+import at.asitplus.wallet.lib.agent.PresentationMetadata
 import at.asitplus.wallet.lib.agent.SubjectCredentialStore.StoreEntry
 
 /** Matching and submission validation for ISO Device Retrieval requests. */
@@ -28,7 +30,7 @@ internal object DeviceRetrievalProcedure {
     fun validateSubmission(
         deviceRequest: DeviceRequest,
         submissions: Collection<DeviceRequestCredentialDisclosure<StoreEntry>>,
-    ): KmmResult<List<Pair<StoreEntry.Iso, Collection<NormalizedJsonPath>>>> = catching {
+    ): KmmResult<Collection<IsoPresentation>> = catching {
         require(submissions.size == deviceRequest.docRequests.size) {
             "A submission is required for every document request"
         }
@@ -44,6 +46,9 @@ internal object DeviceRetrievalProcedure {
             require(credential.schemeIdentifier == itemsRequest.docType) {
                 "Credential docType does not match document request at index $index"
             }
+            val meta = itemsRequest.requestInfo?.zkRequest?.let {
+               PresentationMetadata.IsoMdocZk(it)
+            }
             val requiredPaths = evaluateItemsRequestAgainstCredential(
                 itemsRequest = itemsRequest,
                 issuerSigned = credential.issuerSigned,
@@ -56,7 +61,7 @@ internal object DeviceRetrievalProcedure {
             ) {
                 "Disclosed attributes do not exactly match document request at index $index"
             }
-            credential to submission.disclosedAttributes
+            IsoPresentation(credential, submission.disclosedAttributes, meta)
         }
     }
 

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/iso/DeviceRetrievalProcedure.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/procedures/iso/DeviceRetrievalProcedure.kt
@@ -61,7 +61,7 @@ internal object DeviceRetrievalProcedure {
             ) {
                 "Disclosed attributes do not exactly match document request at index $index"
             }
-            IsoPresentation(credential, submission.disclosedAttributes, meta)
+            IsoPresentation.create(credential, submission.disclosedAttributes, meta).getOrThrow()
         }
     }
 


### PR DESCRIPTION
Preparation for ISO-mDoc cerdential presentations using ZKP methods via DCQL/IsoDeviceRetrievalPresentation:
- Retrieves metadata from dcql/Iso request and passes it to the VerifiablePresentationFactory
- Introduces PresentationMetadata interface to enable future ZKP compatibility for presentation flows other than ISO-mDoc