### PR TITLE
Do not throw on non-lowercase language tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 Release 8.0.0 (unreleased):
+- ETSI data classes:
+    - Normalize decoded RFC 5646 language tags to lowercase instead of rejecting non-lowercase input
 - Credentials:
     - In `SubjectCredentialStore.StoreEntry` make the `schemeIdentifier` non-nullable. Deserialization of old previously stored entries need to be handled by calling applications.
 - OpenID for Verifiable Presentations:

--- a/etsi-data-classes/src/commonMain/kotlin/at/asitplus/etsi/EtsiRfc5646LanguageTagSerializer.kt
+++ b/etsi-data-classes/src/commonMain/kotlin/at/asitplus/etsi/EtsiRfc5646LanguageTagSerializer.kt
@@ -1,5 +1,6 @@
 package at.asitplus.etsi
 
+import io.github.aakira.napier.Napier
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -22,9 +23,11 @@ class EtsiRfc5646LanguageTagSerializer : KSerializer<Rfc5646LanguageTag> {
     }
 
     override fun deserialize(decoder: Decoder) = Rfc5646LanguageTag(
-        decoder.decodeString().also {
-            require(it.lowercase() == it) {
-                "Expected language tag to be lowercase for ETSI compliance, but was $it"
+        decoder.decodeString().let { decodedLanguageTag ->
+            decodedLanguageTag.lowercase().also { normalizedLanguageTag ->
+                if (normalizedLanguageTag != decodedLanguageTag) {
+                    Napier.w("Expected language tag to be lowercase for ETSI compliance, but was $decodedLanguageTag")
+                }
             }
         }
     )

--- a/etsi-data-classes/src/commonTest/kotlin/at/asitplus/etsi/EtsiRfc5646LanguageTagSerializerTest.kt
+++ b/etsi-data-classes/src/commonTest/kotlin/at/asitplus/etsi/EtsiRfc5646LanguageTagSerializerTest.kt
@@ -1,0 +1,14 @@
+package at.asitplus.etsi
+
+import at.asitplus.testballoon.matrix.matrixSuite
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+
+val EtsiRfc5646LanguageTagSerializerTest by matrixSuite {
+    test("deserialization normalizes language tags to lowercase") {
+        Json.decodeFromString(
+            EtsiRfc5646LanguageTagSerializer(),
+            "\"EN-us\"",
+        ).string shouldBe "en-us"
+    }
+}


### PR DESCRIPTION
Fixes an exception being thrown due to uppercase language tags (e.g. "EN"). Merge or close at your discretion