### PR TITLE
Use stable SD-JWT identifiers for the DC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Release 8.0.0 (unreleased):
 - Credentials:
     - In `SubjectCredentialStore.StoreEntry` make the `schemeIdentifier` non-nullable. Deserialization of old previously stored entries need to be handled by calling applications.
+    - Derive SD-JWT Digital Credentials API identifiers from the JWT ID or serialized credential instead of the subject
 - OpenID for Verifiable Presentations:
     - Remove support for Presentation Exchange, since OpenID4VP 1.0 only supports DCQL
     - Implement direct presentation requests and responses according to ISO 18013-5 Device Retrieval with new subtypes `CredentialPresentationRequest.IsoDeviceRetrieval`, `CredentialPresentation.IsoDeviceRetrievalPresentation`, `IsoDeviceRetrievalMatchingResult` for `CredentialMatchingResult`, `HolderIsoDeviceRetrievalQueryMatchingResult` for `HolderPresentationRequestMatchingResult`, and `PresentationResponseParameters.DeviceRetrievalParameters`

--- a/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
+++ b/vck/src/commonMain/kotlin/at/asitplus/wallet/lib/agent/SubjectCredentialStore.kt
@@ -164,7 +164,6 @@ interface SubjectCredentialStore {
         fun getDcApiId(): String = when (this) {
             is Vc -> vc.jwtId
             is SdJwt -> sdJwt.jwtId
-                ?: sdJwt.subject
                 ?: joseCompliantSerializer.encodeToString(sdJwt).toByteArray().sha256().toHexString()
 
             is Iso -> coseCompliantSerializer.encodeToByteArray(issuerSigned).sha256().toHexString()


### PR DESCRIPTION
Fixes the wrong credential being selected as keys may be reused across credentials